### PR TITLE
Show "Sail no." for non-keelboats, "Registration no." for keelboats

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -552,12 +552,10 @@
       <label data-s="boat.defaultPort">Default port</label>
       <select id="bDefaultPortId"><option value="">— none —</option></select>
     </div>
-    <!-- Keelboat-only fields -->
-    <div id="keelboatFields" style="display:none">
-      <div class="field">
-        <label data-s="boat.registrationNo">Registration no.</label>
-        <input type="text" id="bRegNo" placeholder="e.g. ÍS-342">
-      </div>
+    <!-- Registration no. (keelboats) / Sail no. (others) -->
+    <div class="field">
+      <label id="bRegNoLabel" data-s="boat.registrationNo">Registration no.</label>
+      <input type="text" id="bRegNo" placeholder="e.g. ÍS-342">
     </div>
     <!-- All boats: type/model & LOA -->
     <div class="grid2">
@@ -1203,7 +1201,7 @@ function renderBoats() {
             </div>
           </div>
           ${b.oosReason ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${esc(b.oosReason)}</div>` : ""}
-          ${(cat.key === 'keelboat' && (b.registrationNo || b.typeModel)) ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
+          ${(b.registrationNo || b.typeModel) ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
           <div class="boat-card-actions">
             <button class="row-edit" style="flex:1" onclick="openBoatModal('${b.id}')">Edit</button>
             <button class="row-edit" onclick="showBoatQR('${b.id}')" title="Show QR code">🔳</button>
@@ -1243,7 +1241,12 @@ function populateDefaultPortSelect(selectedId) {
 
 function updateBoatModalFields() {
   const cat = document.getElementById("bCategory").value;
-  document.getElementById("keelboatFields").style.display = cat === 'keelboat' ? '' : 'none';
+  const isKeelboat = cat === 'keelboat';
+  const lbl = document.getElementById("bRegNoLabel");
+  const inp = document.getElementById("bRegNo");
+  lbl.setAttribute("data-s", isKeelboat ? "boat.registrationNo" : "boat.sailNo");
+  lbl.textContent = s(isKeelboat ? 'boat.registrationNo' : 'boat.sailNo');
+  inp.placeholder = isKeelboat ? "e.g. ÍS-342" : "e.g. 1234";
 }
 
 function openBoatModal(id) {
@@ -1281,8 +1284,7 @@ async function saveBoat() {
     oos:           document.getElementById("bOOS").checked,
     oosReason:     document.getElementById("bOOSReason").value.trim(),
     active:        document.getElementById("bActive").checked,
-    // keelboat-only
-    registrationNo: cat === 'keelboat' ? document.getElementById("bRegNo").value.trim()  : (id ? (_allBoats.find(x=>x.id===id)||{}).registrationNo||'' : ''),
+    registrationNo: document.getElementById("bRegNo").value.trim(),
     // all boats
     typeModel:      document.getElementById("bTypeModel").value.trim(),
     loa:            parseFloat(document.getElementById("bLoa").value) || '',

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -464,7 +464,7 @@ function tripCard(t){
 
   // Vessel/boat detail rows from boats config
   const kboat = allBoats.find(b=>b.id===t.boatId);
-  const boatRegRow   = isKeelboat && kboat?.registrationNo ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Skráningarnúmer':'Registration no.'}</span><span class="trip-exp-val">${esc(kboat.registrationNo)}</span></div>` : '';
+  const boatRegRow   = kboat?.registrationNo ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?(isKeelboat?'Skráningarnúmer':'Seglnúmer'):(isKeelboat?'Registration no.':'Sail no.')}</span><span class="trip-exp-val">${esc(kboat.registrationNo)}</span></div>` : '';
   const boatModelRow = kboat?.typeModel ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Tegund / gerð':'Type / model'}</span><span class="trip-exp-val">${esc(kboat.typeModel)}</span></div>` : '';
   const boatLoaRow   = kboat?.loa       ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Heildarlengd':'LOA'}</span><span class="trip-exp-val">${kboat.loa} ft</span></div>` : '';
   const hasBoatDetails = !!(boatRegRow||boatModelRow||boatLoaRow);

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -749,6 +749,7 @@ const STRINGS = {
   'logbook.noDriveConfig':   { EN:'File upload not configured — trip saved without attachment.',
                                IS:'Skráarupphal ekki stillt — ferð vistuð án viðhengis.' },
   'boat.registrationNo':     { EN:'Registration no.',                      IS:'Skráningarnúmer' },
+  'boat.sailNo':             { EN:'Sail no.',                              IS:'Seglnúmer' },
   'boat.loa':                { EN:'LOA (ft)',                              IS:'Heildarlengd (fet)' },
   'boat.typeModel':          { EN:'Type / model',                          IS:'Tegund / gerð' },
   'boat.defaultPort':        { EN:'Default port',                          IS:'Heimahöfn' },


### PR DESCRIPTION
The registrationNo field is now available for all boat types. For keelboats it displays as "Registration no." and for all other categories it displays as "Sail no." The underlying data field remains the same.

Closes #102

https://claude.ai/code/session_01UQ2KBBkGCzgFjAuFBrKJEW