### PR TITLE
Maintenance photo uploads via Google Drive + comment photo attachments

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -243,6 +243,7 @@ function route_(action, b) {
     case 'resolveMaintenance': return resolveMaintenance_(b);
     case 'addMaintenanceComment': return addMaintenanceComment_(b);
     case 'deleteMaintenance':       return deleteMaintenance_(b);
+    case 'uploadMaintenancePhoto':  return uploadMaintenancePhoto_(b);
     // ── PAYROLL ────────────────────────────────────────────────────────────────────
     case 'clockIn':             return clockIn_(b);
     case 'clockOut':            return clockOut_(b);
@@ -457,8 +458,7 @@ function getMaintenance_() {
 
 function saveMaintenance_(b) {
   const ts = now_(), id = uid_();
-  let photoUrl = '';
-  if (b.photoData && String(b.photoData).length < 200000) photoUrl = b.photoData;
+  const photoUrl = b.photoUrl || '';
   insertRow_('maintenance', {
     id, category: b.category || 'boat', boatId: b.boatId || '', boatName: b.boatName || '',
     itemName: b.itemName || '', part: b.part || '', severity: b.severity || 'medium',
@@ -812,7 +812,9 @@ function addMaintenanceComment_(b) {
   if (!ex) return failJ('Request not found', 404);
   let comments = [];
   try { comments = JSON.parse(ex.comments || '[]'); } catch (e) { comments = []; }
-  comments.push({ by: b.by || '', at: now_(), text: b.text });
+  const entry = { by: b.by || '', at: now_(), text: b.text };
+  if (b.photoUrl) entry.photoUrl = b.photoUrl;
+  comments.push(entry);
   updateRow_('maintenance', 'id', b.id, { comments: JSON.stringify(comments) });
   cDel_('maintenance');
   return okJ({ commented: true });
@@ -825,6 +827,30 @@ function deleteMaintenance_(b) {
   return okJ({ deleted: deleted });
 }
 
+// Script Property required: DRIVE_FOLDER_ID_MAINT_PHOTOS
+function uploadMaintenancePhoto_(b) {
+  if (!b.fileData) return failJ('fileData required');
+  const props = PropertiesService.getScriptProperties();
+  const folderId = props.getProperty('DRIVE_FOLDER_ID_MAINT_PHOTOS');
+  if (!folderId) return okJ({ ok: false, error: 'Drive folder not configured' });
+
+  try {
+    const ext      = (b.fileName || 'photo.jpg').split('.').pop().toLowerCase();
+    const ts       = now_().replace(/[: ]/g, '-');
+    const safeName = 'maint_' + ts + '_' + (b.fileName || 'photo.' + ext);
+    const base64   = b.fileData.replace(/^data:[^;]+;base64,/, '');
+    const bytes    = Utilities.base64Decode(base64);
+    const mimeMap  = { jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif', webp:'image/webp', heic:'image/heic' };
+    const mime     = b.mimeType || mimeMap[ext] || 'image/jpeg';
+    const blob     = Utilities.newBlob(bytes, mime, safeName);
+    const folder   = DriveApp.getFolderById(folderId);
+    const file     = folder.createFile(blob);
+    file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+    return okJ({ ok: true, photoUrl: file.getUrl() });
+  } catch (e) {
+    return failJ('Photo upload error: ' + e.message);
+  }
+}
 
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -233,6 +233,7 @@ let currentFilter = "open";
 let selectedCat = "";
 let selectedSev = "";
 let photoDataUrl = "";
+let pendingPhotoFile = null;
 
 
 
@@ -384,7 +385,7 @@ function viewPhoto(url) {
 
 // ── New request modal ──────────────────────────────────────────────────────────
 function openNewRequest(prefill) {
-  selectedCat = ""; selectedSev = ""; photoDataUrl = "";
+  selectedCat = ""; selectedSev = ""; photoDataUrl = ""; pendingPhotoFile = null;
   ["newPart","newDesc","newItem"].forEach(id => document.getElementById(id).value = "");
   document.getElementById("newBoat").value = "";
   document.getElementById("newOos").checked = false;
@@ -433,10 +434,10 @@ function handlePhotoChange(input) {
   const file = input.files[0];
   const errEl = document.getElementById("photoErr");
   const preview = document.getElementById("photoPreview");
-  if (!file) { photoDataUrl = ""; preview.className = "photo-preview"; return; }
+  if (!file) { photoDataUrl = ""; pendingPhotoFile = null; preview.className = "photo-preview"; return; }
   if (file.size > 5 * 1024 * 1024) {
     errEl.textContent = `Image too large (${(file.size/1024/1024).toFixed(1)} MB). Max is 5 MB.`;
-    input.value = ""; photoDataUrl = ""; preview.className = "photo-preview"; return;
+    input.value = ""; photoDataUrl = ""; pendingPhotoFile = null; preview.className = "photo-preview"; return;
   }
   errEl.textContent = "";
   const reader = new FileReader();
@@ -452,6 +453,7 @@ function handlePhotoChange(input) {
         canvas.getContext("2d").drawImage(img, 0, 0, canvas.width, canvas.height);
         photoDataUrl = canvas.toDataURL("image/jpeg", 0.82);
       }
+      pendingPhotoFile = { fileName: file.name, fileData: photoDataUrl, mimeType: file.type || 'image/jpeg' };
       preview.src = photoDataUrl;
       preview.className = "photo-preview show";
     };
@@ -483,13 +485,20 @@ async function submitRequest() {
 
   btn.disabled = true; btn.textContent = "Submitting…";
   try {
+    let photoUrl = "";
+    if (pendingPhotoFile) {
+      btn.textContent = "Uploading photo…";
+      const upRes = await apiPost("uploadMaintenancePhoto", pendingPhotoFile);
+      if (upRes.ok) photoUrl = upRes.photoUrl;
+      else console.warn("Photo upload skipped:", upRes.error);
+    }
     await apiPost("saveMaintenance", {
       category: selectedCat, boatId, boatName, itemName,
       part:        document.getElementById("newPart").value.trim(),
       severity:    selectedSev,
       description: desc,
       markOos,
-      photoData:   photoDataUrl,
+      photoUrl,
       reportedBy:  (window._maintUser?.name||'Staff'),
       source:      "staff",
     });

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -128,7 +128,8 @@ function maintOpenDetail(r, currentUser) {
     // Comments: text first, then name · timestamp, · to delete
     const commentHtml = comments.map((c,idx)=>`
       <div class="comment-item" style="position:relative;padding-right:24px">
-        <div style="font-size:13px;margin-bottom:3px">${esc(c.text||'')}</div>
+        ${c.text ? `<div style="font-size:13px;margin-bottom:3px">${esc(c.text)}</div>` : ''}
+        ${c.photoUrl ? `<img src="${esc(c.photoUrl)}" style="max-width:200px;max-height:150px;border-radius:6px;border:1px solid var(--border);margin-bottom:4px;cursor:pointer" onclick="viewPhoto('${esc(c.photoUrl)}')">` : ''}
         <div style="font-size:11px;color:var(--muted)">${esc(c.by||'')} · ${(c.at||'').slice(0,16).replace('T',' ')} UTC</div>
         ${!resolved ? `<button data-cidx="${idx}" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;font-size:14px;color:var(--muted);padding:0 2px;line-height:1" title="Delete comment">&times;</button>` : ''}
       </div>`).join('');
@@ -155,8 +156,14 @@ function maintOpenDetail(r, currentUser) {
       ${commentHtml ? `<div class="comment-thread">${commentHtml}</div>` : ''}
       ${!resolved ? `
       <div class="comment-add" style="margin-top:12px">
-        <input id="mdCommentInput" type="text" placeholder="Add comment&">
-        <button id="mdCommentBtn" class="btn btn-secondary" style="font-size:12px">Post</button>
+        <div style="display:flex;gap:6px;align-items:center">
+          <input id="mdCommentInput" type="text" placeholder="Add comment…" style="flex:1">
+          <label style="cursor:pointer;font-size:16px;padding:4px;color:var(--muted);flex-shrink:0" title="Attach photo">📷
+            <input id="mdCommentPhoto" type="file" accept="image/*" style="display:none">
+          </label>
+          <button id="mdCommentBtn" class="btn btn-secondary" style="font-size:12px">Post</button>
+        </div>
+        <div id="mdCommentPhotoPreview" style="margin-top:6px"></div>
       </div>
       <div class="req-actions" style="margin-top:10px;justify-content:space-between">
         <button id="mdResolveBtn" class="btn btn-primary" style="font-size:12px;padding:7px 16px">Mark Resolved</button>
@@ -218,17 +225,61 @@ function maintOpenDetail(r, currentUser) {
       });
     });
 
+    // Comment photo handling
+    let _mdCommentPhotoData = null;
+    const photoInput = document.getElementById('mdCommentPhoto');
+    const previewEl  = document.getElementById('mdCommentPhotoPreview');
+    if (photoInput) {
+      photoInput.addEventListener('change', function() {
+        const file = this.files[0];
+        if (!file) { _mdCommentPhotoData = null; if(previewEl) previewEl.innerHTML=''; return; }
+        if (file.size > 5*1024*1024) { _mdCommentPhotoData = null; if(previewEl) previewEl.innerHTML='<span style="font-size:11px;color:var(--red)">Max 5 MB</span>'; this.value=''; return; }
+        const reader = new FileReader();
+        reader.onload = function(ev) {
+          const img = new Image();
+          img.onload = function() {
+            const maxW = 1400; let data;
+            if (img.width <= maxW) { data = ev.target.result; }
+            else {
+              const c = document.createElement('canvas'); const ratio = maxW/img.width;
+              c.width = maxW; c.height = Math.round(img.height*ratio);
+              c.getContext('2d').drawImage(img,0,0,c.width,c.height);
+              data = c.toDataURL('image/jpeg',0.82);
+            }
+            _mdCommentPhotoData = { fileName: file.name, fileData: data, mimeType: file.type||'image/jpeg' };
+            if(previewEl) previewEl.innerHTML = '<img src="'+data+'" style="width:60px;height:45px;object-fit:cover;border-radius:4px;border:1px solid var(--border)">'
+              + '<button onclick="this.parentElement.innerHTML=\'\'" style="background:none;border:none;cursor:pointer;font-size:14px;color:var(--muted);vertical-align:top">&times;</button>';
+            previewEl.querySelector('button').addEventListener('click', function(){ _mdCommentPhotoData=null; photoInput.value=''; });
+          };
+          img.src = ev.target.result;
+        };
+        reader.readAsDataURL(file);
+      });
+    }
+
     // Post comment
     const postComment = async () => {
       const input = document.getElementById('mdCommentInput');
       const text  = (input?.value||'').trim();
-      if(!text) return;
+      if(!text && !_mdCommentPhotoData) return;
       const by = getBy();
-      await apiPost('addMaintenanceComment',{id:r.id,by,text});
-      const existing = parseJson(r.comments,[]);
-      r.comments = JSON.stringify([...existing,{text,by,at:new Date().toISOString().slice(0,16)}]);
-      if(input) input.value='';
-      renderAndWire();
+      const btn = document.getElementById('mdCommentBtn');
+      if(btn) { btn.disabled=true; btn.textContent='Posting…'; }
+      try {
+        let photoUrl = '';
+        if (_mdCommentPhotoData) {
+          const upRes = await apiPost('uploadMaintenancePhoto', _mdCommentPhotoData);
+          if (upRes.ok) photoUrl = upRes.photoUrl;
+        }
+        await apiPost('addMaintenanceComment',{id:r.id,by,text:text||'',photoUrl});
+        const existing = parseJson(r.comments,[]);
+        const entry = {text:text||'',by,at:new Date().toISOString().slice(0,16)};
+        if(photoUrl) entry.photoUrl = photoUrl;
+        r.comments = JSON.stringify([...existing,entry]);
+        _mdCommentPhotoData = null;
+        if(input) input.value='';
+        renderAndWire();
+      } finally { if(btn){btn.disabled=false;btn.textContent='Post';} }
     };
     document.getElementById('mdCommentBtn')?.addEventListener('click',postComment);
     document.getElementById('mdCommentInput')?.addEventListener('keydown',e=>{if(e.key==='Enter')postComment();});
@@ -274,7 +325,8 @@ function maintRenderCard(r) {
   const comments = parseJson(r.comments, []);
   const commentHtml = comments.map(c=>`
     <div class="comment-item">
-      <div style="font-size:13px;margin-bottom:3px">${esc(c.text||'')}</div>
+      ${c.text ? `<div style="font-size:13px;margin-bottom:3px">${esc(c.text)}</div>` : ''}
+      ${c.photoUrl ? `<img src="${esc(c.photoUrl)}" style="width:60px;height:45px;object-fit:cover;border-radius:4px;border:1px solid var(--border);margin-bottom:3px;cursor:pointer" onclick="viewPhoto('${esc(c.photoUrl)}')">` : ''}
       <div style="font-size:11px;color:var(--muted)">${esc(c.by||'')} · ${(c.at||'').slice(0,16).replace('T',' ')} UTC</div>
     </div>`).join('');
 


### PR DESCRIPTION
Photos on maintenance requests now upload to Google Drive (like logbook photos) instead of being stored as inline base64. Staff can also attach photos when posting comments on maintenance requests.

Closes #42

https://claude.ai/code/session_01Y3V4ZEFuCRGzWmtL1bozFK