### PR TITLE
Payroll periods: compact dates, show payment date, fix export dropdow…

### DIFF
--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -70,14 +70,14 @@
 
     <!-- TIMESHEETS / LAUNASEDLAR -->
     <div id="pr-periods" class="hidden">
-      <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:14px">
-        <label style="font-size:11px;color:var(--muted)" data-s="payroll.periodFrom"></label>
-        <input id="prPeriodFrom" type="date" style="font-size:11px;padding:3px 6px">
-        <label style="font-size:11px;color:var(--muted)" data-s="payroll.periodTo"></label>
-        <input id="prPeriodTo" type="date" style="font-size:11px;padding:3px 6px">
-        <label style="font-size:11px;color:var(--muted)" data-s="payroll.paymentDate"></label>
-        <input id="prPaymentDate" type="date" style="font-size:11px;padding:3px 6px">
-        <button class="btn btn-primary" style="font-size:11px;padding:4px 12px" onclick="prBuildPreview()" data-s="payroll.previewPayslips"></button>
+      <div style="display:flex;gap:4px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
+        <label style="font-size:10px;color:var(--muted)" data-s="payroll.periodFrom"></label>
+        <input id="prPeriodFrom" type="date" style="font-size:10px;padding:2px 4px;width:120px">
+        <label style="font-size:10px;color:var(--muted)" data-s="payroll.periodTo"></label>
+        <input id="prPeriodTo" type="date" style="font-size:10px;padding:2px 4px;width:120px">
+        <label style="font-size:10px;color:var(--muted)" data-s="payroll.paymentDate"></label>
+        <input id="prPaymentDate" type="date" style="font-size:10px;padding:2px 4px;width:120px">
+        <button class="btn btn-primary" style="font-size:10px;padding:3px 10px" onclick="prBuildPreview()" data-s="payroll.previewPayslips"></button>
       </div>
       <div id="prPreviewPanel" class="hidden">
         <div class="sec-lbl" data-s="payroll.hoursConfirm"></div>
@@ -574,6 +574,7 @@ async function prLoadPeriods(){
       var totG=pr.reduce(function(s,r){return s+(+(r.grossTotal||0));},0);
       var totN=pr.reduce(function(s,r){return s+(+(r.netPay||0));},0);
       var isApproved=pr[0]&&pr[0].approved;
+      var payDate=pr[0]&&pr[0].paymentDate||'';
       var pid=p.replace(/[^a-zA-Z0-9]/g,'_');
       var empRows=pr.map(function(r){
         return '<tr><td>'+_e(r.employeeName||r.employeeId||'')+'</td>'
@@ -592,6 +593,7 @@ async function prLoadPeriods(){
         +'<span class="'+(isApproved?'pill-ok':'pill-open')+'" data-s="'+(isApproved?'payroll.periodApproved':'payroll.periodOpen')+'"></span>'
         +'</div></div>'
         +'<div class="period-body hidden" id="pb_'+pid+'">'
+        +(payDate?'<div style="font-size:11px;color:var(--muted);margin-bottom:8px">'+s('payroll.paymentDate')+': '+_e(payDate)+'</div>':'')
         +'<table class="ts-table"><thead><tr>'
         +'<th data-s="lbl.name"></th><th style="text-align:right" data-s="payroll.hoursTotal"></th>'
         +'<th style="text-align:right" data-s="payroll.grossLabel"></th>'
@@ -801,13 +803,14 @@ async function prApprovePeriod(){
   var rows=Object.keys(_previewData.employees||{}).map(function(empId){
     var d=_previewData.employees[empId];
     var c=d.calc||window.calculatePayslip(d.emp,d.regularMins,d.otMins||{},d.manualLines,window.PAYROLL_CONFIG);
+    var totalHrs=c.regularHrs+(c.ot1Hrs||0)+(c.ot2Hrs||0);
     return {employeeId:empId,employeeName:d.emp.name,kt:d.emp.kt,
       bankAccount:d.emp.bankAccount,orlofsreikningur:d.emp.orlofsreikningur,
       title:d.emp.title,baseRateKr:d.emp.baseRateKr,
       periodFrom:from,periodTo:to,paymentDate:payDate,
-      regularMinutes:d.regularMins,otMinutes:d.otMins||{},manualLines:d.manualLines,
+      regularMinutes:d.regularMins,otMinutes:JSON.stringify(d.otMins||{}),manualLines:JSON.stringify(d.manualLines),
       grossTotal:c.grossTotal,dagvinna:c.dagvinna,
-      eftirvinna1:c.eftirvinna1,eftirvinna2:c.eftirvinna2,otLines:c.otLines||[],
+      eftirvinna1:c.eftirvinna1,eftirvinna2:c.eftirvinna2,otLines:JSON.stringify(c.otLines||[]),
       orlofslaun:c.orlofslaun,orlofsRate:c.orlofsRate,manualTotal:c.manualTotal,
       employeePension:c.employeePension,sereignarsjodur:c.sereignarsjodur,sereignRate:c.sereignRate,
       unionDues:c.totalUnionEmp||c.unionDues||0,
@@ -816,6 +819,7 @@ async function prApprovePeriod(){
       orlofIBanki:c.orlofIBanki,totalDeductions:c.totalDeductions,netPay:c.netPay,
       employerPension:c.employerPensionAmt,endurhaefingarsjodur:c.endurhaefingarsjodur,
       regularHrs:c.regularHrs,ot1Hrs:c.ot1Hrs,ot2Hrs:c.ot2Hrs,pensionRate:c.pensionRate,
+      totalHours:totalHrs.toFixed(2),
       configSnapshot:JSON.stringify(window.PAYROLL_CONFIG||{}),approved:true};
   });
   try{
@@ -833,7 +837,7 @@ function prViewPayslip(btn){
   var calc={grossTotal:r.grossTotal||0,dagvinna:r.dagvinna||r.grossTotal||0,
     eftirvinna1:r.eftirvinna1||0,eftirvinna2:r.eftirvinna2||0,
     orlofslaun:r.orlofslaun||0,orlofsRate:r.orlofsRate||0.1017,
-    manualLines:r.manualLines||[],manualTotal:r.manualTotal||0,
+    manualLines:parseJson(r.manualLines,[]),manualTotal:r.manualTotal||0,
     employeePension:r.employeePension||0,sereignarsjodur:r.sereignarsjodur||0,sereignRate:r.sereignRate||0,
     unionDues:r.unionDues||0,unionRate:r.unionRate||0,
     taxBase:r.taxBase||0,taxGross:r.taxGross||0,personalCredit:r.personalCredit||68681,

--- a/code.gs
+++ b/code.gs
@@ -718,9 +718,43 @@ function closePayPeriod_(b) {
   // payslip always reflects the config values that were in effect at approval time.
   const rows = b.rows;
   if (!rows || !rows.length) return failJ('rows array required');
-  const results = [];
-  rows.forEach(function(r) {
-    const row = Object.assign({}, r, { id: uid_(), generatedBy: b.by || 'admin' });
+
+  // Ensure newer columns exist in the payroll sheet
+  ['periodFrom','periodTo','paymentDate','slipNumber','employeeName','kt',
+   'bankAccount','orlofsreikningur','title','baseRateKr','regularMinutes',
+   'otMinutes','manualLines','dagvinna','eftirvinna1','eftirvinna2','otLines',
+   'orlofslaun','orlofsRate','manualTotal','employeePension','sereignarsjodur',
+   'sereignRate','unionDues','taxBase','taxGross','personalCredit',
+   'taxWithheld','taxAfterCredit','orlofIBanki','totalDeductions',
+   'employerPension','endurhaefingarsjodur','regularHrs','ot1Hrs','ot2Hrs',
+   'pensionRate','configSnapshot','approved','totalHours'
+  ].forEach(function(c) { addColIfMissing_(TABS_.payroll, c); });
+
+  // Generate slip numbers: YY0M0x based on payment date month
+  var payDate = b.paymentDate || '';
+  var yy = payDate.slice(2, 4) || '00';
+  var mm = payDate.slice(5, 7) || '01';
+  var prefix = yy + mm;
+  // Find the highest existing counter for this prefix
+  var existing = readAll_(TABS_.payroll);
+  var maxCounter = 0;
+  existing.forEach(function(r) {
+    var sn = String(r.slipNumber || '');
+    if (sn.indexOf(prefix) === 0) {
+      var num = parseInt(sn.slice(prefix.length), 10);
+      if (num > maxCounter) maxCounter = num;
+    }
+  });
+
+  var results = [];
+  rows.forEach(function(r, i) {
+    var counter = String(maxCounter + i + 1).padStart(2, '0');
+    var slipNumber = prefix + counter;
+    var row = Object.assign({}, r, {
+      id: uid_(),
+      generatedBy: b.by || 'admin',
+      slipNumber: slipNumber
+    });
     insertRow_(TABS_.payroll, row);
     results.push(row);
   });
@@ -730,15 +764,19 @@ function closePayPeriod_(b) {
 
 function getPayroll_(b) {
   var rows = readAll_(TABS_.payroll);
-  if (b.period)     rows = rows.filter(function(r){ return r.period===b.period; });
+  if (b.period)     rows = rows.filter(function(r){ return r.period===b.period || r.periodFrom===b.period; });
   if (b.employeeId) rows = rows.filter(function(r){ return r.employeeId===b.employeeId; });
   const allRows = readAll_(TABS_.payroll);
   const fields  = ['grossWage','orlofsfe','grossTotal','lifeyrir','sereignarsjodur',
     'stadgreidslaSkattur','netPay','tryggingagjald','motframlag','totalEmployerCost',
     'hoursRegular','hoursOT133','hoursOT155'];
   rows.forEach(function(row) {
-    const yr  = (row.period||'').slice(0,4);
-    const ytd = allRows.filter(function(r){ return r.employeeId===row.employeeId && (r.period||'').startsWith(yr) && r.period<=row.period; });
+    const pKey = row.period || row.periodFrom || '';
+    const yr  = pKey.slice(0,4);
+    const ytd = allRows.filter(function(r){
+      var rk = r.period || r.periodFrom || '';
+      return r.employeeId===row.employeeId && rk.startsWith(yr) && rk<=pKey;
+    });
     const tot = {};
     fields.forEach(function(f){ tot[f]=ytd.reduce(function(s,r){ return s+Number(r[f]||0); },0); });
     row._ytd = tot;


### PR DESCRIPTION
…ns, add slip numbers

- Make from/to/payment date inputs more compact (smaller font, fixed widths)
- Show payment date on closed period cards in the expandable body
- Fix export tab dropdowns not populating: ensure periodFrom/periodTo/paymentDate columns exist in payroll sheet via addColIfMissing_ before inserting rows
- Generate seðilnúmer (slip number) in YY0M0x format when closing a period, where YY=year, 0M=month of payment date, 0x=sequential counter
- Fix getPayroll_ YTD calculation to handle rows with periodFrom (not just period)
- Stringify complex objects (otMinutes, manualLines, otLines) before storing

Closes #48

https://claude.ai/code/session_013ZQx3itaUYNeFSEycRtHTX