### PR TITLE
feat: keelboat expanded functionality — Phase 1

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -545,7 +545,29 @@
     <h3 id="boatModalTitle">Add Boat</h3>
     <div class="field"><label>Name</label><input type="text" id="bName"></div>
     <div class="field"><label>Category</label>
-      <select id="bCategory"></select>
+      <select id="bCategory" onchange="updateBoatModalFields()"></select>
+    </div>
+    <!-- Default port (all boats) -->
+    <div class="field">
+      <label data-s="boat.defaultPort">Default port</label>
+      <select id="bDefaultPortId"><option value="">— none —</option></select>
+    </div>
+    <!-- Keelboat-only fields -->
+    <div id="keelboatFields" style="display:none">
+      <div class="grid2">
+        <div class="field">
+          <label data-s="boat.registrationNo">Registration no.</label>
+          <input type="text" id="bRegNo" placeholder="e.g. ÍS-342">
+        </div>
+        <div class="field">
+          <label data-s="boat.loa">LOA (ft)</label>
+          <input type="number" id="bLoa" min="0" step="0.1" placeholder="e.g. 34.0">
+        </div>
+      </div>
+      <div class="field">
+        <label data-s="boat.typeModel">Type / model</label>
+        <input type="text" id="bTypeModel" placeholder="e.g. Hallberg-Rassy 34">
+      </div>
     </div>
     <div class="check-row">
       <input type="checkbox" id="bOOS"> <label for="bOOS">Out of service</label>
@@ -569,6 +591,13 @@
   <div class="modal">
     <h3 id="locationModalTitle">Add Location</h3>
     <div class="field"><label>Name</label><input type="text" id="lName"></div>
+    <div class="field">
+      <label data-s="location.type">Type</label>
+      <select id="lType">
+        <option value="location" data-s="location.typeLocation">Location</option>
+        <option value="port" data-s="location.typePort">Port</option>
+      </select>
+    </div>
     <div class="check-row" style="margin-bottom:12px">
       <input type="checkbox" id="lActive" checked> <label for="lActive">Active</label>
     </div>
@@ -1160,6 +1189,7 @@ function renderBoats() {
             </div>
           </div>
           ${b.oosReason ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${esc(b.oosReason)}</div>` : ""}
+          ${(cat.key === 'keelboat' && (b.registrationNo || b.typeModel)) ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
           <div class="boat-card-actions">
             <button class="row-edit" style="flex:1" onclick="openBoatModal('${b.id}')">Edit</button>
             <button class="row-edit" onclick="showBoatQR('${b.id}')" title="Show QR code">🔳</button>
@@ -1189,9 +1219,22 @@ function openBoatModalForCat(catKey) {
   if (sel) sel.value = catKey;
 }
   
+function populateDefaultPortSelect(selectedId) {
+  const sel = document.getElementById("bDefaultPortId");
+  if (!sel) return;
+  const ports = _allLocations.filter(l => l.type === 'port' && (l.active !== false && l.active !== 'false'));
+  sel.innerHTML = `<option value="">— none —</option>` +
+    ports.map(p => `<option value="${esc(p.id)}"${p.id === selectedId ? ' selected' : ''}>${esc(p.name)}</option>`).join('');
+}
+
+function updateBoatModalFields() {
+  const cat = document.getElementById("bCategory").value;
+  document.getElementById("keelboatFields").style.display = cat === 'keelboat' ? '' : 'none';
+}
+
 function openBoatModal(id) {
   editingId = id || null;
-  const b   = id ? boats.find(x => x.id === id) : null;
+  const b   = id ? _allBoats.find(x => x.id === id) : null;
   document.getElementById("boatModalTitle").textContent = b ? s('admin.boatModal.edit') : s('admin.boatModal.add');
   populateCategorySelects();  // ensure select is fresh
   document.getElementById("bName").value      = b ? b.name                     : "";
@@ -1201,6 +1244,13 @@ function openBoatModal(id) {
   document.getElementById("oosReasonField").classList.toggle("hidden", !b || !bool(b.oos));
   document.getElementById("bActive").checked  = b ? bool(b.active)            : true;
   document.getElementById("bDeleteBtn").classList.toggle("hidden", !b);
+  // Keelboat-only fields
+  document.getElementById("bRegNo").value      = b ? (b.registrationNo || "") : "";
+  document.getElementById("bLoa").value        = b ? (b.loa || "")            : "";
+  document.getElementById("bTypeModel").value  = b ? (b.typeModel || "")      : "";
+  populateDefaultPortSelect(b ? (b.defaultPortId || "") : "");
+  updateBoatModalFields();
+  applyStrings(document.getElementById("boatModal"));
   openModal("boatModal");
 }
 
@@ -1208,13 +1258,19 @@ async function saveBoat() {
   const name = document.getElementById("bName").value.trim();
   if (!name) { toast("Name required.", "err"); return; }
 
-  const id      = editingId || ("boat_" + Date.now().toString(36));
+  const id  = editingId || ("boat_" + Date.now().toString(36));
+  const cat = document.getElementById("bCategory").value;
   const payload = {
     id, name,
-    category:  document.getElementById("bCategory").value,
-    oos:       document.getElementById("bOOS").checked,
-    oosReason: document.getElementById("bOOSReason").value.trim(),
-    active:    document.getElementById("bActive").checked,
+    category:      cat,
+    defaultPortId: document.getElementById("bDefaultPortId").value || "",
+    oos:           document.getElementById("bOOS").checked,
+    oosReason:     document.getElementById("bOOSReason").value.trim(),
+    active:        document.getElementById("bActive").checked,
+    // keelboat-only (ignored for other categories; kept to preserve existing data if category changes)
+    registrationNo: cat === 'keelboat' ? document.getElementById("bRegNo").value.trim()  : (id ? (_allBoats.find(x=>x.id===id)||{}).registrationNo||'' : ''),
+    loa:            cat === 'keelboat' ? (parseFloat(document.getElementById("bLoa").value)||'') : (id ? (_allBoats.find(x=>x.id===id)||{}).loa||'' : ''),
+    typeModel:      cat === 'keelboat' ? document.getElementById("bTypeModel").value.trim() : (id ? (_allBoats.find(x=>x.id===id)||{}).typeModel||'' : ''),
   };
 
   const idx = _allBoats.findIndex(x => x.id === id);
@@ -1276,7 +1332,7 @@ function renderLocations() {
   if (!active.length) { card.innerHTML = `<div class="empty-state">No locations yet.</div>`; return; }
   card.innerHTML = active.map(l => `
     <div class="list-row">
-      <span class="list-name">${esc(l.name)}</span>
+      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓ PORT</span>' : ''}</span>
       <button class="row-edit" onclick="openLocationModal('${l.id}')">Edit</button>
       <button class="row-del"  onclick="deleteLocation('${l.id}')">×</button>
     </div>`).join("");
@@ -1286,9 +1342,11 @@ function openLocationModal(id) {
   editingId = id || null;
   const l   = id ? _allLocations.find(x => x.id === id) : null;
   document.getElementById("locationModalTitle").textContent = l ? s('admin.locModal.edit') : s('admin.locModal.add');
-  document.getElementById("lName").value     = l ? l.name         : "";
-  document.getElementById("lActive").checked = l ? bool(l.active) : true;
+  document.getElementById("lName").value     = l ? l.name              : "";
+  document.getElementById("lType").value     = l ? (l.type || 'location') : 'location';
+  document.getElementById("lActive").checked = l ? bool(l.active)      : true;
   document.getElementById("lDeleteBtn").classList.toggle("hidden", !l);
+  applyStrings(document.getElementById("locationModal"));
   openModal("locationModal");
 }
 
@@ -1297,7 +1355,7 @@ async function saveLocation() {
   if (!name) { toast("Name required.", "err"); return; }
 
   const id      = editingId || ("loc_" + Date.now().toString(36));
-  const payload = { id, name, active: document.getElementById("lActive").checked };
+  const payload = { id, name, type: document.getElementById("lType").value || 'location', active: document.getElementById("lActive").checked };
 
   const idx = _allLocations.findIndex(x => x.id === id);
   if (idx >= 0) _allLocations[idx] = { ..._allLocations[idx], ...payload };

--- a/code.gs
+++ b/code.gs
@@ -280,6 +280,7 @@ function route_(action, b) {
     case 'saveTrip': return saveTrip_(b);
     case 'deleteTrip': return deleteTrip_(b.id);
     case 'requestValidation': return requestValidation_(b);
+    case 'uploadTripFile': return uploadTripFile_(b);
     case 'getWeather': return getWeather_();
     case 'getOverdueAlerts': return getOverdueAlerts_(b);
     case 'silenceAlert': return silenceAlert_(b);
@@ -1230,6 +1231,9 @@ function saveTrip_(b) {
       'isLinked','linkedCheckoutId','linkedTripId',
       'verified','verifiedBy','verifiedAt','staffComment',
       'validationRequested',
+      'distanceNm','departurePort','arrivalPort',
+      'trackFileUrl','trackSimplified','trackSource',
+      'photoUrls',
     ];
     UPDATABLE.forEach(k => { if (b[k] !== undefined) updates[k] = b[k]; });
     updateRow_('trips', 'id', b.id, updates);
@@ -1250,6 +1254,9 @@ function saveTrip_(b) {
     linkedCheckoutId: b.linkedCheckoutId || '', linkedTripId: b.linkedTripId || '',
     verified: false, verifiedBy: '', verifiedAt: '', staffComment: '',
     validationRequested: b.validationRequested || false,
+    distanceNm: b.distanceNm || '', departurePort: b.departurePort || '', arrivalPort: b.arrivalPort || '',
+    trackFileUrl: b.trackFileUrl || '', trackSimplified: b.trackSimplified || '', trackSource: b.trackSource || '',
+    photoUrls: b.photoUrls || '',
     createdAt: ts,
   });
   return okJ({ id, created: true });
@@ -1264,6 +1271,238 @@ function requestValidation_(b) {
   if (!b.tripId) return failJ('tripId required');
   updateRow_('trips', 'id', b.tripId, { validationRequested: true });
   return okJ({ requested: true });
+}
+
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TRIP FILE UPLOADS  (GPS tracks + photos → Google Drive)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Script Properties required:
+//   DRIVE_FOLDER_ID_TRACKS — folder ID for raw GPX/KML/KMZ files
+//   DRIVE_FOLDER_ID_PHOTOS — folder ID for trip photos
+//
+// If a property is not set the function returns ok:false so the frontend
+// can warn the user and save the trip without the attachment.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function uploadTripFile_(b) {
+  if (!b.fileType) return failJ('fileType required');
+  if (b.fileType === 'track') return saveTripTrack_(b);
+  if (b.fileType === 'photo') return saveTripPhoto_(b);
+  return failJ('Unknown fileType: ' + b.fileType);
+}
+
+function saveTripTrack_(b) {
+  if (!b.fileData) return failJ('fileData required');
+  const props = PropertiesService.getScriptProperties();
+  const folderId = props.getProperty('DRIVE_FOLDER_ID_TRACKS');
+  if (!folderId) return okJ({ ok: false, error: 'Drive folder not configured' });
+
+  try {
+    const ext = (b.fileName || 'track.gpx').split('.').pop().toLowerCase();
+    const ts  = now_().replace(/[: ]/g, '-');
+    const safeName = ts + '_' + (b.fileName || 'track.' + ext);
+
+    let contentBytes = Utilities.base64Decode(b.fileData.replace(/^data:[^;]+;base64,/, ''));
+    let parseFormat  = ext;
+
+    // KMZ = zipped KML — decompress and extract .kml entry
+    if (ext === 'kmz') {
+      const blobs = Utilities.unzip(Utilities.newBlob(contentBytes, 'application/zip', safeName));
+      const kmlBlob = blobs.find(bl => bl.getName().toLowerCase().endsWith('.kml'));
+      if (!kmlBlob) return failJ('No .kml found inside KMZ');
+      contentBytes = kmlBlob.getBytes();
+      parseFormat  = 'kml';
+    }
+
+    // Save raw file to Drive
+    const folder  = DriveApp.getFolderById(folderId);
+    const mimeMap = { gpx:'application/gpx+xml', kml:'application/vnd.google-earth.kml+xml', kmz:'application/vnd.google-earth.kmz' };
+    const blob    = Utilities.newBlob(contentBytes, mimeMap[ext] || 'application/octet-stream', safeName);
+    const file    = folder.createFile(blob);
+    file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+    const trackFileUrl = file.getUrl();
+
+    // Parse GPS content
+    const contentStr = Utilities.newBlob(contentBytes).getDataAsString('UTF-8');
+    const parsed = parseGpsTrack_(contentStr, parseFormat);
+
+    return okJ({
+      ok: true,
+      trackFileUrl,
+      trackSource: ext.toUpperCase(),
+      distanceNm:      parsed.distanceNm,
+      departureTime:   parsed.departureTime,
+      arrivalTime:     parsed.arrivalTime,
+      trackSimplified: JSON.stringify(parsed.simplifiedTrack),
+      pointCount:      parsed.pointCount,
+    });
+  } catch (e) {
+    return failJ('Track upload error: ' + e.message);
+  }
+}
+
+function saveTripPhoto_(b) {
+  if (!b.fileData) return failJ('fileData required');
+  const props = PropertiesService.getScriptProperties();
+  const folderId = props.getProperty('DRIVE_FOLDER_ID_PHOTOS');
+  if (!folderId) return okJ({ ok: false, error: 'Drive folder not configured' });
+
+  try {
+    const ext      = (b.fileName || 'photo.jpg').split('.').pop().toLowerCase();
+    const ts       = now_().replace(/[: ]/g, '-');
+    const safeName = ts + '_' + (b.fileName || 'photo.' + ext);
+    const base64   = b.fileData.replace(/^data:[^;]+;base64,/, '');
+    const bytes    = Utilities.base64Decode(base64);
+    const mimeMap  = { jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif', webp:'image/webp', heic:'image/heic' };
+    const mime     = b.mimeType || mimeMap[ext] || 'image/jpeg';
+    const blob     = Utilities.newBlob(bytes, mime, safeName);
+    const folder   = DriveApp.getFolderById(folderId);
+    const file     = folder.createFile(blob);
+    file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+    return okJ({ ok: true, photoUrl: file.getUrl() });
+  } catch (e) {
+    return failJ('Photo upload error: ' + e.message);
+  }
+}
+
+// ── GPS track parser ──────────────────────────────────────────────────────────
+
+function parseGpsTrack_(content, format) {
+  const doc = XmlService.parse(content);
+  const root = doc.getRootElement();
+  let points = [];   // [{lat, lng, time}]
+
+  if (format === 'gpx') {
+    // Support GPX 1.0 and 1.1 namespaces
+    const ns0 = XmlService.getNamespace('http://www.topografix.com/GPX/1/0');
+    const ns1 = XmlService.getNamespace('http://www.topografix.com/GPX/1/1');
+    [ns0, ns1].forEach(function(ns) {
+      try {
+        root.getChildren('trk', ns).forEach(function(trk) {
+          trk.getChildren('trkseg', ns).forEach(function(seg) {
+            seg.getChildren('trkpt', ns).forEach(function(pt) {
+              const lat  = parseFloat(pt.getAttribute('lat').getValue());
+              const lng  = parseFloat(pt.getAttribute('lon').getValue());
+              const timeEl = pt.getChild('time', ns);
+              const time = timeEl ? timeEl.getText() : null;
+              if (!isNaN(lat) && !isNaN(lng)) points.push({ lat, lng, time });
+            });
+          });
+        });
+      } catch(e) {}
+    });
+    // Fallback: try without namespace
+    if (!points.length) {
+      root.getDescendants().forEach(function(cNode) {
+        try {
+          const el = cNode.asElement();
+          if (el && el.getName() === 'trkpt') {
+            const lat = parseFloat(el.getAttribute('lat').getValue());
+            const lng = parseFloat(el.getAttribute('lon').getValue());
+            const timeEl = el.getChildren().find(function(c){ return c.getName()==='time'; });
+            const time = timeEl ? timeEl.getText() : null;
+            if (!isNaN(lat) && !isNaN(lng)) points.push({ lat, lng, time });
+          }
+        } catch(e) {}
+      });
+    }
+  } else {
+    // KML: look for LineString coordinates or gx:Track when/coord pairs
+    const kmlNs  = XmlService.getNamespace('http://www.opengis.net/kml/2.2');
+    const gxNs   = XmlService.getNamespace('http://www.google.com/kml/ext/2.2');
+
+    // Try gx:Track first (has timestamps)
+    const allEls = root.getDescendants();
+    let gxTrackFound = false;
+    for (let i = 0; i < allEls.length; i++) {
+      let el; try { el = allEls[i].asElement(); } catch(e) { continue; }
+      if (!el || el.getName() !== 'Track') continue;
+      gxTrackFound = true;
+      const whens  = el.getChildren('when', gxNs);
+      const coords = el.getChildren('coord', gxNs);
+      const len    = Math.min(whens.length, coords.length);
+      for (let j = 0; j < len; j++) {
+        const parts = coords[j].getText().trim().split(/\s+/);
+        const lng = parseFloat(parts[0]), lat = parseFloat(parts[1]);
+        if (!isNaN(lat) && !isNaN(lng)) points.push({ lat, lng, time: whens[j].getText() });
+      }
+      break;
+    }
+
+    // Fall back to LineString coordinates (no timestamps)
+    if (!gxTrackFound || !points.length) {
+      for (let i = 0; i < allEls.length; i++) {
+        let el; try { el = allEls[i].asElement(); } catch(e) { continue; }
+        if (!el || el.getName() !== 'coordinates') continue;
+        const raw = el.getText().trim();
+        raw.split(/\s+/).forEach(function(token) {
+          const parts = token.split(',');
+          const lng = parseFloat(parts[0]), lat = parseFloat(parts[1]);
+          if (!isNaN(lat) && !isNaN(lng)) points.push({ lat, lng, time: null });
+        });
+      }
+    }
+  }
+
+  if (!points.length) return { distanceNm: 0, departureTime: null, arrivalTime: null, simplifiedTrack: [], pointCount: 0 };
+
+  // Sort by timestamp where available
+  points.sort(function(a, b) { return a.time && b.time ? a.time < b.time ? -1 : 1 : 0; });
+
+  // Compute total distance (Haversine)
+  let totalM = 0;
+  for (let i = 1; i < points.length; i++) {
+    totalM += haversineM_(points[i-1].lat, points[i-1].lng, points[i].lat, points[i].lng);
+  }
+  const distanceNm = Math.round((totalM / 1852) * 10) / 10;
+
+  // RDP simplification → target ~50-100 representative points
+  const simplified = rdpSimplify_(points.map(function(p){ return {lat:p.lat,lng:p.lng}; }), 0.0005);
+
+  return {
+    distanceNm,
+    departureTime: points[0].time || null,
+    arrivalTime:   points[points.length - 1].time || null,
+    simplifiedTrack: simplified,
+    pointCount: points.length,
+  };
+}
+
+function haversineM_(lat1, lng1, lat2, lng2) {
+  const R  = 6371000;
+  const f1 = lat1 * Math.PI / 180, f2 = lat2 * Math.PI / 180;
+  const df = (lat2 - lat1) * Math.PI / 180;
+  const dl = (lng2 - lng1) * Math.PI / 180;
+  const a  = Math.sin(df/2)*Math.sin(df/2) + Math.cos(f1)*Math.cos(f2)*Math.sin(dl/2)*Math.sin(dl/2);
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+}
+
+function rdpSimplify_(points, epsilon) {
+  if (points.length < 3) return points;
+  // Find point farthest from the line between first and last
+  const first = points[0], last = points[points.length - 1];
+  let maxDist = 0, maxIdx = 0;
+  for (let i = 1; i < points.length - 1; i++) {
+    const d = perpendicularDist_(points[i], first, last);
+    if (d > maxDist) { maxDist = d; maxIdx = i; }
+  }
+  if (maxDist > epsilon) {
+    const left  = rdpSimplify_(points.slice(0, maxIdx + 1), epsilon);
+    const right = rdpSimplify_(points.slice(maxIdx), epsilon);
+    return left.slice(0, -1).concat(right);
+  }
+  return [first, last];
+}
+
+function perpendicularDist_(p, a, b) {
+  const dx = b.lng - a.lng, dy = b.lat - a.lat;
+  if (dx === 0 && dy === 0) {
+    return Math.sqrt(Math.pow(p.lng - a.lng, 2) + Math.pow(p.lat - a.lat, 2));
+  }
+  const t = ((p.lng - a.lng) * dx + (p.lat - a.lat) * dy) / (dx*dx + dy*dy);
+  return Math.sqrt(Math.pow(p.lng - (a.lng + t*dx), 2) + Math.pow(p.lat - (a.lat + t*dy), 2));
 }
 
 

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -78,6 +78,12 @@
 .trip-pick-card .tpc-boat{font-weight:500;margin-bottom:3px}
 .trip-pick-card .tpc-sub{color:var(--muted);font-size:11px}
 .wx-row{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
+.photo-thumb{width:60px;height:60px;object-fit:cover;border-radius:6px;border:1px solid var(--border);cursor:pointer}
+.photo-thumb-link{display:block;width:60px;height:60px}
+.trip-photos{display:flex;gap:6px;flex-wrap:wrap;margin-top:4px}
+details#portDetails summary::-webkit-details-marker{display:none}
+details#portDetails[open] #portSummaryLabel::after{content:' ▴';font-size:8px}
+details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-size:8px}
 </style>
 </head>
 <body>
@@ -153,7 +159,7 @@
         </div>
       </div>
       <div class="form-field"><label>Boat</label>
-        <select id="mBoat"><option value="">Select boat…</option></select>
+        <select id="mBoat" onchange="onBoatChange()"><option value="">Select boat…</option></select>
       </div>
       <div class="form-field"><label>Location</label>
         <select id="mLocation"><option value="">Select location…</option></select>
@@ -164,7 +170,34 @@
         <div class="form-field"><label>Returned</label><input type="text" id="mTimeIn" placeholder="HH:MM"
           oninput="var v=this.value.replace(/[^0-9]/g,'');if(v.length>=3)v=v.slice(0,2)+':'+v.slice(2);this.value=v"></div>
       </div>
-      <div class="form-field"><label>Crew aboard (total incl. you)</label><input type="number" id="mCrew" min="1" value="1"></div>
+      <div class="form-row">
+        <div class="form-field"><label>Crew aboard (total incl. you)</label><input type="number" id="mCrew" min="1" value="1"></div>
+        <div class="form-field"><label>Distance (nm) <span style="font-size:9px;color:var(--muted)">optional</span></label>
+          <input type="number" id="mDistanceNm" min="0" step="0.1" placeholder="e.g. 12.5"></div>
+      </div>
+
+      <!-- Port section: open/prominent for keelboats, collapsed for others -->
+      <details id="portDetails" style="margin-bottom:12px">
+        <summary id="portSummary" style="font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;cursor:pointer;list-style:none;display:flex;align-items:center;gap:6px;margin-bottom:8px">
+          <span>⚓</span><span id="portSummaryLabel">PORTS — OPTIONAL</span>
+        </summary>
+        <div class="form-row" style="margin-top:6px">
+          <div class="form-field">
+            <label>Departure port</label>
+            <input list="portsList" id="mDeparturePort" placeholder="e.g. Reykjavík" autocomplete="off"
+              oninput="watchPortInput('departure')">
+          </div>
+          <div class="form-field">
+            <label>Arrival port</label>
+            <input list="portsList" id="mArrivalPort" placeholder="Same as departure" autocomplete="off"
+              oninput="watchPortInput('arrival')">
+          </div>
+        </div>
+        <datalist id="portsList"></datalist>
+        <div id="addPortHint" style="display:none;font-size:10px;color:var(--brass);cursor:pointer;margin-top:4px"
+          onclick="addNewPort()">+ Add "<span id="addPortName"></span>" to ports list</div>
+      </details>
+
       <!-- Weather -->
       <div style="font-size:9px;color:var(--muted);letter-spacing:1px;margin:12px 0 8px">WEATHER (OPTIONAL)</div>
       <div class="wx-row">
@@ -187,9 +220,23 @@
         </div>
         <div class="form-field"><label>Wave ht (m)</label><input type="number" id="mWave" min="0" step="0.1" placeholder="0.0"></div>
       </div>
+      <!-- GPS Track upload -->
+      <div class="form-field">
+        <label>GPS Track — GPX / KML / KMZ <span style="font-size:9px;color:var(--muted)">optional</span></label>
+        <input type="file" id="mTrackFile" accept=".gpx,.kml,.kmz" onchange="handleTrackFile(this)"
+          style="font-size:11px;color:var(--text)">
+        <div id="mTrackStatus" style="font-size:11px;color:var(--muted);margin-top:4px"></div>
+      </div>
+      <!-- Photo upload -->
+      <div class="form-field">
+        <label>Photos <span style="font-size:9px;color:var(--muted)">optional</span></label>
+        <input type="file" id="mPhotoFiles" accept="image/*" multiple onchange="handlePhotoFiles(this)"
+          style="font-size:11px;color:var(--text)">
+        <div id="mPhotoPreview" style="display:flex;gap:6px;flex-wrap:wrap;margin-top:6px"></div>
+      </div>
       <div class="form-field"><label>Notes</label><textarea id="mNotes" rows="2" placeholder="Optional notes…"></textarea></div>
       <div id="mErr" style="color:var(--red);font-size:11px;margin-bottom:8px;display:none"></div>
-      <button class="btn-primary" onclick="submitManual()">Save to logbook</button>
+      <button class="btn-primary" id="mSubmitBtn" onclick="submitManual()">Save to logbook</button>
     </div>
   </div>
 </div>
@@ -204,6 +251,11 @@ let allBoats = [], allLocs = [];
 let allRecentTrips = [];
 let recentOffset   = 0;
 const RECENT_PAGE  = 10;
+
+// ── File upload state ─────────────────────────────────────────────────────────
+let _pendingTrack  = null;   // {fileName, fileData (base64), mimeType}
+let _pendingPhotos = [];     // [{fileName, fileData (base64), mimeType}]
+let _lastPortInput = null;   // which port input was last typed into
 
 function esc(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')}
 function parseDateParts(d){
@@ -288,6 +340,14 @@ function tripCard(t){
                     cardDir  && `<span style="opacity:.7">${esc(cardDir)}</span>`
                    ].filter(Boolean).join('');
 
+  // Port display (shown on card face for keelboats)
+  const isKeelboat = (t.boatCategory||'').toLowerCase()==='keelboat';
+  const dep=t.departurePort||'', arr=t.arrivalPort||'';
+  const portLine = (dep||arr) ? (
+    (!arr||dep===arr) ? `<span>⚓ ${esc(dep||arr)}</span>`
+                      : `<span>⚓ ${esc(dep)} → ${esc(arr)}</span>`
+  ) : '';
+
   // Expanded wx detail
   const wxRows = wx ? [
     wx.ws     != null ? `<div class="trip-exp-row"><span class="trip-exp-lbl">Wind speed</span><span class="trip-exp-val">${Math.round(wx.ws)} m/s${wx.bft!=null?' · Bft '+wx.bft:''}</span></div>` : '',
@@ -323,6 +383,8 @@ function tripCard(t){
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':'' }
           ${t.validationRequested && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ Validation pending</span>' : ''}
           <span>${esc(dur)}</span>
+          ${t.distanceNm?`<span>${esc(t.distanceNm)} nm</span>`:''}
+          ${isKeelboat&&portLine?portLine:''}
           ${windLine?'<span style="display:flex;align-items:center;gap:3px">'+windLine+'</span>':''}
         </div>
       </div>
@@ -334,8 +396,13 @@ function tripCard(t){
         <div class="trip-exp-row"><span class="trip-exp-lbl">Departed</span><span class="trip-exp-val">${esc(t.timeOut||'—')}</span></div>
         <div class="trip-exp-row"><span class="trip-exp-lbl">Returned</span><span class="trip-exp-val">${esc(t.timeIn||'—')}</span></div>
         <div class="trip-exp-row"><span class="trip-exp-lbl">Crew aboard</span><span class="trip-exp-val">${esc(t.crew||1)}</span></div>
+        ${t.distanceNm?`<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Vegalengd':'Distance'}</span><span class="trip-exp-val">${esc(t.distanceNm)} nm</span></div>`:''}
+        ${(!isKeelboat&&portLine)?`<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Höfn':'Port'}</span><span class="trip-exp-val">${portLine}</span></div>`:''}
+        ${isKeelboat&&dep&&arr&&dep!==arr?`<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Brottfararstaður':'Departure'}</span><span class="trip-exp-val">${esc(dep)}</span></div><div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Komustaður':'Arrival'}</span><span class="trip-exp-val">${esc(arr)}</span></div>`:''}
         ${wxRows}
         ${crewNamesHtml}
+        ${t.trackFileUrl?`<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'GPS-leið':'GPS Track'}</span><span class="trip-exp-val"><a href="${esc(t.trackFileUrl)}" target="_blank" style="color:var(--brass)">📍 ${IS?'Skoða leið':'View track'}</a>${t.trackSource?' · '+esc(t.trackSource):''}</span></div>`:''}
+        ${(()=>{let urls=[];try{if(t.photoUrls)urls=JSON.parse(t.photoUrls);}catch(e){}return urls.length?`<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Myndir':'Photos'}</span><span class="trip-exp-val"><div class="trip-photos">${urls.map(u=>`<a href="${esc(u)}" target="_blank" class="photo-thumb-link"><img src="${esc(u)}" class="photo-thumb" loading="lazy" onerror="this.parentElement.style.display='none'"></a>`).join('')}</div></span></div>`:'';})()}
         ${t.notes?'<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">Notes</span><span class="trip-exp-val">'+esc(t.notes)+'</span></div>':''}
       </div>
     </div>
@@ -440,6 +507,117 @@ function showManualForm(){
   const lSel=document.getElementById('mLocation');
   lSel.innerHTML='<option value="">Select location…</option>';
   allLocs.forEach(l=>{const o=document.createElement('option');o.value=l.id;o.textContent=(l.name||l.id);lSel.appendChild(o);});
+  // Populate ports datalist
+  populatePortsDatalist();
+  // Reset file upload state
+  _pendingTrack=null; _pendingPhotos=[];
+  document.getElementById('mTrackFile').value='';
+  document.getElementById('mTrackStatus').textContent='';
+  document.getElementById('mPhotoFiles').value='';
+  document.getElementById('mPhotoPreview').innerHTML='';
+  document.getElementById('mDistanceNm').value='';
+  document.getElementById('mDeparturePort').value='';
+  document.getElementById('mArrivalPort').value='';
+  document.getElementById('addPortHint').style.display='none';
+  // Port section: collapsed by default until boat selected
+  const pd=document.getElementById('portDetails');
+  pd.removeAttribute('open');
+  onBoatChange();
+}
+
+function populatePortsDatalist(){
+  const dl=document.getElementById('portsList');
+  if(!dl) return;
+  const ports=allLocs.filter(l=>l.type==='port');
+  dl.innerHTML=ports.map(p=>`<option value="${esc(p.name)}">`).join('');
+}
+
+function onBoatChange(){
+  const boatId=document.getElementById('mBoat').value;
+  const boat=allBoats.find(b=>b.id===boatId);
+  const isKeelboat=(boat?.category||'').toLowerCase()==='keelboat';
+  const pd=document.getElementById('portDetails');
+  if(isKeelboat){
+    pd.setAttribute('open','');
+    document.getElementById('portSummaryLabel').textContent=IS?'HÖFNAR':'PORTS';
+  } else {
+    pd.removeAttribute('open');
+    document.getElementById('portSummaryLabel').textContent=IS?'HÖFNAR — VALFRJÁLST':'PORTS — OPTIONAL';
+  }
+  // Auto-fill default port if fields are empty
+  if(boat?.defaultPortId){
+    const port=allLocs.find(l=>l.id===boat.defaultPortId);
+    if(port){
+      const dep=document.getElementById('mDeparturePort');
+      const arr=document.getElementById('mArrivalPort');
+      if(!dep.value) dep.value=port.name;
+      if(!arr.value) arr.value=port.name;
+    }
+  }
+}
+
+function watchPortInput(which){
+  const inputId = which==='departure' ? 'mDeparturePort' : 'mArrivalPort';
+  const val=document.getElementById(inputId).value.trim();
+  _lastPortInput=which;
+  if(!val){ document.getElementById('addPortHint').style.display='none'; return; }
+  const ports=allLocs.filter(l=>l.type==='port');
+  const exists=ports.some(p=>p.name.toLowerCase()===val.toLowerCase());
+  if(!exists){
+    document.getElementById('addPortName').textContent=val;
+    document.getElementById('addPortHint').style.display='';
+  } else {
+    document.getElementById('addPortHint').style.display='none';
+  }
+}
+
+async function addNewPort(){
+  const inputId=_lastPortInput==='arrival'?'mArrivalPort':'mDeparturePort';
+  const val=document.getElementById(inputId).value.trim();
+  if(!val) return;
+  const newPort={id:'loc_'+Date.now().toString(36), name:val, type:'port', active:true};
+  allLocs.push(newPort);
+  try{
+    await apiPost('saveConfig',{locations:allLocs});
+    populatePortsDatalist();
+    document.getElementById('addPortHint').style.display='none';
+    // Also fill the other port field if empty
+    const otherEl=document.getElementById(_lastPortInput==='arrival'?'mDeparturePort':'mArrivalPort');
+    if(!otherEl.value) otherEl.value=val;
+    showToast(IS?'Höfn bætt við':'Port added ✓','success');
+  }catch(e){ showToast('Save failed: '+e.message,'err'); allLocs.pop(); }
+}
+
+function handleTrackFile(input){
+  const file=input.files[0];
+  if(!file){ _pendingTrack=null; document.getElementById('mTrackStatus').textContent=''; return; }
+  const statusEl=document.getElementById('mTrackStatus');
+  statusEl.textContent=IS?'Lesur skrá…':'Reading file…';
+  const reader=new FileReader();
+  reader.onload=function(e){
+    _pendingTrack={fileName:file.name, fileData:e.target.result, mimeType:file.type||'application/octet-stream'};
+    statusEl.textContent=(IS?'Tilbúið: ':'Ready: ')+file.name;
+    statusEl.style.color='var(--brass)';
+  };
+  reader.onerror=function(){ statusEl.textContent=IS?'Lestur mistókst':'Read error'; statusEl.style.color='var(--red)'; _pendingTrack=null; };
+  reader.readAsDataURL(file);
+}
+
+function handlePhotoFiles(input){
+  const files=Array.from(input.files);
+  _pendingPhotos=[];
+  const preview=document.getElementById('mPhotoPreview');
+  preview.innerHTML='';
+  files.forEach(function(file){
+    const reader=new FileReader();
+    reader.onload=function(e){
+      _pendingPhotos.push({fileName:file.name, fileData:e.target.result, mimeType:file.type||'image/jpeg'});
+      const img=document.createElement('img');
+      img.src=e.target.result; img.className='photo-thumb';
+      preview.appendChild(img);
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function renderClubTripsList(){
@@ -495,19 +673,26 @@ async function joinTripAsCrew(tripId, el){
 async function submitManual(){
   const errEl=document.getElementById('mErr');
   errEl.style.display='none';
-  const date  = document.getElementById('mDate').value;
-  const boatId= document.getElementById('mBoat').value;
-  const boatName=document.getElementById('mBoat').selectedOptions[0]?.text||'';
-  const locId = document.getElementById('mLocation').value;
-  const locName=document.getElementById('mLocation').selectedOptions[0]?.text||'';
-  const timeOut=document.getElementById('mTimeOut').value;
-  const timeIn =document.getElementById('mTimeIn').value;
-  const crew   =parseInt(document.getElementById('mCrew').value)||1;
-  const role   =document.getElementById('mRole').value;
-  const bft    =document.getElementById('mBft').value;
-  const wdir   =document.getElementById('mWindDir').value;
-  const wave   =document.getElementById('mWave').value;
-  const notes  =document.getElementById('mNotes').value.trim();
+  const date      = document.getElementById('mDate').value;
+  const boatId    = document.getElementById('mBoat').value;
+  const boatName  = document.getElementById('mBoat').selectedOptions[0]?.text||'';
+  const locId     = document.getElementById('mLocation').value;
+  const locName   = document.getElementById('mLocation').selectedOptions[0]?.text||'';
+  const timeOut   = document.getElementById('mTimeOut').value;
+  const timeIn    = document.getElementById('mTimeIn').value;
+  const crew      = parseInt(document.getElementById('mCrew').value)||1;
+  const role      = document.getElementById('mRole').value;
+  const bft       = document.getElementById('mBft').value;
+  const wdir      = document.getElementById('mWindDir').value;
+  const wave      = document.getElementById('mWave').value;
+  const notes     = document.getElementById('mNotes').value.trim();
+  const distInput = parseFloat(document.getElementById('mDistanceNm').value)||'';
+  let   depPort   = document.getElementById('mDeparturePort').value.trim();
+  let   arrPort   = document.getElementById('mArrivalPort').value.trim();
+  if(arrPort===''&&depPort!=='') arrPort=depPort;   // default arrival = departure
+
+  const boat = allBoats.find(b=>b.id===boatId);
+  const boatCategory = boat?.category||'';
 
   if(!date){errEl.textContent='Please enter a date.';errEl.style.display='';return;}
   if(!boatId){errEl.textContent='Please select a boat.';errEl.style.display='';return;}
@@ -524,16 +709,49 @@ async function submitManual(){
 
   // Build wxSnapshot if wave present
   let wxSnapshot='';
-  if(wave){
-    wxSnapshot=JSON.stringify({wh:parseFloat(wave)||0});
+  if(wave){ wxSnapshot=JSON.stringify({wh:parseFloat(wave)||0}); }
+
+  // Disable submit while uploading
+  const btn=document.getElementById('mSubmitBtn');
+  btn.disabled=true; btn.textContent=IS?'Hleður upp…':'Uploading…';
+
+  // Upload GPS track
+  let trackFileUrl='', trackSimplified='', trackSource='', distanceNm=distInput;
+  if(_pendingTrack){
+    try{
+      const tr=await apiPost('uploadTripFile',{fileType:'track',fileName:_pendingTrack.fileName,fileData:_pendingTrack.fileData,mimeType:_pendingTrack.mimeType});
+      if(tr.ok){
+        trackFileUrl=tr.trackFileUrl||'';
+        trackSimplified=tr.trackSimplified||'';
+        trackSource=tr.trackSource||'';
+        if(!distanceNm && tr.distanceNm) distanceNm=tr.distanceNm;
+      } else {
+        showToast(IS?'Skráarupphal ekki stillt — ferð vistuð án viðhengis.':'File upload not configured — trip saved without attachment.','warn');
+      }
+    }catch(e){ showToast((IS?'GPS upphal mistókst: ':'GPS upload failed: ')+e.message,'warn'); }
   }
+
+  // Upload photos
+  const photoUrls=[];
+  for(const ph of _pendingPhotos){
+    try{
+      const pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType});
+      if(pr.ok && pr.photoUrl) photoUrls.push(pr.photoUrl);
+      else if(!pr.ok) showToast(IS?'Skráarupphal ekki stillt':'File upload not configured','warn');
+    }catch(e){ showToast((IS?'Mynda upphal mistókst: ':'Photo upload failed: ')+e.message,'warn'); }
+  }
+
+  btn.disabled=false; btn.textContent=IS?'Vista í siglingabók':'Save to logbook';
 
   try{
     await apiPost('saveTrip',{
-      date, boatId, boatName,
+      date, boatId, boatName, boatCategory,
       locationId:locId, locationName:locName,
       timeOut, timeIn, hoursDecimal, crew, role,
       beaufort:bft, windDir:wdir, notes, wxSnapshot,
+      distanceNm, departurePort:depPort, arrivalPort:arrPort,
+      trackFileUrl, trackSimplified, trackSource,
+      photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
     });
     showToast('Trip saved ✓','success');
     closeLogModal();

--- a/shared/certs.js
+++ b/shared/certs.js
@@ -7,6 +7,12 @@ const DEFAULT_CERT_DEFS = [
     subcats:[{key:'ws1',label:'Level 1',description:'',rank:1},{key:'ws2',label:'Level 2',description:'',rank:2},{key:'ws3',label:'Level 3',description:'',rank:3}] },
   { id:'released_rower', name:'Released Rower', description:'', color:'', staffOnly:false, renewalDays:0, subcats:[] },
   { id:'support_boat_skipper', name:'Support Boat Skipper', description:'', color:'', staffOnly:true, renewalDays:0, subcats:[] },
+  { id:'keelboat_crew', name:'Keelboat Crew', description:'Certified to sail on club keelboats.', color:'#d4af37', staffOnly:false, renewalDays:0,
+    subcats:[
+      {key:'crew',     label:'Crew',     description:'Certified basic keelboat crew.',                                               rank:1},
+      {key:'helmsman', label:'Helmsman', description:'Certified to helm a keelboat.',                                                rank:2},
+      {key:'captain',  label:'Captain',  description:'Authorized keelboat captain — may skipper club keelboats independently.',      rank:3},
+    ]},
 ];
 
 const _CERT_PALETTE = [

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -685,6 +685,28 @@ const STRINGS = {
   'payroll.istarf95':          { EN:'Job code (ISTARF)',                  IS:'Starfaflokkun (ISTARF)' },
   'payroll.taxWithheld':       { EN:'Tax withheld',                   IS:'Staðgreiðsla' },
 
+  // ── Keelboat / logbook expanded (Phase 1) ──────────────────────────────────
+  'logbook.distanceNm':      { EN:'Distance (nm)',                         IS:'Vegalengd (sjómílur)' },
+  'logbook.departurePort':   { EN:'Departure port',                        IS:'Brottfararstaður' },
+  'logbook.arrivalPort':     { EN:'Arrival port',                          IS:'Komustaður' },
+  'logbook.portsOptional':   { EN:'Ports — optional',                      IS:'Höfnar — valfrjálst' },
+  'logbook.addPort':         { EN:'+ Add "{name}" to ports list',          IS:'+ Bæta „{name}" við höfnalista' },
+  'logbook.gpsTrack':        { EN:'GPS Track — GPX / KML / KMZ',           IS:'GPS-leið — GPX / KML / KMZ' },
+  'logbook.photos':          { EN:'Photos',                                IS:'Myndir' },
+  'logbook.trackReady':      { EN:'Ready: {name}',                         IS:'Tilbúið: {name}' },
+  'logbook.trackAttached':   { EN:'📍 GPS track',                          IS:'📍 GPS-leið' },
+  'logbook.portSame':        { EN:'⚓ {port}',                             IS:'⚓ {port}' },
+  'logbook.portRoute':       { EN:'⚓ {from} → {to}',                      IS:'⚓ {from} → {to}' },
+  'logbook.noDriveConfig':   { EN:'File upload not configured — trip saved without attachment.',
+                               IS:'Skráarupphal ekki stillt — ferð vistuð án viðhengis.' },
+  'boat.registrationNo':     { EN:'Registration no.',                      IS:'Skráningarnúmer' },
+  'boat.loa':                { EN:'LOA (ft)',                              IS:'Heildarlengd (fet)' },
+  'boat.typeModel':          { EN:'Type / model',                          IS:'Tegund / gerð' },
+  'boat.defaultPort':        { EN:'Default port',                          IS:'Heimahöfn' },
+  'location.type':           { EN:'Type',                                  IS:'Tegund' },
+  'location.typePort':       { EN:'Port',                                  IS:'Höfn' },
+  'location.typeLocation':   { EN:'Location',                              IS:'Staðsetning' },
+
 };
 
 window.s = function s(key, vars, lang) {


### PR DESCRIPTION
- Add 'Keelboat Crew' certification with ranked subcategories (Crew / Helmsman / Captain) using the existing cert framework. Gold color #d4af37 matches keelboat visual palette.

- Add GPS track upload (GPX/KML/KMZ) to all trips: files stored to Google Drive (DRIVE_FOLDER_ID_TRACKS property), KMZ decompressed via Utilities.unzip(), tracks parsed with XmlService (supports GPX 1.0/1.1 and KML/gx:Track), Haversine distance computed and Ramer-Douglas-Peucker simplification (~50-100 pts) applied.

- Add photo upload to all trips: files stored to Google Drive (DRIVE_FOLDER_ID_PHOTOS property); Drive shareable URLs stored as JSON array in trip record.

- Add port system: locations gain a 'type' field (location | port); boats gain a 'defaultPortId'; logbook form auto-fills departure and arrival port from boat default, with a datalist picker, free-text fallback, and inline 'Add to list' flow. Port info shown on card face for keelboat trips (same port → '⚓ X'; route → '⚓ X → Y').

- Add keelboat-only boat fields in admin: registration number, LOA (ft), type/model — shown/hidden based on category select. Reg + model displayed as sub-line on boat cards.

- Add distance (nm), GPS track link, and photo thumbnails to expanded trip cards. GPS/photo uploads are non-blocking: trip saves normally if Drive folders are not yet configured.

- Add bilingual strings (EN + IS) for all new UI labels.

Closes skarfur/ymir#37 (Phase 1)

https://claude.ai/code/session_01V6grEcojMtLs9wEPb7cG43