### PR TITLE
feat: use Esri Ocean basemap + OpenSeaMap seamark overlay for tracks

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -1059,6 +1059,11 @@ function toggleTripCard(card) {
 const _thumbMaps = {};  // id → Leaflet map instance (thumbnails)
 let   _fullMap   = null;
 
+function addSeaLayers(map) {
+  L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}', { maxZoom:16, attribution:'Esri Ocean' }).addTo(map);
+  L.tileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', { maxZoom:16, opacity:0.9 }).addTo(map);
+}
+
 function initSingleThumbMap(el) {
   const id = el.id;
   if (_thumbMaps[id]) return;
@@ -1066,7 +1071,7 @@ function initSingleThumbMap(el) {
   try { pts = JSON.parse(el.dataset.track); } catch(e) { return; }
   if (!pts || pts.length < 2) return;
   const map = L.map(el, { zoomControl:false, attributionControl:false, dragging:false, scrollWheelZoom:false, doubleClickZoom:false, touchZoom:false, boxZoom:false, keyboard:false });
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { maxZoom:18 }).addTo(map);
+  addSeaLayers(map);
   const latlngs = pts.map(p => [p.lat, p.lng]);
   L.polyline(latlngs, { color:'#d4af37', weight:2.5, opacity:.9 }).addTo(map);
   L.circleMarker(latlngs[0], { radius:4, color:'#27ae60', fillColor:'#27ae60', fillOpacity:1, weight:0 }).addTo(map);
@@ -1097,7 +1102,7 @@ function openMapModal(tripId) {
   container.appendChild(div);
 
   _fullMap = L.map(div, { zoomControl: true });
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { maxZoom: 18 }).addTo(_fullMap);
+  addSeaLayers(_fullMap);
   const latlngs = pts.map(p => [p.lat, p.lng]);
   L.polyline(latlngs, { color:'#d4af37', weight: 3, opacity: .9 }).addTo(_fullMap);
   L.circleMarker(latlngs[0], { radius: 6, color:'#27ae60', fillColor:'#27ae60', fillOpacity:1, weight:0 }).bindPopup(IS ? 'Brottför' : 'Departure').addTo(_fullMap);


### PR DESCRIPTION
Replaces the generic CartoDB dark tiles with marine-appropriate layers: Esri Ocean Basemap (bathymetry) as the base with OpenSeaMap seamark overlay (buoys, lights, harbors, depth contours) on top.

https://claude.ai/code/session_01GTRuy5dLFtYzqBNawoVvso