### PR TITLE
Reduce click latency across all pages

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -267,7 +267,7 @@ function route_(action, b) {
     case 'saveCertDef': return saveCertDef_(b);
     case 'deleteCertDef': return deleteCertDef_(b.id);
     case 'saveMemberCert': return saveMemberCert_(b);
-    case 'getIncidents': return getIncidents_();
+    case 'getIncidents': return getIncidents_(b);
     case 'createIncident': return createIncident_(b);
     case 'resolveIncident': return resolveIncident_(b);
     case 'addIncidentNote': return addIncidentNote_(b);
@@ -1073,9 +1073,16 @@ function saveMemberCert_(b) {
 // INCIDENTS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-function getIncidents_() {
-  const c = cGet_('incidents'); if (c) return okJ({ incidents: c });
-  const incidents = readAll_('incidents'); cPut_('incidents', incidents); return okJ({ incidents });
+function getIncidents_(b) {
+  b = b || {};
+  const c = cGet_('incidents');
+  const all = c || readAll_('incidents');
+  if (!c) cPut_('incidents', all);
+  if (b.date) {
+    const incidents = all.filter(function(i) { return (i.filedAt || i.createdAt || '').slice(0, 10) === b.date; });
+    return okJ({ incidents });
+  }
+  return okJ({ incidents: all });
 }
 
 function createIncident_(b) {

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -674,8 +674,12 @@ document.addEventListener('DOMContentLoaded', () => {
     openTripDetail(row.dataset.tripId);
   });
 
-  dom.prevBtn.addEventListener('click',  () => navigateDay(-1));
-  dom.nextBtn.addEventListener('click',  () => navigateDay(1));
+  function debounce(fn, ms) {
+    let t; return function(...a) { clearTimeout(t); t = setTimeout(() => fn(...a), ms); };
+  }
+  const debouncedNav = debounce(navigateDay, 300);
+  dom.prevBtn.addEventListener('click',  () => debouncedNav(-1));
+  dom.nextBtn.addEventListener('click',  () => debouncedNav(1));
   dom.todayBtn.addEventListener('click', () => navigateToToday());
 
   dom.addActivityBtn.addEventListener('click', openActivityModal);
@@ -954,12 +958,12 @@ async function loadTodayLog() {
 
 async function loadPastLog() {
   try {
-    const [logRes, cfgRes] = await Promise.all([
+    const [logRes, cfgRes, incidents] = await Promise.all([
       apiGet('getDailyLog', { date: viewDate }),
       apiGet('getConfig'),
+      loadIncidentsForDate(viewDate),
     ]);
     applyLogData(logRes.log, cfgRes);
-    const incidents = await loadIncidentsForDate(viewDate);
     renderIncidentSection(incidents);
   } catch(e) {
     console.warn('loadPastLog failed:', e.message);
@@ -989,8 +993,8 @@ async function loadPastTrips() {
 }
 async function loadIncidentsForDate(date) {
   try {
-    const res = await apiGet('getIncidents');
-    return (res.incidents || []).filter(i => (i.filedAt||i.createdAt||'').slice(0,10) === date);
+    const res = await apiGet('getIncidents', { date });
+    return res.incidents || [];
   } catch(e) { return []; }
 }
 

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -518,8 +518,9 @@ function buildFilters(){
 }
 
 // ── Log manually modal ────────────────────────────────────────────────────────
-let allClubTrips = [], clubTripsOffset = 0;
+let allClubTrips = [], clubTripsOffset = 0, _clubTripsLoadedAt = 0;
 const CLUB_PAGE = 10;
+const CLUB_TRIPS_TTL = 30000; // 30s cache
 
 async function openLogModal(){
   document.getElementById('logModal').classList.remove('hidden');
@@ -527,15 +528,21 @@ async function openLogModal(){
   _selectedClubTrip=null;
   document.getElementById('joinExtras').style.display='none';
   showStep1();
-  document.getElementById('recentTripsList').innerHTML='<div class="empty-note">Loading recent trips…</div>';
   document.getElementById('loadMoreTripsBtn').style.display='none';
-  // Always refresh club trips so already-logged entries are excluded
+  // Use cached club trips if fresh (< 30s), otherwise refetch
+  const myIds=new Set(myTrips.flatMap(t=>[t.linkedTripId,t.linkedCheckoutId,t.id]).filter(Boolean));
+  if(Date.now() - _clubTripsLoadedAt < CLUB_TRIPS_TTL && allClubTrips.length){
+    clubTripsOffset=0;
+    renderClubTripsList();
+    return;
+  }
+  document.getElementById('recentTripsList').innerHTML='<div class="empty-note">Loading recent trips…</div>';
   try{
     const res=await apiGet('getTrips',{limit:100});
-    const myIds=new Set(myTrips.flatMap(t=>[t.linkedTripId,t.linkedCheckoutId,t.id]).filter(Boolean));
     allClubTrips=(res.trips||[])
       .filter(t=>t.kennitala!==user.kennitala && !myIds.has(t.id))
       .sort((a,b)=>(b.date||'').localeCompare(a.date||''));
+    _clubTripsLoadedAt=Date.now();
   }catch(e){allClubTrips=[];}
   clubTripsOffset=0;
   renderClubTripsList();
@@ -730,18 +737,18 @@ async function submitJoinTrip(){
     }catch(e){ showToast((IS?'GPS upphal mistókst: ':'GPS upload failed: ')+e.message,'warn'); }
   }
 
-  // Upload photos
+  // Upload photos in parallel
   const photoUrls=[];
-  for(const ph of _joinPendingPhotos){
+  await Promise.all(_joinPendingPhotos.map(async ph=>{
     try{
       const pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType});
       if(pr.ok && pr.photoUrl) photoUrls.push(pr.photoUrl);
       else if(!pr.ok) showToast(IS?'Skráarupphal ekki stillt':'File upload not configured','warn');
     }catch(e){ showToast((IS?'Mynda upphal mistókst: ':'Photo upload failed: ')+e.message,'warn'); }
-  }
+  }));
 
   try{
-    await apiPost('saveTrip',{
+    const res=await apiPost('saveTrip',{
       linkedTripId: t.id,
       linkedCheckoutId: t.linkedCheckoutId||'',
       date: t.date, boatId: t.boatId, boatName: t.boatName, boatCategory: t.boatCategory||'',
@@ -753,9 +760,20 @@ async function submitJoinTrip(){
       trackFileUrl, trackSource,
       photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
     });
+    myTrips.unshift({
+      id: res.id, kennitala: user.kennitala,
+      linkedTripId: t.id, linkedCheckoutId: t.linkedCheckoutId||'',
+      date: t.date, boatId: t.boatId, boatName: t.boatName, boatCategory: t.boatCategory||'',
+      locationId: t.locationId, locationName: t.locationName,
+      timeOut: t.timeOut, timeIn: t.timeIn, hoursDecimal: t.hoursDecimal,
+      crew: t.crew, role: 'crew',
+      beaufort: t.beaufort||'', windDir: t.windDir||'',
+      notes, trackFileUrl, trackSource,
+      photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
+    });
+    renderStats(); buildFilters(); applyFilter();
     showToast(IS?'Bætt við siglingabókinni ✓':'Added to your logbook ✓','success');
     closeLogModal();
-    reload();
   }catch(e){
     errEl.textContent=e.message;
     errEl.style.display='';
@@ -897,20 +915,20 @@ async function submitManual(){
     }catch(e){ showToast((IS?'GPS upphal mistókst: ':'GPS upload failed: ')+e.message,'warn'); }
   }
 
-  // Upload photos
+  // Upload photos in parallel
   const photoUrls=[];
-  for(const ph of _pendingPhotos){
+  await Promise.all(_pendingPhotos.map(async ph=>{
     try{
       const pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType});
       if(pr.ok && pr.photoUrl) photoUrls.push(pr.photoUrl);
       else if(!pr.ok) showToast(IS?'Skráarupphal ekki stillt':'File upload not configured','warn');
     }catch(e){ showToast((IS?'Mynda upphal mistókst: ':'Photo upload failed: ')+e.message,'warn'); }
-  }
+  }));
 
   btn.disabled=false; btn.textContent=IS?'Vista í siglingabók':'Save to logbook';
 
   try{
-    await apiPost('saveTrip',{
+    const res=await apiPost('saveTrip',{
       date, boatId, boatName, boatCategory,
       locationId:locId, locationName:locName,
       timeOut, timeIn, hoursDecimal, crew, role,
@@ -919,9 +937,19 @@ async function submitManual(){
       trackFileUrl, trackSimplified, trackSource,
       photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
     });
+    myTrips.unshift({
+      id: res.id, kennitala: user.kennitala,
+      date, boatId, boatName, boatCategory,
+      locationId:locId, locationName:locName,
+      timeOut, timeIn, hoursDecimal, crew, role,
+      beaufort:bft, windDir:wdir, notes, wxSnapshot,
+      distanceNm, departurePort:depPort, arrivalPort:arrPort,
+      trackFileUrl, trackSimplified, trackSource,
+      photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
+    });
+    renderStats(); buildFilters(); applyFilter();
     showToast('Trip saved ✓','success');
     closeLogModal();
-    reload();
   }catch(e){
     errEl.textContent=e.message;
     errEl.style.display='';

--- a/member/index.html
+++ b/member/index.html
@@ -509,15 +509,21 @@ async function submitLaunch() {
       guardianName:user.guardianName||'', guardianPhone:user.guardianPhone||'',
       wxSnapshot:snap,
     });
-    checkouts=(await apiGet('getActiveCheckouts')).checkouts||[];
+    // Optimistic update — push new checkout locally instead of refetching
+    checkouts.push({
+      id:res.id, boatId:launchBoat.id, boatName:launchBoat.name, boatCategory:launchBoat.category||'',
+      memberKennitala:user.kennitala, memberName:user.name, crew:crewCount,
+      locationId:lid, locationName:location.name||lid,
+      checkedOutAt:tout, expectedReturn:ret, status:'out',
+    });
     if(crewNames.length){
       var _trip={boatId:launchBoat.id,boatName:launchBoat.name,boatCategory:launchBoat.category||'',
         locationId:lid,locationName:location.name||lid,timeOut:tout,expectedReturn:ret,role:'crew',isLinked:true,wxSnapshot:snap};
-      for(var i=0;i<crewNames.length;i++){
-        var cn=crewNames[i];
-        try{await apiPost('saveTrip',Object.assign({},_trip,{linkedCheckoutId:res?.checkoutId||res?.id||'',crewMemberName:cn.name,crewMemberKennitala:cn.kennitala}));}
-        catch(e2){console.warn('crew trip:',cn,e2.message);}
-      }
+      var _coId=res?.checkoutId||res?.id||'';
+      await Promise.all(crewNames.map(function(cn){
+        return apiPost('saveTrip',Object.assign({},_trip,{linkedCheckoutId:_coId,crewMemberName:cn.name,crewMemberKennitala:cn.kennitala}))
+          .catch(function(e2){console.warn('crew trip:',cn,e2.message);});
+      }));
     }
     window._launchFormValues=null;
     closeModal('launchModal'); renderActiveCheckouts(); renderFleetByCat();
@@ -846,20 +852,20 @@ async function confirmCheckIn(coId) {
     }catch(e){showToast((IS?'GPS upphal mistókst: ':'GPS upload failed: ')+e.message,'warn');}
   }
 
-  // Upload photos
+  // Upload photos in parallel
   var photoUrls=[];
-  for(var _pi=0;_pi<(window._retPendingPhotos||[]).length;_pi++){
-    var ph=window._retPendingPhotos[_pi];
+  await Promise.all((window._retPendingPhotos||[]).map(async function(ph){
     try{
       var pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType});
       if(pr.ok&&pr.photoUrl)photoUrls.push(pr.photoUrl);
       else if(!pr.ok)showToast(IS?'Skráarupphal ekki stillt':'Photo upload not configured','warn');
     }catch(e){showToast((IS?'Mynda upphal mistókst: ':'Photo upload failed: ')+e.message,'warn');}
-  }
+  }));
 
   try {
-    await apiPost('checkIn',{id:coId,timeIn,kennitala:user.kennitala,memberName:user.name,boatId:co.boatId,boatName:co.boatName});
-    await apiPost('saveTrip',{kennitala:user.kennitala,memberName:user.name,memberId:user.id||user.kennitala,
+    await Promise.all([
+      apiPost('checkIn',{id:coId,timeIn,kennitala:user.kennitala,memberName:user.name,boatId:co.boatId,boatName:co.boatName}),
+      apiPost('saveTrip',{kennitala:user.kennitala,memberName:user.name,memberId:user.id||user.kennitala,
       date:today,boatId:co.boatId,boatName:co.boatName,boatCategory:co.boatCategory||'',
       locationId:co.locationId||'',locationName:co.locationName||'',
       timeOut:tout,timeIn,hoursDecimal:h>0?h.toFixed(2):'0',crew:co.crew||1,
@@ -868,8 +874,9 @@ async function confirmCheckIn(coId) {
       departurePort:co.departurePort||'',arrivalPort,
       distanceNm,trackFileUrl,trackSimplified,trackSource,
       photoUrls:photoUrls.length?JSON.stringify(photoUrls):'',
-    });
-    checkouts=(await apiGet('getActiveCheckouts')).checkouts||[];
+      }),
+    ]);
+    checkouts=checkouts.filter(function(c){return c.id!==coId;});
     closeModal('returnModal'); renderActiveCheckouts(); renderFleetByCat();
     logbookLoaded=false; showToast(s('toast.checkedIn'));
   } catch(e){

--- a/shared/api.js
+++ b/shared/api.js
@@ -125,16 +125,36 @@ window.chunk = function(arr, n) {
 // Apps Script container is warm before the next user action.
 function warmContainer() {
   var lastWarm = 0;
-  document.addEventListener('visibilitychange', function() {
-    if (document.visibilityState !== 'visible') return;
+  var idleTimer = null;
+  var IDLE_MS = 5 * 60 * 1000; // re-warm after 5 min of in-tab inactivity
+
+  function doWarm() {
     var now = Date.now();
-    if (now - lastWarm < 60000) return; // Don't ping more than once per minute
+    if (now - lastWarm < 60000) return;
     lastWarm = now;
-    // Background ping — result updates the cache
     _call('getConfig', {}).then(function(r) {
       try {
         sessionStorage.setItem('ymir_getConfig_', JSON.stringify({ ts: Date.now(), data: r }));
       } catch(e) {}
     }).catch(function() {});
+  }
+
+  function resetIdleTimer() {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(doWarm, IDLE_MS);
+  }
+
+  // Warm on tab return
+  document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState !== 'visible') return;
+    doWarm();
+    resetIdleTimer();
   });
+
+  // Warm after idle period within the tab
+  ['mousemove', 'keydown', 'pointerdown', 'scroll'].forEach(function(ev) {
+    document.addEventListener(ev, resetIdleTimer, { passive: true });
+  });
+
+  resetIdleTimer();
 }


### PR DESCRIPTION
- shared/api.js: warmContainer now also fires after 5min of in-tab inactivity (mousemove/keydown/scroll idle timer), not just on visibilitychange
- code.gs: getIncidents_ accepts optional date param and filters server-side; router passes payload to it
- dailylog: loadPastLog now fetches log, config, and incidents in one Promise.all instead of sequential awaits; loadIncidentsForDate passes date to server; day-navigation buttons are debounced (300ms) to avoid stacked in-flight requests
- logbook: photo uploads in submitJoinTrip and submitManual now use Promise.all instead of sequential for-await loops; openLogModal caches club trips for 30s and skips the getTrips fetch on repeat opens; both submit handlers push the new trip into myTrips locally and skip the 500-trip reload() round-trip
- member: photo uploads in confirmCheckIn parallelised with Promise.all; checkIn and saveTrip fired concurrently with Promise.all; post-checkIn uses local filter instead of re-fetching getActiveCheckouts; crew trip saves in submitLaunch parallelised with Promise.all; post-launch checkout added to local state optimistically

https://claude.ai/code/session_019uzfaRzu91rHEzeqLgWvHq