### PR TITLE
fix: use standard OSM tile URL for basemap

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -1060,7 +1060,7 @@ const _thumbMaps = {};  // id → Leaflet map instance (thumbnails)
 let   _fullMap   = null;
 
 function addSeaLayers(map) {
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', { maxZoom:19, attribution:'CartoDB' }).addTo(map);
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom:19, attribution:'&copy; OpenStreetMap' }).addTo(map);
   L.tileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', { maxNativeZoom:17, maxZoom:19, opacity:0.9 }).addTo(map);
 }
 


### PR DESCRIPTION
CartoDB Voyager tiles were not loading. Switch to the standard OpenStreetMap tile server (tile.openstreetmap.org) which is the most reliable option, with OpenSeaMap seamark overlay on top.

https://claude.ai/code/session_01GTRuy5dLFtYzqBNawoVvso