### PR TITLE
Make logbook filters compact with single-line grid layout

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -28,10 +28,11 @@
 .cat-hour-val{font-size:11px;color:var(--muted);min-width:32px;text-align:right}
 .section-hdr{font-size:9px;color:var(--muted);letter-spacing:1.2px;text-transform:uppercase;margin:20px 0 8px;display:flex;align-items:center;justify-content:space-between}
 .cert-grid{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:4px}
-.filter-bar{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px;align-items:center}
-.filter-bar select,.filter-bar input{background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 9px;height:30px;outline:none;transition:border-color .15s}
+.filter-bar{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin-bottom:12px;align-items:center}
+.filter-bar select,.filter-bar input{background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 9px;height:30px;outline:none;transition:border-color .15s;width:100%;box-sizing:border-box}
 .filter-bar select:focus,.filter-bar input:focus{border-color:var(--brass)}
-.filter-bar input{flex:1;min-width:100px}
+.filter-bar .filter-search-row{grid-column:1/-1;display:flex;gap:6px;align-items:center}
+.filter-bar .filter-search-row input{flex:1;min-width:0}
 .filter-count{font-size:10px;color:var(--muted);white-space:nowrap}
 .trip-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:8px;overflow:hidden;cursor:pointer;transition:border-color .15s}
 .trip-card:hover{border-color:var(--brass)}
@@ -135,8 +136,10 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
       <option value="gt4">Above Force 4</option>
       <option value="lte4">Force 4 or under</option>
     </select>
-    <input id="fText" type="text" placeholder="Search…">
-    <span class="filter-count" id="filterCount"></span>
+    <div class="filter-search-row">
+      <input id="fText" type="text" placeholder="Search…">
+      <span class="filter-count" id="filterCount"></span>
+    </div>
   </div>
   <div id="tripList"><div class="empty-note">Loading…</div></div>
 </div>


### PR DESCRIPTION
Use CSS grid with 4 equal columns for the select filters (year, boat, role, wind) so they sit on one row. Move the text search input to a second row spanning the full width.

Closes #76

https://claude.ai/code/session_019DYtrzTtQGEN4TmLGPjELK