### PR TITLE
Fix boat category emoji (kayak, rowing shell, rowboat, sup, wingfoil,…

### DIFF
--- a/shared/boats.js
+++ b/shared/boats.js
@@ -41,12 +41,12 @@ const boatRegistry = {
 const BOAT_EMOJI = {
   dinghy:        "⛵",
   keelboat:      "⛵",
-  kayak:         "=",
-  "rowing shell":"=",
-  rowboat:       "=",
-  sup:           "<",
-  wingfoil:      ">",
-  other:         "=",
+  kayak:         "🛶",
+  "rowing shell":"🚣",
+  rowboat:       "🚣",
+  sup:           "🏄",
+  wingfoil:      "🪁",
+  other:         "🚤",
 };
 
 const BOAT_CAT_COLORS = {


### PR DESCRIPTION
… other)

Corrupted placeholders (=, <, >) replaced with correct emoji sourced from the canonical category list in admin/index.html:
  kayak         = → 🛶
  rowing shell  = → 🚣
  rowboat       = → 🚣
  sup           < → 🏄
  wingfoil      > → 🪁
  other         = → 🚤

https://claude.ai/code/session_01RmBxLNyMDoWEi51moEQA8v