### PR TITLE
fix(checkin): move GPS/photo/port to member check-in; staff check-in …

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -627,30 +627,103 @@ function advanceToChecklist() {
 
 function renderLandingChecklist() {
   if(!returnCo) return;
+  // Reset pending upload state each time this step is rendered
+  window._retPendingTrack=null; window._retPendingPhotos=[];
   document.getElementById('returnModalTitle').textContent=s('member.checkInTitle')+' — '+(returnCo.boatName||'');
+  var IS=getLang()==='IS';
   var cat=(returnCo.boatCategory||'other').toLowerCase();
+  var isKeel=cat==='keelboat';
   var cl=_launchChecklists[cat]||_launchChecklists.other||{};
   var items=Array.isArray(cl.landing)?cl.landing.slice().sort((a,b)=>(a.sort||0)-(b.sort||0)):[];
   var checks=items.map(it=>
     '<label style="display:flex;align-items:center;gap:10px;padding:8px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
     '<input type="checkbox" class="land-check" style="width:16px;height:16px;accent-color:var(--brass)">'+
     '<span>'+esc(_clItemLabel(it))+'</span></label>').join('');
+
+  // Arrival port — keelboat only
+  var portHtml='';
+  if(isKeel){
+    var portOpts=(locations||[]).filter(function(l){return l.type==='port';}).map(function(p){return'<option value="'+esc(p.name)+'">';}).join('');
+    var homePt=returnCo.departurePort||'';
+    if(!homePt){var _b=boats.find(function(x){return x.id===returnCo.boatId;});if(_b&&_b.defaultPortId){var _lp=locations.find(function(l){return l.id===_b.defaultPortId;});if(_lp)homePt=_lp.name;}}
+    portHtml='<div class="field" style="margin-bottom:12px">'+
+      '<label style="display:block;font-size:9px;color:var(--brass);letter-spacing:.8px;margin-bottom:6px">'+(IS?'⚓ KOMUSTAÐUR':'⚓ ARRIVAL PORT')+'</label>'+
+      '<input list="retPortsList" id="retArrivalPort" placeholder="'+(IS?'Sama og brottfararstaður':'Same as departure')+'" value="'+esc(homePt)+'" autocomplete="off" style="width:100%;box-sizing:border-box">'+
+      '<datalist id="retPortsList">'+portOpts+'</datalist>'+
+    '</div>';
+  }
+
+  // GPS track upload
+  var trackHtml='<div class="field" style="margin-bottom:10px">'+
+    '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">'+(IS?'GPS-LEIÐ — GPX / KML / KMZ':'GPS TRACK — GPX / KML / KMZ')+'</label>'+
+    '<input type="file" id="retTrackFile" accept=".gpx,.kml,.kmz" onchange="_handleRetTrack(this)" style="font-size:11px;color:var(--text);width:100%;box-sizing:border-box">'+
+    '<div id="retTrackStatus" style="font-size:11px;color:var(--muted);margin-top:4px"></div>'+
+  '</div>';
+
+  // Distance (auto-filled from GPS, editable)
+  var distHtml='<div class="field" style="margin-bottom:10px">'+
+    '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">'+(IS?'VEGALENGD (NM)':'DISTANCE (NM)')+'</label>'+
+    '<input type="number" id="retDistNm" min="0" step="0.1" placeholder="0.0" style="width:90px">'+
+  '</div>';
+
+  // Photo upload
+  var photoHtml='<div class="field" style="margin-bottom:14px">'+
+    '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">'+(IS?'MYNDIR':'PHOTOS')+'</label>'+
+    '<input type="file" id="retPhotoFiles" accept="image/*" multiple onchange="_handleRetPhotos(this)" style="font-size:11px;color:var(--text);width:100%;box-sizing:border-box">'+
+    '<div id="retPhotoPreview" style="display:flex;gap:6px;flex-wrap:wrap;margin-top:6px"></div>'+
+  '</div>';
+
   document.getElementById('returnModalBody').innerHTML=
     (items.length?'<div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:10px">LANDING — '+_fmtCatLabel(cat)+'</div>'+checks:'')+
-    '<div id="landCheckErr" style="display:none;font-size:11px;color:var(--red);margin:6px 0">Please confirm all items.</div>'+
+    '<div id="landCheckErr" style="display:none;font-size:11px;color:var(--red);margin:6px 0">'+(IS?'Staðfestu alla liði.':'Please confirm all items.')+'</div>'+
     '<div style="display:flex;gap:8px;margin:12px 0">'+
-      '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--orange);border-color:var(--orange)55" onclick="openInlineReport(\'damage\')">&#9888; Report damage</button>'+
-      '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--red);border-color:var(--red)55" onclick="openInlineReport(\'incident\')">&#128680; Report incident</button>'+
+      '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--orange);border-color:var(--orange)55" onclick="openInlineReport(\'damage\')">&#9888; '+(IS?'Tilkynna skemmdir':'Report damage')+'</button>'+
+      '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--red);border-color:var(--red)55" onclick="openInlineReport(\'incident\')">&#128680; '+(IS?'Tilkynna atvik':'Report incident')+'</button>'+
     '</div>'+
     '<div id="reportFlagNote" style="display:none;font-size:11px;padding:5px 8px;border-radius:4px;background:var(--surface);margin-bottom:8px"></div>'+
+    portHtml+trackHtml+distHtml+photoHtml+
     '<div class="field" style="margin-bottom:14px">'+
-      '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">PERSONAL NOTE</label>'+
-      '<textarea id="retNotes" rows="2" placeholder="Optional note for your logbook" style="width:100%;resize:none;font-size:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px;font-family:inherit;box-sizing:border-box"></textarea>'+
+      '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">'+(IS?'PERSÓNULEGAR SKÝRINGAR':'PERSONAL NOTE')+'</label>'+
+      '<textarea id="retNotes" rows="2" placeholder="'+(IS?'Valfrjáls athugasemd fyrir siglingabókina':'Optional note for your logbook')+'" style="width:100%;resize:none;font-size:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px;font-family:inherit;box-sizing:border-box"></textarea>'+
     '</div>'+
     '<div class="btn-row">'+
-      '<button class="btn btn-secondary" onclick="renderReturnForm()">&#8592; Back</button>'+
-      '<button class="btn btn-primary" onclick="confirmCheckIn(\''+returnCo.id+'\')">&#10003; Check In</button>'+
+      '<button class="btn btn-secondary" onclick="renderReturnForm()">&#8592; '+(IS?'Til baka':'Back')+'</button>'+
+      '<button class="btn btn-primary" id="retSubmitBtn" onclick="confirmCheckIn(\''+returnCo.id+'\')">&#10003; '+(IS?'Skrá inn':'Check In')+'</button>'+
     '</div>';
+}
+
+function _handleRetTrack(input){
+  var file=input.files[0];
+  var statusEl=document.getElementById('retTrackStatus');
+  var IS=getLang()==='IS';
+  if(!file){window._retPendingTrack=null;statusEl.textContent='';return;}
+  statusEl.textContent=IS?'Lesur skrá…':'Reading…';statusEl.style.color='var(--muted)';
+  var reader=new FileReader();
+  reader.onload=function(e){
+    window._retPendingTrack={fileName:file.name,fileData:e.target.result,mimeType:file.type||'application/octet-stream'};
+    statusEl.textContent=(IS?'Tilbúið: ':'Ready: ')+file.name;statusEl.style.color='var(--brass)';
+  };
+  reader.onerror=function(){statusEl.textContent=IS?'Lestur mistókst':'Read error';statusEl.style.color='var(--red)';window._retPendingTrack=null;};
+  reader.readAsDataURL(file);
+}
+
+function _handleRetPhotos(input){
+  var files=Array.from(input.files);
+  window._retPendingPhotos=[];
+  var preview=document.getElementById('retPhotoPreview');
+  preview.innerHTML='';
+  files.forEach(function(file){
+    var reader=new FileReader();
+    reader.onload=function(e){
+      window._retPendingPhotos.push({fileName:file.name,fileData:e.target.result,mimeType:file.type||'image/jpeg'});
+      var img=document.createElement('img');
+      img.src=e.target.result;
+      img.style.cssText='width:56px;height:56px;object-fit:cover;border-radius:4px;border:1px solid var(--border)';
+      img.title=file.name;
+      preview.appendChild(img);
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 // ── Inline report forms ───────────────────────────────────────────────────────
@@ -723,24 +796,66 @@ async function submitInlineReport(type) {
 
 async function confirmCheckIn(coId) {
   var boxes=document.querySelectorAll('.land-check');
-  if(boxes.length&&!Array.from(boxes).every(b=>b.checked)){document.getElementById('landCheckErr').style.display='block';return;}
+  if(boxes.length&&!Array.from(boxes).every(function(b){return b.checked;})){document.getElementById('landCheckErr').style.display='block';return;}
   var timeIn=window._retTimeIn||fmtTimeNow(), tripSnap=window._retWxSnap||null;
   var notes=(document.getElementById('retNotes')||{}).value||'';
-  var co=checkouts.find(c=>c.id===coId); if(!co) return;
+  var co=checkouts.find(function(c){return c.id===coId;}); if(!co) return;
   var tout=(co.checkedOutAt||co.timeOut||'').slice(0,5);
   var h=(tout&&timeIn)?((new Date('2000-01-01T'+timeIn)-new Date('2000-01-01T'+tout))/3600000):0;
-  var today=new Date().toISOString().slice(0,10), errEl=document.getElementById('landCheckErr');
+  if(h<0) h+=24;
+  var today=new Date().toISOString().slice(0,10);
+  var errEl=document.getElementById('landCheckErr');
+  var IS=getLang()==='IS';
+  var isKeel=(co.boatCategory||'').toLowerCase()==='keelboat';
+  var arrivalPort=isKeel?((document.getElementById('retArrivalPort')||{}).value||'').trim():'';
+  var manualDist=parseFloat((document.getElementById('retDistNm')||{}).value)||'';
+
+  // Disable submit while uploading
+  var submitBtn=document.getElementById('retSubmitBtn');
+  if(submitBtn){submitBtn.disabled=true;submitBtn.textContent=IS?'Hleður upp…':'Uploading…';}
+
+  // Upload GPS track
+  var trackFileUrl='',trackSimplified='',trackSource='',distanceNm=manualDist;
+  if(window._retPendingTrack){
+    try{
+      var tr=await apiPost('uploadTripFile',{fileType:'track',fileName:window._retPendingTrack.fileName,fileData:window._retPendingTrack.fileData,mimeType:window._retPendingTrack.mimeType});
+      if(tr.ok){
+        trackFileUrl=tr.trackFileUrl||'';trackSimplified=tr.trackSimplified||'';trackSource=tr.trackSource||'';
+        if(!distanceNm&&tr.distanceNm){distanceNm=tr.distanceNm;var dEl=document.getElementById('retDistNm');if(dEl)dEl.value=tr.distanceNm;}
+      } else {showToast(IS?'GPS upphal ekki stillt':'GPS upload not configured','warn');}
+    }catch(e){showToast((IS?'GPS upphal mistókst: ':'GPS upload failed: ')+e.message,'warn');}
+  }
+
+  // Upload photos
+  var photoUrls=[];
+  for(var _pi=0;_pi<(window._retPendingPhotos||[]).length;_pi++){
+    var ph=window._retPendingPhotos[_pi];
+    try{
+      var pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType});
+      if(pr.ok&&pr.photoUrl)photoUrls.push(pr.photoUrl);
+      else if(!pr.ok)showToast(IS?'Skráarupphal ekki stillt':'Photo upload not configured','warn');
+    }catch(e){showToast((IS?'Mynda upphal mistókst: ':'Photo upload failed: ')+e.message,'warn');}
+  }
+
   try {
     await apiPost('checkIn',{id:coId,timeIn,kennitala:user.kennitala,memberName:user.name,boatId:co.boatId,boatName:co.boatName});
     await apiPost('saveTrip',{kennitala:user.kennitala,memberName:user.name,memberId:user.id||user.kennitala,
-      date:today,boatId:co.boatId,boatName:co.boatName,locationId:co.locationId||'',locationName:co.locationName||'',
+      date:today,boatId:co.boatId,boatName:co.boatName,boatCategory:co.boatCategory||'',
+      locationId:co.locationId||'',locationName:co.locationName||'',
       timeOut:tout,timeIn,hoursDecimal:h>0?h.toFixed(2):'0',crew:co.crew||1,
       beaufort:tripSnap?tripSnap.bft:null,windDir:tripSnap?(tripSnap.dir||tripSnap.wDir||''):'',
-      wxSnapshot:tripSnap?JSON.stringify(tripSnap):null,notes,role:'skipper',linkedCheckoutId:coId});
+      wxSnapshot:tripSnap?JSON.stringify(tripSnap):null,notes,role:'skipper',linkedCheckoutId:coId,isLinked:true,
+      departurePort:co.departurePort||'',arrivalPort,
+      distanceNm,trackFileUrl,trackSimplified,trackSource,
+      photoUrls:photoUrls.length?JSON.stringify(photoUrls):'',
+    });
     checkouts=(await apiGet('getActiveCheckouts')).checkouts||[];
     closeModal('returnModal'); renderActiveCheckouts(); renderFleetByCat();
     logbookLoaded=false; showToast(s('toast.checkedIn'));
-  } catch(e){ if(errEl){errEl.textContent=s('toast.error')+': '+e.message;errEl.style.display='block';} }
+  } catch(e){
+    if(submitBtn){submitBtn.disabled=false;submitBtn.textContent='&#10003; '+(IS?'Skrá inn':'Check In');}
+    if(errEl){errEl.textContent=s('toast.error')+': '+e.message;errEl.style.display='block';}
+  }
 }
 
 // ══ MANUAL TRIP MODAL ════════════════════════════════════════════════════════

--- a/staff/index.html
+++ b/staff/index.html
@@ -336,10 +336,9 @@ border-bottom:1px solid var(--border)44; }
         <div style="font-size:10px;color:var(--muted);margin-top:4px">Named crew get this trip logged in their logbook automatically.</div>
       </div>
       <!-- Departure port — shown for keelboats only -->
-      <div id="coPortRow" style="display:none;margin-bottom:10px">
-        <label style="font-size:9px;color:var(--brass);letter-spacing:1px;text-transform:uppercase;display:block;margin-bottom:6px">⚓ <span id="coPortLabel">Departure Port</span></label>
-        <input list="coPortsList" id="coDeparturePort" placeholder="Home port" autocomplete="off"
-          style="width:100%;box-sizing:border-box">
+      <div id="coPortRow" class="field" style="display:none">
+        <label style="color:var(--brass)">⚓ Departure Port</label>
+        <input list="coPortsList" id="coDeparturePort" placeholder="Home port" autocomplete="off">
         <datalist id="coPortsList"></datalist>
       </div>
       <div class="field">
@@ -437,7 +436,7 @@ border-bottom:1px solid var(--border)44; }
       <div class="dl-drow" id="cdGuardianRow"><span class="dl-dlbl" data-s="lbl.guardian"></span><span class="dl-dval" id="cdGuardian"></span></div>
     </div>
     <div style="display:flex;gap:8px;flex-wrap:wrap">
-      <button class="btn btn-primary" onclick="openCheckInModal(_detailId)"
+      <button class="btn btn-primary" onclick="staffCheckIn(_detailId);closeCoDetail()"
         style="flex:1;min-width:120px" data-s="staff.checkIn"></button>
       <button class="btn btn-secondary" onclick="staffDeleteCheckout(_detailId,document.getElementById('cdBoat').textContent);closeCoDetail()"
         style="flex:1;min-width:120px" data-s="btn.delete"></button>
@@ -626,7 +625,7 @@ function renderCheckouts() {
   singles.forEach(c => {
     const inner = renderCheckoutCard(c, {
       staffView: true,
-      onCheckIn: "openCheckInModal('" + c.id + "')",
+      onCheckIn: "staffCheckIn('" + c.id + "')",
       onDelete:  "staffDeleteCheckout('" + c.id + "','" + esc(c.boatName||'') + "')",
     });
     const wrapper = document.createElement('div');
@@ -838,13 +837,39 @@ async function submitCheckout() {
 
 async function staffCheckIn(id) {
   try {
-    const timeIn = new Date().toTimeString().slice(0,5);
-    await apiPost('checkIn', { id, timeIn });
     const co = checkouts.find(c => c.id === id);
-    if (co) { co.status='in'; co.checkedInAt=timeIn; }
+    const timeIn = new Date().toTimeString().slice(0, 5);
+    await apiPost('checkIn', { id, timeIn });
+    // Auto-create trip record for the skipper
+    if (co && co.memberKennitala) {
+      const timeOut = (co.checkedOutAt || co.timeOut || '').slice(0, 5);
+      let hoursDecimal = 0;
+      if (timeOut && timeIn) {
+        const [oh, om] = timeOut.split(':').map(Number);
+        const [ih, im] = timeIn.split(':').map(Number);
+        let mins = (ih * 60 + im) - (oh * 60 + om);
+        if (mins < 0) mins += 1440;
+        hoursDecimal = +(mins / 60).toFixed(2);
+      }
+      try {
+        await apiPost('saveTrip', {
+          kennitala: co.memberKennitala, memberName: co.memberName || '',
+          date: new Date().toISOString().slice(0, 10),
+          timeOut, timeIn, hoursDecimal,
+          boatId: co.boatId, boatName: co.boatName, boatCategory: co.boatCategory || '',
+          locationId: co.locationId, locationName: co.locationName,
+          crew: co.crew || 1, role: 'skipper',
+          linkedCheckoutId: id, isLinked: true,
+          departurePort: co.departurePort || '',
+          wxSnapshot: co.wxSnapshot || '',
+        });
+      } catch(e2) { console.warn('Auto trip save failed:', e2.message); }
+    }
+    const localCo = checkouts.find(c => c.id === id);
+    if (localCo) { localCo.status = 'in'; localCo.checkedInAt = timeIn; }
     renderAll();
     showToast(s('toast.checkedIn'));
-  } catch(e) { alert(s('toast.error')+': '+e.message); }
+  } catch(e) { alert(s('toast.error') + ': ' + e.message); }
 }
 
 async function staffDeleteCheckout(id, boatName) {
@@ -908,198 +933,6 @@ function onCoBoatChange() {
     }
   } else {
     document.getElementById('coDeparturePort').value = '';
-  }
-}
-
-// ── Check-in modal ────────────────────────────────────────────────────────────
-let _ciCheckoutId = null;
-let _ciPendingTrack = null;
-let _ciPendingPhotos = [];
-
-function openCheckInModal(id) {
-  const co = checkouts.find(c => c.id === id);
-  if (!co) return;
-  _ciCheckoutId = id;
-  _ciPendingTrack = null;
-  _ciPendingPhotos = [];
-
-  const IS = getLang() === 'IS';
-
-  // Labels
-  document.getElementById('ciTitle').textContent     = esc(co.boatName || co.boatId);
-  document.getElementById('ciTimeLabel').textContent = IS ? 'Skilatími' : 'Check-in time';
-  document.getElementById('ciTrackLabel').textContent= IS ? 'GPS-leið — GPX / KML / KMZ' : 'GPS Track — GPX / KML / KMZ';
-  document.getElementById('ciPhotoLabel').textContent= IS ? 'Myndir' : 'Photos';
-  document.getElementById('ciCancelBtn').textContent = IS ? 'Hætta við' : 'Cancel';
-  document.getElementById('ciSubmitBtn').textContent = IS ? '✓ Skrá inn' : '✓ Check In';
-
-  // Reset file inputs
-  document.getElementById('ciTrackFile').value = '';
-  document.getElementById('ciTrackStatus').textContent = '';
-  document.getElementById('ciPhotoFiles').value = '';
-  document.getElementById('ciPhotoPreview').innerHTML = '';
-  document.getElementById('ciErr').style.display = 'none';
-
-  // Default check-in time to now
-  document.getElementById('ciTimeIn').value = fmtTimeNow();
-
-  // Arrival port — keelboats only
-  const isKeel = (co.boatCategory || '').toLowerCase() === 'keelboat';
-  const portRow = document.getElementById('ciPortRow');
-  portRow.style.display = isKeel ? '' : 'none';
-  if (isKeel) {
-    document.getElementById('ciArrivalPortLabel').textContent = IS ? '⚓ KOMUSTAÐUR' : '⚓ ARRIVAL PORT';
-    document.getElementById('ciArrivalPort').placeholder = IS ? 'Sama og brottfararstaður' : 'Same as departure';
-    const dl = document.getElementById('ciPortsList');
-    dl.innerHTML = locations.filter(l => l.type === 'port')
-      .map(p => `<option value="${esc(p.name)}">`).join('');
-    // Soft-populate with home port or departure port stored on checkout
-    const boat = boats.find(b => b.id === co.boatId);
-    const home = boat?.defaultPortId ? locations.find(l => l.id === boat.defaultPortId) : null;
-    document.getElementById('ciArrivalPort').value = co.departurePort || (home ? home.name : '');
-  }
-
-  closeModal('coDetailModal');
-  openModal('checkInModal');
-}
-
-function closeCheckInModal() { closeModal('checkInModal'); }
-
-function handleCiTrack(input) {
-  const file = input.files[0];
-  const status = document.getElementById('ciTrackStatus');
-  if (!file) { _ciPendingTrack = null; status.textContent = ''; return; }
-  const IS = getLang() === 'IS';
-  status.textContent = IS ? 'Lesur skrá…' : 'Reading…';
-  status.style.color = 'var(--muted)';
-  const reader = new FileReader();
-  reader.onload = e => {
-    _ciPendingTrack = { fileName: file.name, fileData: e.target.result, mimeType: file.type || 'application/octet-stream' };
-    status.textContent = (IS ? 'Tilbúið: ' : 'Ready: ') + file.name;
-    status.style.color = 'var(--brass)';
-  };
-  reader.onerror = () => {
-    status.textContent = IS ? 'Lestur mistókst' : 'Read error';
-    status.style.color = 'var(--red)';
-    _ciPendingTrack = null;
-  };
-  reader.readAsDataURL(file);
-}
-
-function handleCiPhotos(input) {
-  const files = Array.from(input.files);
-  _ciPendingPhotos = [];
-  const preview = document.getElementById('ciPhotoPreview');
-  preview.innerHTML = '';
-  const IS = getLang() === 'IS';
-  files.forEach(file => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      _ciPendingPhotos.push({ fileName: file.name, fileData: e.target.result, mimeType: file.type || 'image/jpeg' });
-      const img = document.createElement('img');
-      img.src = e.target.result;
-      img.style.cssText = 'width:56px;height:56px;object-fit:cover;border-radius:4px;border:1px solid var(--border)';
-      img.title = file.name;
-      preview.appendChild(img);
-    };
-    reader.readAsDataURL(file);
-  });
-}
-
-async function submitCheckIn() {
-  const id = _ciCheckoutId;
-  const co = checkouts.find(c => c.id === id);
-  if (!co) return;
-  const IS = getLang() === 'IS';
-
-  const timeIn = document.getElementById('ciTimeIn').value.trim() || fmtTimeNow();
-  const isKeel = (co.boatCategory || '').toLowerCase() === 'keelboat';
-  const arrivalPort = isKeel ? (document.getElementById('ciArrivalPort').value || '').trim() : '';
-  const btn    = document.getElementById('ciSubmitBtn');
-  const errEl  = document.getElementById('ciErr');
-  errEl.style.display = 'none';
-  btn.disabled = true;
-  btn.textContent = IS ? 'Hleður upp…' : 'Uploading…';
-
-  // ── Upload GPS track ──────────────────────────────────────────────────────
-  let trackFileUrl = '', trackSimplified = '', trackSource = '', distanceNm = '';
-  if (_ciPendingTrack) {
-    try {
-      const tr = await apiPost('uploadTripFile', {
-        fileType: 'track', fileName: _ciPendingTrack.fileName,
-        fileData: _ciPendingTrack.fileData, mimeType: _ciPendingTrack.mimeType,
-      });
-      if (tr.ok) {
-        trackFileUrl    = tr.trackFileUrl    || '';
-        trackSimplified = tr.trackSimplified || '';
-        trackSource     = tr.trackSource     || '';
-        distanceNm      = tr.distanceNm      || '';
-      } else {
-        showToast(IS ? 'GPS upphal ekki stillt — ferð vistuð án GPS.' : 'GPS upload not configured — trip saved without track.', 'warn');
-      }
-    } catch(e) {
-      showToast((IS ? 'GPS upphal mistókst: ' : 'GPS upload failed: ') + e.message, 'warn');
-    }
-  }
-
-  // ── Upload photos ─────────────────────────────────────────────────────────
-  const photoUrls = [];
-  for (const ph of _ciPendingPhotos) {
-    try {
-      const pr = await apiPost('uploadTripFile', {
-        fileType: 'photo', fileName: ph.fileName, fileData: ph.fileData, mimeType: ph.mimeType,
-      });
-      if (pr.ok && pr.photoUrl) photoUrls.push(pr.photoUrl);
-      else if (!pr.ok) showToast(IS ? 'Skráarupphal ekki stillt' : 'Photo upload not configured', 'warn');
-    } catch(e) {
-      showToast((IS ? 'Mynda upphal mistókst: ' : 'Photo upload failed: ') + e.message, 'warn');
-    }
-  }
-
-  try {
-    // 1. Check in the checkout record
-    await apiPost('checkIn', { id, timeIn });
-
-    // 2. Always save a trip record for the skipper
-    if (co.memberKennitala) {
-      const timeOut = (co.checkedOutAt || co.timeOut || '').slice(0, 5);
-      let hoursDecimal = 0;
-      if (timeOut && timeIn) {
-        const [oh, om] = timeOut.split(':').map(Number);
-        const [ih, im] = timeIn.split(':').map(Number);
-        let mins = (ih * 60 + im) - (oh * 60 + om);
-        if (mins < 0) mins += 1440;
-        hoursDecimal = +(mins / 60).toFixed(2);
-      }
-      await apiPost('saveTrip', {
-        kennitala: co.memberKennitala, memberName: co.memberName || '',
-        date: new Date().toISOString().slice(0, 10),
-        timeOut, timeIn, hoursDecimal,
-        boatId: co.boatId, boatName: co.boatName, boatCategory: co.boatCategory || '',
-        locationId: co.locationId, locationName: co.locationName,
-        crew: co.crew || 1, role: 'skipper',
-        linkedCheckoutId: id, isLinked: true,
-        departurePort: co.departurePort || '',
-        arrivalPort,
-        distanceNm,
-        trackFileUrl, trackSimplified, trackSource,
-        photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
-        wxSnapshot: co.wxSnapshot || '',
-      });
-    }
-
-    // Update local state optimistically
-    const localCo = checkouts.find(c => c.id === id);
-    if (localCo) { localCo.status = 'in'; localCo.checkedInAt = timeIn; }
-
-    closeCheckInModal();
-    renderAll();
-    showToast(s('toast.checkedIn'));
-  } catch(e) {
-    errEl.textContent = s('toast.error') + ': ' + e.message;
-    errEl.style.display = 'block';
-    btn.disabled = false;
-    btn.textContent = IS ? '✓ Skrá inn' : '✓ Check In';
   }
 }
 
@@ -1595,58 +1428,6 @@ async function toggleStaffStatus(field) {
 
 <!-- ══ DAILY LOG LINK MODAL ══════════════════════════════════════════════ -->
 <div class="dl-link-overlay hidden" id="dlLinkModal">
-<!-- ══ CHECK-IN MODAL ══ -->
-<div class="modal-overlay hidden" id="checkInModal" onclick="if(event.target===this)closeCheckInModal()">
-  <div class="modal" style="max-width:440px">
-    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
-      <h3 style="margin:0" id="ciTitle">Check In</h3>
-      <button class="btn-ghost" onclick="closeCheckInModal()"
-        style="font-size:20px;padding:0 6px;line-height:1;border:none;color:var(--muted)">×</button>
-    </div>
-
-    <!-- Time -->
-    <div class="field" style="margin-bottom:12px">
-      <label style="font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:5px"
-        id="ciTimeLabel">Check-in time</label>
-      <input type="text" id="ciTimeIn" pattern="[0-9]{2}:[0-9]{2}" placeholder="HH:MM"
-        maxlength="5" style="width:90px">
-    </div>
-
-    <!-- Arrival port — keelboat only -->
-    <div id="ciPortRow" style="display:none;margin-bottom:12px">
-      <label style="font-size:9px;color:var(--brass);letter-spacing:1px;text-transform:uppercase;display:block;margin-bottom:5px"
-        id="ciArrivalPortLabel">⚓ Arrival Port</label>
-      <input list="ciPortsList" id="ciArrivalPort" placeholder="Same as departure" autocomplete="off"
-        style="width:100%;box-sizing:border-box">
-      <datalist id="ciPortsList"></datalist>
-    </div>
-
-    <!-- GPS Track -->
-    <div style="margin-bottom:12px">
-      <label style="font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:5px"
-        id="ciTrackLabel">GPS Track — GPX / KML / KMZ</label>
-      <input type="file" id="ciTrackFile" accept=".gpx,.kml,.kmz" onchange="handleCiTrack(this)"
-        style="font-size:11px;color:var(--text);width:100%">
-      <div id="ciTrackStatus" style="font-size:11px;color:var(--muted);margin-top:4px"></div>
-    </div>
-
-    <!-- Photos -->
-    <div style="margin-bottom:16px">
-      <label style="font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:5px"
-        id="ciPhotoLabel">Photos</label>
-      <input type="file" id="ciPhotoFiles" accept="image/*" multiple onchange="handleCiPhotos(this)"
-        style="font-size:11px;color:var(--text);width:100%">
-      <div id="ciPhotoPreview" style="display:flex;gap:6px;flex-wrap:wrap;margin-top:6px"></div>
-    </div>
-
-    <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeCheckInModal()" id="ciCancelBtn">Cancel</button>
-      <button class="btn btn-primary" id="ciSubmitBtn" onclick="submitCheckIn()">✓ Check In</button>
-    </div>
-    <div id="ciErr" style="color:var(--red);font-size:11px;margin-top:8px;display:none"></div>
-  </div>
-</div>
-
   <div class="dl-link-sheet">
     <div class="dl-link-title">Link to daily log activity?</div>
     <div class="dl-link-sub">This group checkout can be linked to an activity in today's log.</div>


### PR DESCRIPTION
…direct

Staff hub:
- Revert check-in to direct (no modal) — staff just checks the member in, member manages log details themselves.
- staffCheckIn() auto-creates a basic trip record for the skipper with time, boat, location, departure port, and wx snapshot.
- Remove the check-in modal HTML and all _ci* functions entirely.
- Fix departure port field styling to use .field class, matching the location and boat selects.

Member portal (renderLandingChecklist + confirmCheckIn):
- Add arrival port field (keelboats only), soft-populated with home port or the stored departure port from the checkout.
- Add GPS track upload (GPX/KML/KMZ) with file-ready status indicator.
- Add distance (nm) field, auto-filled from GPS parse result.
- Add photo upload with thumbnail preview.
- confirmCheckIn() uploads GPS track and photos before saving trip, populates distanceNm from backend parse if not manually set, and passes all new fields to saveTrip.
- _handleRetTrack / _handleRetPhotos handlers store pending files in window state, reset each time the checklist step is rendered.
- Bilingual (EN/IS) throughout.

https://claude.ai/code/session_01GTYuY9qFbziAYxKZMt6cRP