### PR TITLE
Use category labels instead of keys in logbook stats and share feature

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -2825,6 +2825,15 @@ function pubRecordPageHtml_(member, certs, certDefs, opts) {
   var boats = [];
   try { boats = JSON.parse(boatsJson || '[]'); } catch(e) {}
 
+  // Load boat categories for label resolution
+  var boatCats = [];
+  try { var bcRaw2 = getConfigSheetValue_('boatCategories'); if (bcRaw2) boatCats = JSON.parse(bcRaw2); } catch(e) {}
+  function pubCatLabel_(key) {
+    var c = boatCats.find(function(x) { return x.key === key; });
+    if (!c) return key;
+    return c.labelEN || key;
+  }
+
   // Trips
   var allTrips = readAll_('trips');
   var memberTrips = allTrips.filter(function(t) {
@@ -2860,7 +2869,7 @@ function pubRecordPageHtml_(member, certs, certDefs, opts) {
     html += '<div class="cat-legend">';
     catKeys.forEach(function(c) {
       var col = pubCatColor_(c);
-      html += '<span class="cat-pill" style="color:' + col.color + ';border-color:' + col.border + ';background:' + col.bg + '">' + esc_(c) + '</span>';
+      html += '<span class="cat-pill" style="color:' + col.color + ';border-color:' + col.border + ';background:' + col.bg + '">' + esc_(pubCatLabel_(c)) + '</span>';
     });
     html += '</div>';
   }

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -398,7 +398,7 @@ function renderStats(){
       const pct=max?Math.round(h/max*100):0;
       return `<div class="cat-hour-row">
         <span style="font-size:14px;width:20px;text-align:center">${boatEmoji(cat.toLowerCase())}</span>
-        <span style="min-width:80px;color:var(--text)">${esc(cat)}</span>
+        <span style="min-width:80px;color:var(--text)">${esc(_boatCatLabel(cat))}</span>
         <div class="cat-hour-bar-wrap"><div class="cat-hour-bar" style="width:${pct}%;background:${col.color}"></div></div>
         <span class="cat-hour-val">${h.toFixed(0)}h</span>
       </div>`;
@@ -448,6 +448,8 @@ function tripCard(t){
                    ].filter(Boolean).join('');
 
   // Port display (shown on card face for keelboats)
+  const tripCat = (allBoats.find(b=>b.id===t.boatId)?.category) || t.boatCategory || '';
+  const catCol = BOAT_CAT_COLORS[(tripCat||'').toLowerCase()] || BOAT_CAT_COLORS.other;
   const isKeelboat = (t.boatCategory||'').toLowerCase()==='keelboat';
   const dep=t.departurePort||'', arr=t.arrivalPort||'';
   const portLine = (dep||arr) ? (
@@ -525,7 +527,7 @@ function tripCard(t){
   const hasWeather = !!(eWs||eDir||eGust||eCond||eAir||eFeel||eSst||eWv||ePres);
   const hasNotes   = !!(notesRow||photosRow||trackRow);
 
-  return `<div class="trip-card" onclick="toggleTripCard(this)">
+  return `<div class="trip-card" style="border-left:3px solid ${catCol.color}" onclick="toggleTripCard(this)">
     <div class="trip-card-main">
       <div class="trip-date-col">
         <div class="trip-date-day">${esc(p.day)}</div>
@@ -1217,7 +1219,7 @@ function renderShareCatChecks(){
     var col=BOAT_CAT_COLORS[key]||BOAT_CAT_COLORS.other;
     return '<label style="font-size:11px;color:'+col.color+';display:flex;align-items:center;gap:5px;text-transform:none;letter-spacing:0;margin:0;padding:3px 8px;border-radius:10px;border:1px solid '+col.border+';background:'+col.bg+'">'
       +'<input type="checkbox" class="share-cat-chk" value="'+esc(c)+'" checked style="width:14px;height:14px;accent-color:'+col.color+'">'
-      +esc(c)+'</label>';
+      +esc(_boatCatLabel(c))+'</label>';
   }).join('');
 }
 async function loadShareTokens(){
@@ -1300,6 +1302,7 @@ async function reload(){
     const locs =cfgRes.locations||[];
     allBoats=boats.filter(b=>!b.oos&&b.oos!=='true');
     allLocs =locs;
+    registerBoatCats(cfgRes.boatCategories||[]);
     renderStats();
     buildFilters();
     applyFilter();

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -190,7 +190,7 @@ const STRINGS = {
   'member.tokenCreated': { EN:'Share link created.', IS:'Deilingarhlekkur búinn til.' },
 
   // ── Logbook share ─────────────────────────────────────────────────────────
-  'logbook.shareBtn':     { EN:'Share logbook',          IS:'Deila dagbók' },
+  'logbook.shareBtn':     { EN:'Share your logbook',      IS:'Deila dagbókinni þinni' },
   'logbook.sharePhotos':  { EN:'Include photos',         IS:'Taka myndir með' },
   'logbook.shareTracks':  { EN:'Include GPS tracks',     IS:'Taka GPS-leiðir með' },
   'logbook.shareCopy':    { EN:'Generate & copy link',   IS:'Búa til og afrita hlekk' },


### PR DESCRIPTION
- Register boatCategories in logbook init so _boatCatLabel() resolves translated titles (EN/IS) from category keys
- Category hour stats now show "Dinghy" instead of "dinghy"
- Share panel category checkboxes show labels (values remain keys for API)
- Trip cards get a colored left border matching their boat category
- Public share page category legend pills use labels via pubCatLabel_()
- Rename share button from "Share logbook" to "Share your logbook"

https://claude.ai/code/session_01CA2DpnFfsBwVv2Ru7MeC8S