### PR TITLE
Fix timesheet pairing + remove live clock counter

### DIFF
--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -371,6 +371,33 @@ function prRenderCalLabel(){
   var d=new Date(_calYear,_calMonth,1);
   document.getElementById('prCalLabel').textContent=d.toLocaleDateString(locale(),{month:'long',year:'numeric'});
 }
+// Pair separate type='in'/type='out' rows into single session entries,
+// and preserve legacy single-row entries (originalTimestamp format).
+function _pairTimeEntries(rows) {
+  var ins   = rows.filter(function(r){ return r.type==='in'; });
+  var outs  = rows.filter(function(r){ return r.type==='out'; });
+  var other = rows.filter(function(r){ return r.type!=='in'&&r.type!=='out'&&r.type!=='break_start'&&r.type!=='break_end'; });
+  var paired = [];
+  // Legacy single-row entries
+  other.forEach(function(r){
+    var e=Object.assign({},r);
+    if(!e.clockIn&&e.originalTimestamp)e.clockIn=e.originalTimestamp;
+    paired.push(e);
+  });
+  // Pair out rows with their matching in rows
+  var usedInIds=new Set();
+  outs.slice().sort(function(a,b){return a.timestamp>b.timestamp?1:-1;}).forEach(function(out){
+    var matchIn=null;
+    ins.slice().reverse().forEach(function(inn){
+      if(!matchIn&&!usedInIds.has(inn.id)&&inn.employeeId===out.employeeId&&inn.timestamp<out.timestamp)
+        matchIn=inn;
+    });
+    var e=Object.assign({},out);
+    if(matchIn){e.clockIn=matchIn.timestamp;usedInIds.add(matchIn.id);}
+    paired.push(e);
+  });
+  return paired;
+}
 async function prLoadTsEntries(){
   var empId=document.getElementById('prTsEmp').value;
   var firstDay=new Date(_calYear,_calMonth,1);
@@ -383,7 +410,7 @@ async function prLoadTsEntries(){
     var params={from:rangeStart.toISOString().slice(0,10),to:rangeEnd.toISOString().slice(0,10),period:_calYear+'-'+String(_calMonth+1).padStart(2,'0')+'-01'};
     if(empId)params.employeeId=empId;
     var res=await apiGet('getTimeEntries',params);
-    _tsEntries=(res.entries||res.timeEntries||[]).map(function(e){if(!e.clockIn&&e.originalTimestamp)e.clockIn=e.originalTimestamp;return e;});
+    _tsEntries=_pairTimeEntries(res.entries||res.timeEntries||[]);
     var filtered=empId?_tsEntries.filter(function(e){return e.employeeId===empId;}):_tsEntries;
     var totalMins=filtered.reduce(function(s,e){return s+(+(e.durationMinutes||0));},0);
     document.getElementById('prTsTotal').textContent=fmtMins(totalMins)+' '+s('payroll.totalHours');

--- a/shared/payroll.js
+++ b/shared/payroll.js
@@ -299,7 +299,6 @@ function punchClockWidget(el, employeeId, opts) {
       '.pc-btn-brk{background:var(--surface);border:1px solid var(--brass);color:var(--brass)}' +
       '.pc-btn-brk-end{background:var(--brass);color:#0b1f38}' +
       '.pc-status{font-size:11px;color:var(--muted);display:flex;align-items:center;gap:6px}' +
-      '.pc-timer{font-size:20px;font-weight:700;font-variant-numeric:tabular-nums;color:var(--brass);letter-spacing:.5px}' +
       '.pc-recent{border-top:1px solid var(--border);padding:10px 16px 12px;display:flex;flex-direction:column;gap:0}' +
       '.pc-recent-lbl{font-size:9px;letter-spacing:1.2px;color:var(--muted);text-transform:uppercase;margin-bottom:6px}' +
       '.pc-row{display:flex;align-items:center;gap:8px;font-size:12px;padding:5px 0;border-bottom:1px solid var(--border)}' +
@@ -323,37 +322,24 @@ function punchClockWidget(el, employeeId, opts) {
   function t(k) { return typeof s === 'function' ? s(k) : k.split('.').pop(); }
   function _esc(v) { return String(v||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
-  function fmtMs(ms) {
-    var sec = Math.floor(Math.max(0, ms) / 1000);
-    var h = Math.floor(sec / 3600), m = Math.floor((sec % 3600) / 60), sc = sec % 60;
-    return h > 0
-      ? h + 'h ' + String(m).padStart(2,'0') + 'm'
-      : m + 'm ' + String(sc).padStart(2,'0') + 's';
-  }
-
   function fmtTime(iso) { return iso ? String(iso).slice(11,16) : '--:--'; }
   function fmtDate(iso) { return iso ? String(iso).slice(0,10) : ''; }
 
   // ── State: { clockedIn, onBreak, clockedInAt, breakStartedAt, recent, todayEntries }
   function render(state) {
-    clearInterval(el._pcTick);
     var ci    = state.clockedIn;
     var onBrk = state.onBreak;
-    var since = ci ? new Date(state.clockedInAt || 0) : null;
-    var brkSince = onBrk ? new Date(state.breakStartedAt || 0) : null;
     var allowBreaks = opts.allowBreaks;
 
     // ── Status line
     var statusHTML = '';
     if (ci && !onBrk) {
       statusHTML = '<div class="pc-status">'
-        + '<span>' + t('payroll.clockedInAt') + ' <strong>' + fmtTime(state.clockedInAt) + '</strong></span>'
-        + '&nbsp;·&nbsp;<span class="pc-timer" id="pcTimerDisplay">' + fmtMs(Date.now() - since) + '</span>'
+        + t('payroll.clockedInAt') + ' <strong>' + fmtTime(state.clockedInAt) + '</strong>'
         + '</div>';
     } else if (onBrk) {
       statusHTML = '<div class="pc-status">'
-        + '<span>' + t('payroll.onBreak') + ' <strong>' + fmtTime(state.breakStartedAt) + '</strong></span>'
-        + '&nbsp;·&nbsp;<span class="pc-timer" id="pcTimerDisplay">' + fmtMs(Date.now() - brkSince) + '</span>'
+        + t('payroll.onBreak') + ' <strong>' + fmtTime(state.breakStartedAt) + '</strong>'
         + '</div>';
     }
 
@@ -417,15 +403,6 @@ function punchClockWidget(el, employeeId, opts) {
       };
     }
 
-    // ── Live timer tick
-    if (ci || onBrk) {
-      var _timerBase = onBrk ? brkSince : since;
-      el._pcTick = setInterval(function() {
-        var d = document.getElementById('pcTimerDisplay');
-        if (d) d.textContent = fmtMs(Date.now() - _timerBase);
-        else   clearInterval(el._pcTick);
-      }, 1000);
-    }
   }
 
   // ── End-of-shift summary modal


### PR DESCRIPTION
Timesheet was showing only clock-out rows because clockIn_/clockOut_ write separate type='in'/type='out' rows, but the timesheet expected single paired rows. Add _pairTimeEntries() to match each out row with its preceding in row before rendering (calendar pills and list rows).

Remove live elapsed-time counter from punch clock widget; keep only static "Clocked in at HH:MM" / "On break since HH:MM" status line.

https://claude.ai/code/session_017r6miEjFgEb5h3owCKng3n