### PR TITLE
Remove submit incident report from current day's log

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -541,6 +541,8 @@ function renderActivitiesReadonly() {
 function renderIncidentSection(incidents) {
   const container = dom.incidentContainer;
   const heading   = dom.incidentHeading;
+  heading.hidden = false;
+  container.hidden = false;
   if (!incidents) {
     heading.textContent = s('daily.incidentReport');
     container.innerHTML = `<a href="../incidents/" class="incident-btn">
@@ -936,7 +938,9 @@ async function loadDay() {
 }
 
 async function loadTodayLog() {
-  renderChecklists(); renderActivities(); renderWxLog(); renderActTypeBtns(); renderIncidentSection(null);
+  renderChecklists(); renderActivities(); renderWxLog(); renderActTypeBtns();
+  dom.incidentHeading.hidden = true;
+  dom.incidentContainer.hidden = true;
   try {
     const [logRes, cfgRes] = await Promise.all([
       apiGet('getDailyLog', { date: TODAY }),
@@ -950,7 +954,6 @@ async function loadTodayLog() {
   renderActivities();
   renderWxLog();
   renderActTypeBtns();
-  renderIncidentSection(null);
 }
 
 async function loadPastLog() {
@@ -964,7 +967,7 @@ async function loadPastLog() {
     renderIncidentSection(incidents);
   } catch(e) {
     console.warn('loadPastLog failed:', e.message);
-    renderIncidentSection(null);
+    renderIncidentSection([]);
   }
   renderChecklistsReadonly();
   renderActivitiesReadonly();


### PR DESCRIPTION
The incident report submission button is handled on the staff hub, so hide the incident section entirely when viewing today's log. Past days continue to display any incidents filed on that date.

Fixes #46