### PR TITLE
Rename non-port locations to "Sailing area" / "Siglingasvæði"

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1332,7 +1332,7 @@ function renderLocations() {
   if (!active.length) { card.innerHTML = `<div class="empty-state">No locations yet.</div>`; return; }
   card.innerHTML = active.map(l => `
     <div class="list-row">
-      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓ PORT</span>' : ''}</span>
+      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓ PORT</span>' : ' <span style="font-size:9px;color:var(--ice);border:1px solid var(--ice)44;border-radius:4px;padding:1px 5px;margin-left:4px">⛵ SAILING AREA</span>'}</span>
       <button class="row-edit" onclick="openLocationModal('${l.id}')">Edit</button>
       <button class="row-del"  onclick="deleteLocation('${l.id}')">×</button>
     </div>`).join("");

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -454,7 +454,7 @@ function tripCard(t){
       <div class="exp-section exp-logistics">
         <div class="exp-section-hdr">${IS?'Upplýsingar um ferð':'Trip Details'}</div>
         <div class="trip-expand-grid">
-          <div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Staður':'Location'}</span><span class="trip-exp-val">${esc(t.locationName||'—')}</span></div>
+          <div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Siglingasvæði':'Sailing area'}</span><span class="trip-exp-val">${esc(t.locationName||'—')}</span></div>
           <div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Brottfarartími':'Departed'}</span><span class="trip-exp-val">${esc(t.timeOut||'—')}</span></div>
           <div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Komutími':'Returned'}</span><span class="trip-exp-val">${esc(t.timeIn||'—')}</span></div>
           ${portRow}${crewRow}${keelboatInfoRow}

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -233,7 +233,7 @@ const STRINGS = {
   'staff.coForm.notesPlaceholder':  { EN:'Any notes…',              IS:'Einhverjar athugasemdir…' },
   'staff.coForm.errMember':         { EN:'Select a member.',        IS:'Veldu félaga.' },
   'staff.coForm.errBoat':           { EN:'Select a boat.',          IS:'Veldu bát.' },
-  'staff.coForm.errLocation':       { EN:'Select a location.',      IS:'Veldu staðsetningu.' },
+  'staff.coForm.errLocation':       { EN:'Select a sailing area.',   IS:'Veldu siglingasvæði.' },
   'staff.coForm.checkedOut':        { EN:'Checked out ✓',           IS:'Útskráð ✓' },
   // Detail modal sub-keys
   'staff.coDetail.title':     { EN:'Checkout Details',   IS:'Upplýsingar um útskráningu' },
@@ -723,7 +723,7 @@ const STRINGS = {
   'boat.defaultPort':        { EN:'Default port',                          IS:'Heimahöfn' },
   'location.type':           { EN:'Type',                                  IS:'Tegund' },
   'location.typePort':       { EN:'Port',                                  IS:'Höfn' },
-  'location.typeLocation':   { EN:'Location',                              IS:'Staðsetning' },
+  'location.typeLocation':   { EN:'Sailing area',                          IS:'Siglingasvæði' },
 
   // ── Fleet card badges & labels ─────────────────────────────────────────────
   'fleet.badgeAvail':        { EN:'AVAIL',                                 IS:'LAUST' },

--- a/staff/index.html
+++ b/staff/index.html
@@ -650,7 +650,7 @@ function renderRecentCheckins() {
     <span>${IS?'Inn':'In'}</span>
     <span>${IS?'Félagi':'Member'}</span>
     <span>${IS?'Bát':'Boat'}</span>
-    <span>${IS?'Svæði':'Location'}</span>
+    <span>${IS?'Siglingasvæði':'Sailing area'}</span>
     <span>${IS?'Tími':'Duration'}</span>
   </div>`;
   const rows = recent.map(c => {
@@ -1053,7 +1053,7 @@ function openGroupModal() {
   document.getElementById('groupModalTitle').textContent = IS ? 'Hópaúthlutun' : 'Group Checkout';
   document.getElementById('gmBoatsLabel').textContent    = IS ? 'Veldu báta' : 'Select boats';
   document.getElementById('gmParticLabel').textContent   = IS ? 'Iðkendur' : 'Participants (Iðkendur)';
-  document.getElementById('gmLocLabel').textContent      = IS ? 'Staðsetning' : 'Location';
+  document.getElementById('gmLocLabel').textContent      = IS ? 'Siglingasvæði' : 'Sailing area';
   document.getElementById('gmActivityLabel').textContent = IS ? 'Tegund' : 'Activity type';
   _groupBoats = new Set();
   _groupParticipants = 0;
@@ -1171,7 +1171,7 @@ async function submitGroupCheckout() {
   err.style.display = 'none';
   if (_groupBoats.size === 0) { err.textContent = 'Select at least one boat.'; err.style.display = ''; return; }
   const lid = document.getElementById('gmLocation').value;
-  if (!lid) { err.textContent = 'Select a location.'; err.style.display = ''; return; }
+  if (!lid) { err.textContent = (getLang()==='IS'?'Veldu siglingasvæði.':'Select a sailing area.'); err.style.display = ''; return; }
   const tout  = document.getElementById('gmTimeOut').value || fmtTimeNow();
   const retBy = document.getElementById('gmReturnBy').value;
   const actId = document.getElementById('gmActivity').value;


### PR DESCRIPTION
Locations not designated as "port" are now labeled "Sailing area" (Siglingasvæði) instead of "Location" (Staðsetning) across the UI: strings, admin badges, staff dashboard, group checkout, and logbook.

Closes #91

https://claude.ai/code/session_01Xr139qrEYuV9R5y1ArGm4C