### PR TITLE
Filter ports from location dropdowns for non-keelboat checkouts

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -572,7 +572,7 @@ function showManualForm(){
   allBoats.forEach(b=>{const o=document.createElement('option');o.value=b.id;o.textContent=(b.name||b.id);bSel.appendChild(o);});
   const lSel=document.getElementById('mLocation');
   lSel.innerHTML='<option value="">Select location…</option>';
-  allLocs.forEach(l=>{const o=document.createElement('option');o.value=l.id;o.textContent=(l.name||l.id);lSel.appendChild(o);});
+  allLocs.filter(l=>l.type!=='port').forEach(l=>{const o=document.createElement('option');o.value=l.id;o.textContent=(l.name||l.id);lSel.appendChild(o);});
   // Populate ports datalist
   populatePortsDatalist();
   // Reset file upload state

--- a/member/index.html
+++ b/member/index.html
@@ -354,10 +354,17 @@ function renderLaunchForm(boat) {
   if(!boat) return;
   launchBoat=boat;
   document.getElementById('launchModalTitle').textContent=s('member.launchTitle')+' — '+boat.name;
-  var locOpts=locations.map(l=>'<option value="'+l.id+'">'+esc(l.name)+'</option>').join('');
+  var isKeel=(boat.category||'').toLowerCase()==='keelboat';
+  var locOpts=locations.filter(function(l){return l.type!=='port';}).map(l=>'<option value="'+l.id+'">'+esc(l.name)+'</option>').join('');
+  var portOpts=isKeel?locations.filter(function(l){return l.type==='port';}).map(function(p){return'<option value="'+esc(p.name)+'">';}).join(''):'';
+  var defaultPort='';
+  if(isKeel&&boat.defaultPortId){var _hp=locations.find(function(l){return l.id===boat.defaultPortId;});if(_hp)defaultPort=_hp.name;}
   document.getElementById('launchModalBody').innerHTML=
     '<div class="field"><label>'+s('lbl.location')+'</label>'+
     '<select id="launchLocation"><option value="">'+s('lbl.selectDots')+'</option>'+locOpts+'</select></div>'+
+    (isKeel?'<div class="field"><label style="color:var(--brass)">⚓ '+(L==='IS'?'Brottfararhöfn':'Departure Port')+'</label>'+
+      '<input type="text" list="launchPortsList" id="launchDeparturePort" placeholder="'+(L==='IS'?'Heimahöfn':'Home port')+'" value="'+esc(defaultPort)+'" autocomplete="off">'+
+      '<datalist id="launchPortsList">'+portOpts+'</datalist></div>':'')+
     '<div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px">'+
       '<div class="field"><label>'+s('staff.coForm.departure')+'</label>'+
       '<input type="text" id="launchTimeOut" value="'+fmtTimeNow()+'" pattern="[0-9]{2}:[0-9]{2}" placeholder="HH:MM" maxlength="5" style="width:80px"></div>'+
@@ -407,6 +414,7 @@ function advanceToLaunchChecklist() {
     crewNames: Array.from(document.querySelectorAll('#launchCrewInputs input'))
       .map(i=>({name:i.value.trim(),kennitala:i.dataset.kennitala||''}))
       .filter(c=>c.name),
+    departurePort: (document.getElementById('launchDeparturePort')?.value||'').trim(),
   };
   renderLaunchChecklist(launchBoat);
 }
@@ -495,7 +503,7 @@ async function submitLaunch() {
     document.getElementById('launchCheckErr').style.display='block'; return;
   }
   var fv=window._launchFormValues||{};
-  var lid=fv.lid, tout=fv.tout, ret=fv.ret, crewCount=fv.crew||1, crewNames=fv.crewNames||[];
+  var lid=fv.lid, tout=fv.tout, ret=fv.ret, crewCount=fv.crew||1, crewNames=fv.crewNames||[], depPort=fv.departurePort||'';
   if(!lid){showToast(s('staff.coForm.errLocation'),'err');return;}
   var location=locations.find(l=>l.id===lid)||{};
   var snap=(typeof wxSnapshot==='function')?wxSnapshot(currentWx):null;
@@ -505,6 +513,7 @@ async function submitLaunch() {
       boatId:launchBoat.id, boatName:launchBoat.name, boatCategory:launchBoat.category||'',
       locationId:lid, locationName:location.name||lid,
       checkedOutAt:tout, expectedReturn:ret, crew:crewCount,
+      departurePort:depPort,
       memberPhone:user.phone||'', memberIsMinor:user.isMinor||false,
       guardianName:user.guardianName||'', guardianPhone:user.guardianPhone||'',
       wxSnapshot:snap,
@@ -907,7 +916,7 @@ async function submitManualTrip() {
 function populateFormSelects() {
   const rBoat=document.getElementById('rBoat'),rLoc=document.getElementById('rLocation');
   boats.forEach(b=>{const o=document.createElement('option');o.value=b.id;o.textContent=b.name;rBoat.appendChild(o);});
-  locations.forEach(l=>{const o=document.createElement('option');o.value=l.id;o.textContent=l.name;rLoc.appendChild(o);});
+  locations.filter(l=>l.type!=='port').forEach(l=>{const o=document.createElement('option');o.value=l.id;o.textContent=l.name;rLoc.appendChild(o);});
 }
 function parseJson(v,fallback){if(!v)return fallback;try{return typeof v==='string'?JSON.parse(v):v;}catch(e){return fallback;}}
 

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -203,7 +203,9 @@ function renderCheckoutCard(co, opts) {
   }
 
   // Sub-line
-  const subLine = `${_besc(co.locationName||"")} · ${_besc(s("fleet.outTime",{t:tout}))}`;
+  const isKeel  = cat === 'keelboat';
+  const portInfo = isKeel && co.departurePort ? ` · ⚓ ${_besc(co.departurePort)}` : '';
+  const subLine = `${_besc(co.locationName||"")}${portInfo} · ${_besc(s("fleet.outTime",{t:tout}))}`;
 
   // Wx snapshot (staff)
   let wxHtml = "";

--- a/staff/index.html
+++ b/staff/index.html
@@ -557,7 +557,7 @@ function populateSelects() {
       const o = document.createElement('option'); o.value=b.id; o.textContent=b.name; bSel.appendChild(o);
     });
   const lSel = document.getElementById('coLocation');
-  locations.forEach(l => {
+  locations.filter(l => l.type !== 'port').forEach(l => {
     const o = document.createElement('option'); o.value=l.id; o.textContent=l.name; lSel.appendChild(o);
   });
   document.getElementById('coTimeOut').value = fmtTimeNow();
@@ -1078,8 +1078,8 @@ function openGroupModal() {
   });
   const lSel = document.getElementById('gmLocation');
   lSel.innerHTML = '<option value="">—</option>';
-  locations.forEach(l => { const o=document.createElement('option'); o.value=l.id; o.textContent=l.name; lSel.appendChild(o); });
-  const foss = locations.find(l => l.name && l.name.toLowerCase().includes('fossvogur'));
+  locations.filter(l => l.type !== 'port').forEach(l => { const o=document.createElement('option'); o.value=l.id; o.textContent=l.name; lSel.appendChild(o); });
+  const foss = locations.filter(l => l.type !== 'port').find(l => l.name && l.name.toLowerCase().includes('fossvogur'));
   if (foss) lSel.value = foss.id;
   const aSel = document.getElementById('gmActivity');
   aSel.innerHTML = '<option value="">— None —</option>';


### PR DESCRIPTION
Ports (locations with type==='port') no longer appear in the location selector when checking out dinghies, kayaks, SUPs, etc. For keelboat checkouts, the member launch form now includes a departure port field (pre-loaded from the boat's home port) alongside the sailing location, matching the existing staff checkout behavior. The checkout card sub-line also shows the departure port for keelboats.

Closes #44

https://claude.ai/code/session_01YFXVMLqsKXSQHFWfXqLbvX