### PR TITLE
fix(weather): implement issue #24 weather widget and page improvements

### DIFF
--- a/shared/weather.js
+++ b/shared/weather.js
@@ -135,7 +135,7 @@ function wxMsToBft(ms) {
 }
 function wxMsToKt(ms)   { return Math.round(ms * 1.944); }
 function wxDirLabel(d)  { if (d == null) return ''; return ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'][Math.round(d/22.5)%16]; }
-function wxDirArrow(d)  { if (d == null) return ''; return ['↑','↗','→','↘','↓','↙','←','↖'][Math.round(d/45)%8]; }
+function wxDirArrow(d)  { if (d == null) return ''; return ['↓','↙','←','↖','↑','↗','→','↘'][Math.round(d/45)%8]; }
 function wxBftDesc(b)   { return ['Calm','Light air','Light breeze','Gentle breeze','Moderate breeze','Fresh breeze','Strong breeze','Near gale','Gale','Strong gale','Storm','Violent storm','Hurricane'][b] || ''; }
 function wxBftDescIS(b)  { return ['Logn','Andvari','Kul','Gola','Stinningsgola','Kaldi','Stinningskaldi','Allhvass vindur','Hvassviðri','Stormur','Rok','Ofsaveður','Fárviðri'][b] || ''; }
 function wxCondIcon(c)  {
@@ -500,7 +500,7 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
               <b style="color:var(--text)">${wDir}</b> · <b style="color:var(--text)">${wxMsToKt(ws)}</b> kt · ${IS?'Vindstig':'Force'} <b style="color:var(--text)">${bft}</b>
             </div>
             <div style="font-size:10px;color:var(--muted);margin-top:3px">
-              ${IS?'Hviður':'Gusts'} <b style="color:var(--text)">${Math.round(wg)} m/s</b> · ${IS?wxBftDescIS(bft):wxBftDesc(bft)}
+              ${IS?'Hviður':'Gusts'} <b style="color:var(--text)">${Math.round(wg)} m/s</b> · <b style="color:var(--text)">${wxMsToKt(wg)}</b> kt · ${IS?wxBftDescIS(bft):wxBftDesc(bft)}
             </div>
           </div>
           <div class="wx-cell">

--- a/weather/index.html
+++ b/weather/index.html
@@ -37,7 +37,7 @@
 .wind-cols { display:flex; align-items:flex-start; gap:16px; margin-bottom:16px; }
 .wind-data { flex:1; }
 .wind-speed-row { display:flex; align-items:center; gap:6px; line-height:1; }
-.dir-arrow { font-size:56px; color:var(--brass); line-height:1; font-weight:500; }
+.dir-arrow { font-size:56px; color:var(--brass); line-height:1; font-weight:700; }
 .wind-ms   { font-size:56px; font-weight:500; color:var(--brass); line-height:1; }
 .wind-unit { font-size:18px; color:var(--muted); }
 .wind-sub  { font-size:16px; color:var(--muted); display:flex; align-items:center; gap:8px; margin-top:6px; }
@@ -147,8 +147,12 @@ async function fetchAll() {
   document.getElementById('mainContent').innerHTML = '<div class="loading-msg">⚓ Fetching weather data…</div>';
   document.getElementById('updatedAt').textContent = 'Updating…';
   try {
-    const { wx, marine } = await wxFetch(FOSSVOGUR.lat, FOSSVOGUR.lon);
-    render(wx, marine);
+    const [{ wx, marine }, cfgRes] = await Promise.all([
+      wxFetch(FOSSVOGUR.lat, FOSSVOGUR.lon),
+      apiGet('getConfig').catch(() => null),
+    ]);
+    const staffStatus = cfgRes?.staffStatus ?? null;
+    render(wx, marine, staffStatus);
     document.getElementById('updatedAt').textContent =
       'Updated ' + new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   } catch(e) {
@@ -161,7 +165,7 @@ async function fetchAll() {
   }
 }
 
-function render(wx, marine) {
+function render(wx, marine, staffStatus) {
   const c   = wx.current, hr  = wx.hourly;
   const mc  = marine?.current, mhr = marine?.hourly;
 
@@ -204,7 +208,8 @@ function render(wx, marine) {
 
   const marineNote = ''
 
-  window._wfFlagResult = { flagKey, flag, score, breakdown };
+  window._wfFlagResult  = { flagKey, flag, score, breakdown };
+  window._wfStaffStatus = staffStatus;
   document.getElementById('mainContent').innerHTML = `
 
 <div class="flag-banner" onclick="openWfFlagModal()" style="background:${flag.bg};border-color:${flag.border};color:${flag.color};cursor:pointer" title="Tap for score breakdown">
@@ -215,6 +220,7 @@ function render(wx, marine) {
     ${reasons.length ? `<div class="flag-reasons">${reasons.map(r=>`<span class="flag-chip" style="color:${FLAG_CONFIG.flags[r.f].color};border-color:${FLAG_CONFIG.flags[r.f].border}">${esc(r.t)}</span>`).join('')}</div>` : ''}
   </div>
 </div>
+${staffStatus ? wxStaffStatusHtml(staffStatus, null) : ''}
 
 <!-- WIND HERO -->
 <div class="wind-hero">
@@ -235,7 +241,7 @@ function render(wx, marine) {
       </div>
     </div>
     <div class="wind-icon-col">
-      <div style="font-size:36px;line-height:1">${condIcon}</div>
+      <div style="font-size:52px;line-height:1">${condIcon}</div>
       <div style="font-size:10px;color:var(--muted);text-align:center;margin-top:4px">${condDesc}</div>
     </div>
   </div>
@@ -380,6 +386,11 @@ function drawWindChart(pts, nowI) {
   h+=`<text x="${nowX}" y="${H-P.b+11}" text-anchor="middle" font-family="DM Mono,monospace" font-size="8" fill="#d4af37">NOW</text>`;
   pts.forEach((p,i) => {
     h+=`<circle cx="${xOf(i).toFixed(1)}" cy="${yOf(p.ws).toFixed(1)}" r="2.5" fill="${p.isPast?'#6b92b8':'#d4af37'}" opacity="0.8"/>`;
+    if (p.isNow||i===0||i===pts.length-1) {
+      h+=`<text x="${xOf(i).toFixed(1)}" y="${(yOf(p.ws)-4).toFixed(1)}" text-anchor="middle" font-size="9" fill="#d4af37" font-family="DM Mono,monospace">${Math.round(p.ws)}</text>`;
+      if (p.mWH != null)
+        h+=`<text x="${xOf(i).toFixed(1)}" y="${(yOf(p.mWH)-4).toFixed(1)}" text-anchor="middle" font-size="9" fill="#4a9eca" font-family="DM Mono,monospace">${p.mWH.toFixed(1)}</text>`;
+    }
     if (p.isNow||i===0||i===pts.length-1||i%2===0)
       h+=`<text x="${xOf(i).toFixed(1)}" y="${H-2}" text-anchor="middle" font-size="8" fill="#6b92b8" font-family="DM Mono,monospace">${p.t}</text>`;
   });
@@ -428,7 +439,7 @@ function openWfFlagModal() {
   const r = window._wfFlagResult;
   if (title) title.textContent = (IS && r.flag.labelIS ? r.flag.labelIS : r.flag.label) + ' · ' + r.score + ' pts';
   body.innerHTML = typeof wxFlagDetailHtml === 'function'
-    ? wxFlagDetailHtml(r, null, IS ? 'IS' : 'EN')
+    ? wxFlagDetailHtml(r, window._wfStaffStatus ?? null, IS ? 'IS' : 'EN')
     : '<div style="color:var(--muted);font-size:12px">Detail unavailable.</div>';
   document.getElementById('wfFlagModal')?.classList.remove('hidden');
 }


### PR DESCRIPTION
- Reverse wxDirArrow so arrows point FROM wind/wave direction (meteorological convention)
- Increase wind hero dir-arrow font-weight 500→700 for visual balance
- Enlarge conditions icon in wind hero from 36px to 52px
- Add gusts in knots to widget gust line
- Add wind speed and wave height labels at start/now/end of wind/wave chart
- Load staffStatus from getConfig on full weather page and show duty badges below flag banner; pass staffStatus to flag detail modal

https://claude.ai/code/session_013eP3WGbWdrt3fgs4irTfim