### PR TITLE
fix: prevent blank tiles when zooming past native tile limits

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -1060,8 +1060,9 @@ const _thumbMaps = {};  // id → Leaflet map instance (thumbnails)
 let   _fullMap   = null;
 
 function addSeaLayers(map) {
-  L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}', { maxZoom:16, attribution:'Esri Ocean' }).addTo(map);
-  L.tileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', { maxZoom:16, opacity:0.9 }).addTo(map);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom:19, attribution:'OSM' }).addTo(map);
+  L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}', { maxNativeZoom:13, maxZoom:19, attribution:'Esri Ocean' }).addTo(map);
+  L.tileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', { maxNativeZoom:17, maxZoom:19, opacity:0.9 }).addTo(map);
 }
 
 function initSingleThumbMap(el) {


### PR DESCRIPTION
Add OSM as a base layer underneath Esri Ocean so high-zoom areas still show detail. Set maxNativeZoom on Esri/OpenSeaMap layers so Leaflet upscales the last available tiles instead of showing "Map data not yet available" placeholders.

https://claude.ai/code/session_01GTRuy5dLFtYzqBNawoVvso