### PR TITLE
fix: show single port name when only departure or arrival is set

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -431,8 +431,8 @@ function tripCard(t){
   const isKeelboat = (t.boatCategory||'').toLowerCase()==='keelboat';
   const dep=t.departurePort||'', arr=t.arrivalPort||'';
   const portLine = (dep||arr) ? (
-    (!arr||dep===arr) ? `<span>⚓ ${esc(dep||arr)}</span>`
-                      : `<span>⚓ ${esc(dep)} → ${esc(arr)}</span>`
+    (!arr||!dep||dep===arr) ? `<span>⚓ ${esc(dep||arr)}</span>`
+                            : `<span>⚓ ${esc(dep)} → ${esc(arr)}</span>`
   ) : '';
 
   // Expanded wx cells — order: wind speed, direction, gusts, conditions, air temp, feels like, sea temp, wave height, pressure


### PR DESCRIPTION
When only one port was filled in, the arrow separator still appeared (e.g. "⚓ → Ingólfsgarður"). Now shows just "⚓ Ingólfsgarður" unless both ports exist and differ.

https://claude.ai/code/session_01GTRuy5dLFtYzqBNawoVvso