### PR TITLE
Polish tide widget: match weather chart style, today button, compact …

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -877,69 +877,13 @@ function _autoFillTide() {
 
 function _renderDailyTide() {
   const el = document.getElementById('dailyTideWidget');
-  if (!el || typeof tideChartSeries !== 'function') return;
-  const IS = typeof getLang === 'function' && getLang() === 'IS';
+  if (!el || typeof tideSvgChart !== 'function') return;
   const extrema = tideExtrema(viewDate);
   const series  = tideChartSeries(viewDate);
-
-  // Merge + sort events
-  const events = [
-    ...extrema.highs.map(e => ({ ...e, type: 'high' })),
-    ...extrema.lows.map(e  => ({ ...e, type: 'low' })),
-  ].sort((a, b) => a.time - b.time);
-
-  const fmt = d => String(d.getUTCHours()).padStart(2,'0') + ':' + String(d.getUTCMinutes()).padStart(2,'0');
-
-  // Compact event pills
-  const pills = events.map(e => {
-    const icon = e.type === 'high' ? '▲' : '▼';
-    const color = e.type === 'high' ? 'var(--brass)' : '#4a9eca';
-    return `<span style="display:inline-flex;align-items:center;gap:3px;font-size:11px;color:var(--muted)"><span style="color:${color}">${icon}</span><b style="color:var(--text);font-family:'DM Mono',monospace">${fmt(e.time)}</b>${e.height.toFixed(1)}m</span>`;
-  }).join('<span style="color:var(--border);margin:0 2px">·</span>');
-
-  // Mini SVG wave — reuse the widget's curve logic inlined
-  const W = 260, H = 50, PT = 14, PB = 2;
-  const plotH = H - PT - PB;
-  const hMin = Math.min(...series.map(p => p.height));
-  const hMax = Math.max(...series.map(p => p.height));
-  const range = hMax - hMin || 1;
-  const t0 = series[0].time.getTime(), t1 = series[series.length - 1].time.getTime();
-  const tR = t1 - t0 || 1;
-  const xf = t => ((t - t0) / tR) * W;
-  const yf = h => PT + plotH - ((h - hMin) / range) * plotH;
-
-  const pathPts = series.map(p => `${xf(p.time.getTime()).toFixed(1)},${yf(p.height).toFixed(1)}`);
-  const fill = `M${pathPts.join('L')}L${W},${PT + plotH}L0,${PT + plotH}Z`;
-  const line = `M${pathPts.join('L')}`;
-
-  // Labels at extrema
-  const labels = events.map(e => {
-    const ex = xf(e.time.getTime()), ey = yf(e.height);
-    const isHigh = e.type === 'high';
-    const color = isHigh ? 'var(--brass)' : '#4a9eca';
-    const ly = isHigh ? Math.max(2, ey - 4) : Math.min(H - 1, ey + 9);
-    return `<text x="${ex.toFixed(1)}" y="${ly.toFixed(1)}" text-anchor="middle" fill="${color}" font-size="7" font-family="'DM Mono',monospace" font-weight="500">${fmt(e.time)} ${e.height.toFixed(1)}m</text>`
-      + `<circle cx="${ex.toFixed(1)}" cy="${ey.toFixed(1)}" r="2" fill="${color}"/>`;
-  }).join('');
-
-  // Now line (if viewing today)
-  let nowLine = '';
-  const now = Date.now();
-  if (now >= t0 && now <= t1 && viewDate === new Date().toISOString().slice(0,10)) {
-    const nx = xf(now);
-    nowLine = `<line x1="${nx.toFixed(1)}" y1="${PT}" x2="${nx.toFixed(1)}" y2="${PT + plotH}" stroke="var(--brass)" stroke-width="1" stroke-dasharray="3,2" opacity="0.6"/>`;
-  }
-
-  el.innerHTML = `
-    <div style="background:var(--card);border:1px solid var(--border);border-radius:8px;padding:10px 12px">
-      <svg width="100%" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="display:block;overflow:visible;margin-bottom:4px">
-        <path d="${fill}" fill="var(--brass)" opacity="0.07"/>
-        <path d="${line}" fill="none" stroke="var(--brass)" stroke-width="1.2" opacity="0.5"/>
-        ${nowLine}
-        ${labels}
-      </svg>
-      <div style="display:flex;flex-wrap:wrap;gap:4px 0;justify-content:center">${pills}</div>
-    </div>`;
+  const isToday = viewDate === new Date().toISOString().slice(0,10);
+  const nowMs   = isToday ? Date.now() : -1;
+  const svg = tideSvgChart(series, extrema, nowMs, 320, 80);
+  el.innerHTML = `<div style="background:var(--card);border:1px solid var(--border);border-radius:8px;padding:8px 10px">${svg}</div>`;
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/shared/tides.js
+++ b/shared/tides.js
@@ -37,41 +37,31 @@ function _jcen(d) {
 }
 
 function _astro(T) {
-  const mod360 = v => ((v % 360) + 360) % 360;
+  const m = v => ((v % 360) + 360) % 360;
   return {
-    s:  mod360(218.3165 + 481267.8813 * T),
-    h:  mod360(280.4661 +  36000.7698 * T),
-    p:  mod360( 83.3535 +   4069.0137 * T),
-    N:  mod360(125.0445 -   1934.1363 * T),
+    s: m(218.3165 + 481267.8813 * T),
+    h: m(280.4661 +  36000.7698 * T),
+    p: m( 83.3535 +   4069.0137 * T),
+    N: m(125.0445 -   1934.1363 * T),
   };
 }
 
 function _v0(a) {
   const { s, h, p } = a;
-  const mod360 = v => ((v % 360) + 360) % 360;
+  const m = v => ((v % 360) + 360) % 360;
   return {
-    M2: mod360(2 * h - 2 * s),
-    S2: 0,
-    N2: mod360(2 * h - 3 * s + p),
-    K2: mod360(2 * h),
-    K1: mod360(h - 90),
-    O1: mod360(h - 2 * s + 90),
-    P1: mod360(-h + 90),
-    Q1: mod360(h - 3 * s + p + 90),
+    M2: m(2*h - 2*s), S2: 0, N2: m(2*h - 3*s + p), K2: m(2*h),
+    K1: m(h - 90), O1: m(h - 2*s + 90), P1: m(-h + 90), Q1: m(h - 3*s + p + 90),
   };
 }
 
 function _nodal(N) {
-  const cosN = Math.cos(N * DEG), sinN = Math.sin(N * DEG);
+  const c = Math.cos(N * DEG), s = Math.sin(N * DEG);
   return {
-    M2: { f: 1.0 - 0.037 * cosN, u: -2.14 * sinN },
-    S2: { f: 1.0, u: 0 },
-    N2: { f: 1.0 - 0.037 * cosN, u: -2.14 * sinN },
-    K2: { f: 1.024 + 0.286 * cosN, u: -17.74 * sinN },
-    K1: { f: 1.006 + 0.115 * cosN, u: -8.86 * sinN },
-    O1: { f: 1.009 + 0.187 * cosN, u: 10.80 * sinN },
-    P1: { f: 1.0, u: 0 },
-    Q1: { f: 1.009 + 0.187 * cosN, u: 10.80 * sinN },
+    M2: { f: 1.0 - 0.037*c, u: -2.14*s },   S2: { f: 1.0, u: 0 },
+    N2: { f: 1.0 - 0.037*c, u: -2.14*s },   K2: { f: 1.024 + 0.286*c, u: -17.74*s },
+    K1: { f: 1.006 + 0.115*c, u: -8.86*s },  O1: { f: 1.009 + 0.187*c, u: 10.80*s },
+    P1: { f: 1.0, u: 0 },                     Q1: { f: 1.009 + 0.187*c, u: 10.80*s },
   };
 }
 
@@ -81,65 +71,48 @@ function _nodal(N) {
 
 function tideHeight(date) {
   const midnight = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-  const T = _jcen(midnight);
-  const a = _astro(T);
-  const v0 = _v0(a);
-  const nd = _nodal(a.N);
-  const hoursFromMidnight = (date.getTime() - midnight.getTime()) / 3600000;
+  const T = _jcen(midnight), a = _astro(T), v0 = _v0(a), nd = _nodal(a.N);
+  const hrs = (date.getTime() - midnight.getTime()) / 3600000;
   let h = TIDE_STATION.z0;
   for (const c of TIDE_STATION.constituents) {
     const n = nd[c.name];
-    h += n.f * c.H * Math.cos((c.speed * hoursFromMidnight + v0[c.name] + n.u - c.G) * DEG);
+    h += n.f * c.H * Math.cos((c.speed * hrs + v0[c.name] + n.u - c.G) * DEG);
   }
   return h;
 }
 
-// Dense time series for chart + extrema detection
 function _tideSeries(dateStr, stepMin, padH) {
   const base = new Date(dateStr + 'T00:00:00Z');
-  const start = base.getTime() - (padH || 0) * 3600000;
-  const end   = base.getTime() + 24 * 3600000 + (padH || 0) * 3600000;
-  const step  = stepMin * 60000;
-  const pts = [];
-  for (let ms = start; ms <= end; ms += step) {
-    const d = new Date(ms);
-    pts.push({ time: d, height: tideHeight(d) });
-  }
+  const s = base.getTime() - (padH||0)*3600000, e = base.getTime() + 24*3600000 + (padH||0)*3600000;
+  const step = stepMin * 60000, pts = [];
+  for (let ms = s; ms <= e; ms += step) { const d = new Date(ms); pts.push({ time: d, height: tideHeight(d) }); }
   return pts;
 }
 
 function tideExtrema(dateStr) {
   const pts = _tideSeries(dateStr, 6, 1);
-  const dayStart = new Date(dateStr + 'T00:00:00Z').getTime();
-  const dayEnd   = dayStart + 24 * 3600000;
+  const ds = new Date(dateStr + 'T00:00:00Z').getTime(), de = ds + 86400000;
   const highs = [], lows = [];
   for (let i = 1; i < pts.length - 1; i++) {
-    const prev = pts[i - 1].height, cur = pts[i].height, next = pts[i + 1].height;
-    const t = pts[i].time.getTime();
-    if (t < dayStart || t >= dayEnd) continue;
-    if (cur > prev && cur > next) highs.push({ time: pts[i].time, height: cur });
-    else if (cur < prev && cur < next) lows.push({ time: pts[i].time, height: cur });
+    const p = pts[i-1].height, c = pts[i].height, n = pts[i+1].height, t = pts[i].time.getTime();
+    if (t < ds || t >= de) continue;
+    if (c > p && c > n) highs.push(pts[i]);
+    else if (c < p && c < n) lows.push(pts[i]);
   }
   return { highs, lows };
 }
 
-function tideToDailyLog(extrema) {
-  const fmt = d => String(d.getUTCHours()).padStart(2,'0') + ':' + String(d.getUTCMinutes()).padStart(2,'0');
-  const fH = h => h.toFixed(1);
-  const h1 = extrema.highs[0], h2 = extrema.highs[1];
-  const l1 = extrema.lows[0],  l2 = extrema.lows[1];
+function tideToDailyLog(ex) {
+  const f = d => String(d.getUTCHours()).padStart(2,'0') + ':' + String(d.getUTCMinutes()).padStart(2,'0');
+  const v = h => h.toFixed(1);
+  const [h1,h2] = ex.highs, [l1,l2] = ex.lows;
   return {
-    h1t: h1 ? fmt(h1.time) : '', h1h: h1 ? fH(h1.height) : '',
-    l1t: l1 ? fmt(l1.time) : '', l1h: l1 ? fH(l1.height) : '',
-    h2t: h2 ? fmt(h2.time) : '', h2h: h2 ? fH(h2.height) : '',
-    l2t: l2 ? fmt(l2.time) : '', l2h: l2 ? fH(l2.height) : '',
+    h1t: h1?f(h1.time):'', h1h: h1?v(h1.height):'', l1t: l1?f(l1.time):'', l1h: l1?v(l1.height):'',
+    h2t: h2?f(h2.time):'', h2h: h2?v(h2.height):'', l2t: l2?f(l2.time):'', l2h: l2?v(l2.height):'',
   };
 }
 
-// Chart-resolution series (every 15 min) for SVG rendering
-function tideChartSeries(dateStr) {
-  return _tideSeries(dateStr, 15, 0);
-}
+function tideChartSeries(dateStr) { return _tideSeries(dateStr, 15, 0); }
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MOON PHASE
@@ -148,128 +121,134 @@ const SYNODIC_MONTH = 29.53059;
 const NEW_MOON_EPOCH = Date.UTC(2024, 0, 11, 11, 57, 0);
 
 function moonPhase(date) {
-  const daysSince = (date.getTime() - NEW_MOON_EPOCH) / 86400000;
-  const phase = ((daysSince % SYNODIC_MONTH) + SYNODIC_MONTH) % SYNODIC_MONTH;
-  const fraction = phase / SYNODIC_MONTH;
+  const days = (date.getTime() - NEW_MOON_EPOCH) / 86400000;
+  const fr = (((days % SYNODIC_MONTH) + SYNODIC_MONTH) % SYNODIC_MONTH) / SYNODIC_MONTH;
   const IS = typeof getLang === 'function' && getLang() === 'IS';
-  let icon, label;
-  if      (fraction < 0.0625) { icon = '\u{1F311}'; label = IS ? 'Nýtt tungl'        : 'New Moon'; }
-  else if (fraction < 0.1875) { icon = '\u{1F312}'; label = IS ? 'Vaxandi skera'     : 'Waxing Crescent'; }
-  else if (fraction < 0.3125) { icon = '\u{1F313}'; label = IS ? 'Fyrsti fjórðungur'  : 'First Quarter'; }
-  else if (fraction < 0.4375) { icon = '\u{1F314}'; label = IS ? 'Vaxandi hálft'      : 'Waxing Gibbous'; }
-  else if (fraction < 0.5625) { icon = '\u{1F315}'; label = IS ? 'Fullt tungl'        : 'Full Moon'; }
-  else if (fraction < 0.6875) { icon = '\u{1F316}'; label = IS ? 'Minnkandi hálft'    : 'Waning Gibbous'; }
-  else if (fraction < 0.8125) { icon = '\u{1F317}'; label = IS ? 'Síðasti fjórðungur' : 'Last Quarter'; }
-  else if (fraction < 0.9375) { icon = '\u{1F318}'; label = IS ? 'Minnkandi skera'    : 'Waning Crescent'; }
-  else                        { icon = '\u{1F311}'; label = IS ? 'Nýtt tungl'        : 'New Moon'; }
-  return { fraction, icon, label };
+  const phases = [
+    [0.0625, '\u{1F311}', 'New Moon',        'Nýtt tungl'],
+    [0.1875, '\u{1F312}', 'Waxing Crescent', 'Vaxandi skera'],
+    [0.3125, '\u{1F313}', 'First Quarter',   'Fyrsti fjórðungur'],
+    [0.4375, '\u{1F314}', 'Waxing Gibbous',  'Vaxandi hálft'],
+    [0.5625, '\u{1F315}', 'Full Moon',        'Fullt tungl'],
+    [0.6875, '\u{1F316}', 'Waning Gibbous',   'Minnkandi hálft'],
+    [0.8125, '\u{1F317}', 'Last Quarter',     'Síðasti fjórðungur'],
+    [0.9375, '\u{1F318}', 'Waning Crescent',  'Minnkandi skera'],
+    [1.0001, '\u{1F311}', 'New Moon',          'Nýtt tungl'],
+  ];
+  const p = phases.find(x => fr < x[0]);
+  return { fraction: fr, icon: p[1], label: IS ? p[3] : p[2] };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // SUNRISE / SUNSET
 // ═══════════════════════════════════════════════════════════════════════════════
 async function fetchSunTimes(lat, lon, dateStr) {
-  const cacheKey = 'ymir_sun_' + dateStr;
-  const cached = sessionStorage.getItem(cacheKey);
-  if (cached) { const c = JSON.parse(cached); if (Date.now() - c.ts < 3600000) return c.data; }
+  const k = 'ymir_sun_' + dateStr;
+  const c = sessionStorage.getItem(k);
+  if (c) { const o = JSON.parse(c); if (Date.now() - o.ts < 3600000) return o.data; }
   try {
-    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}`
-      + `&daily=sunrise,sunset&timezone=Atlantic/Reykjavik&start_date=${dateStr}&end_date=${dateStr}`;
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    const json = await res.json();
-    const data = {
-      sunrise: (json.daily?.sunrise?.[0] || '').slice(11, 16) || null,
-      sunset:  (json.daily?.sunset?.[0]  || '').slice(11, 16) || null,
-    };
-    sessionStorage.setItem(cacheKey, JSON.stringify({ ts: Date.now(), data }));
+    const r = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=sunrise,sunset&timezone=Atlantic/Reykjavik&start_date=${dateStr}&end_date=${dateStr}`);
+    if (!r.ok) return null;
+    const j = await r.json();
+    const data = { sunrise: (j.daily?.sunrise?.[0]||'').slice(11,16)||null, sunset: (j.daily?.sunset?.[0]||'').slice(11,16)||null };
+    sessionStorage.setItem(k, JSON.stringify({ ts: Date.now(), data }));
     return data;
-  } catch (_) { return null; }
+  } catch(_) { return null; }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TIDE WIDGET  —  compact card with SVG wave curve + day navigation
+// SHARED SVG CHART  —  matches weather page chart style
+//
+// Renders a tide curve with:
+//  · Past-time dark overlay + dashed NOW marker (like wind/pressure charts)
+//  · Time axis along bottom every 3h
+//  · High labels above peaks, low labels inside troughs (above baseline)
+//  · Dots at extrema
+// ═══════════════════════════════════════════════════════════════════════════════
+function tideSvgChart(series, extrema, nowMs, W, H) {
+  const P = { t: 14, b: 18, l: 4, r: 4 };
+  const iW = W - P.l - P.r, iH = H - P.t - P.b;
+  const heights = series.map(p => p.height);
+  const hMin = Math.min(...heights), hMax = Math.max(...heights);
+  const hRange = hMax - hMin || 1;
+  const t0 = series[0].time.getTime(), t1 = series[series.length-1].time.getTime();
+  const tR = t1 - t0 || 1;
+
+  const xOf = t => P.l + ((t - t0) / tR) * iW;
+  const yOf = h => P.t + (1 - (h - hMin) / hRange) * iH;
+  const f1 = v => v.toFixed(1);
+  const fmtT = d => String(d.getUTCHours()).padStart(2,'0') + ':' + String(d.getUTCMinutes()).padStart(2,'0');
+
+  // Curve paths
+  const pts = series.map(p => `${f1(xOf(p.time.getTime()))},${f1(yOf(p.height))}`);
+  const linePath = 'M' + pts.join('L');
+  const areaPath = linePath + `L${f1(xOf(t1))},${f1(yOf(hMin))}L${f1(xOf(t0))},${f1(yOf(hMin))}Z`;
+
+  let svg = '';
+
+  // Past overlay (dark, like wind chart)
+  if (nowMs > t0 && nowMs <= t1) {
+    const nw = Math.max(0, xOf(nowMs) - P.l);
+    svg += `<rect x="${P.l}" y="${P.t}" width="${f1(nw)}" height="${iH}" fill="#0b1f38" opacity="0.25"/>`;
+  }
+
+  // Area fill + line
+  svg += `<path d="${areaPath}" fill="#4a9eca" opacity="0.08"/>`;
+  svg += `<path d="${linePath}" fill="none" stroke="#4a9eca" stroke-width="1.5"/>`;
+
+  // NOW marker
+  if (nowMs > t0 && nowMs <= t1) {
+    const nx = f1(xOf(nowMs));
+    svg += `<line x1="${nx}" y1="${P.t}" x2="${nx}" y2="${f1(P.t+iH)}" stroke="rgba(255,255,255,0.35)" stroke-width="1" stroke-dasharray="3,3"/>`;
+    svg += `<text x="${nx}" y="${f1(P.t+iH+10)}" text-anchor="middle" font-family="'DM Mono',monospace" font-size="8" fill="#d4af37">NOW</text>`;
+  }
+
+  // Time axis (every 3h)
+  for (let h = 0; h <= 24; h += 3) {
+    const ms = t0 + h * 3600000;
+    if (ms > t1) break;
+    const tx = f1(xOf(ms));
+    const lbl = String(h).padStart(2, '0') + ':00';
+    svg += `<text x="${tx}" y="${f1(H-2)}" text-anchor="middle" font-size="7" fill="#6b92b8" font-family="'DM Mono',monospace">${lbl}</text>`;
+  }
+
+  // Extrema labels + dots
+  const events = [
+    ...extrema.highs.map(e => ({ ...e, type: 'high' })),
+    ...extrema.lows.map(e  => ({ ...e, type: 'low' })),
+  ];
+  events.forEach(e => {
+    const ex = xOf(e.time.getTime()), ey = yOf(e.height);
+    const isHigh = e.type === 'high';
+    const color = isHigh ? '#d4af37' : '#4a9eca';
+    const txt = fmtT(e.time) + '  ' + e.height.toFixed(1) + 'm';
+
+    // High: label above the peak; Low: label inside the trough (above the dot)
+    const ly = isHigh
+      ? Math.max(8, ey - 4)
+      : Math.max(ey - 4, P.t + 6);
+
+    // Background rect for legibility (keeps label from clashing with curve line)
+    const textW = txt.length * 4.2;
+    svg += `<rect x="${f1(ex - textW/2 - 1)}" y="${f1(ly - 7)}" width="${f1(textW + 2)}" height="8" rx="1" fill="var(--card)" opacity="0.85"/>`;
+    svg += `<text x="${f1(ex)}" y="${f1(ly)}" text-anchor="middle" fill="${color}" font-size="8" font-weight="500" font-family="'DM Mono',monospace">${txt}</text>`;
+    svg += `<circle cx="${f1(ex)}" cy="${f1(ey)}" r="2.5" fill="${color}"/>`;
+  });
+
+  return `<svg width="100%" viewBox="0 0 ${W} ${H}" style="display:block;overflow:visible">${svg}</svg>`;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TIDE WIDGET  —  compact card with SVG curve + day nav + today button
 // ═══════════════════════════════════════════════════════════════════════════════
 function tideWidget(targetEl, { onData } = {}) {
-  let timer = null;
-  let _dateOffset = 0; // 0 = today, +1 = tomorrow, -1 = yesterday
+  let timer = null, _dateOffset = 0;
 
-  function _dateStr(offset) {
-    const d = new Date();
-    d.setUTCDate(d.getUTCDate() + (offset || 0));
-    return d.toISOString().slice(0, 10);
+  function _dateStr(off) {
+    const d = new Date(); d.setUTCDate(d.getUTCDate() + (off||0));
+    return d.toISOString().slice(0,10);
   }
 
-  function _fmtTime(d) {
-    return String(d.getUTCHours()).padStart(2, '0') + ':' + String(d.getUTCMinutes()).padStart(2, '0');
-  }
-
-  // ── SVG wave curve ────────────────────────────────────────────────────────
-  function _renderCurve(series, extrema, nowMs, W, H) {
-    const PAD_T = 18, PAD_B = 4, PAD_L = 0, PAD_R = 0;
-    const plotW = W - PAD_L - PAD_R;
-    const plotH = H - PAD_T - PAD_B;
-    const hMin = Math.min(...series.map(p => p.height));
-    const hMax = Math.max(...series.map(p => p.height));
-    const range = hMax - hMin || 1;
-    const t0 = series[0].time.getTime(), t1 = series[series.length - 1].time.getTime();
-    const tRange = t1 - t0 || 1;
-
-    const x = t => PAD_L + ((t - t0) / tRange) * plotW;
-    const y = h => PAD_T + plotH - ((h - hMin) / range) * plotH;
-
-    // Wave path
-    const pathPts = series.map(p => `${x(p.time.getTime()).toFixed(1)},${y(p.height).toFixed(1)}`);
-    const path = `M${pathPts.join('L')}`;
-
-    // Filled area
-    const fill = `${path}L${x(t1).toFixed(1)},${(PAD_T + plotH).toFixed(1)}L${x(t0).toFixed(1)},${(PAD_T + plotH).toFixed(1)}Z`;
-
-    // Now-marker
-    let nowLine = '';
-    if (nowMs >= t0 && nowMs <= t1) {
-      const nx = x(nowMs);
-      nowLine = `<line x1="${nx.toFixed(1)}" y1="${PAD_T}" x2="${nx.toFixed(1)}" y2="${(PAD_T + plotH).toFixed(1)}" stroke="var(--brass)" stroke-width="1.5" stroke-dasharray="3,2" opacity="0.7"/>`;
-    }
-
-    // Extrema labels positioned at the curve peaks/troughs
-    const allEvents = [
-      ...extrema.highs.map(e => ({ ...e, type: 'high' })),
-      ...extrema.lows.map(e  => ({ ...e, type: 'low' })),
-    ];
-    const labels = allEvents.map(e => {
-      const ex = x(e.time.getTime());
-      const ey = y(e.height);
-      const isHigh = e.type === 'high';
-      const color = isHigh ? 'var(--brass)' : '#4a9eca';
-      // Place label above highs, below lows
-      const ly = isHigh ? Math.max(2, ey - 5) : Math.min(H - 1, ey + 11);
-      const txt = _fmtTime(e.time) + ' ' + e.height.toFixed(1) + 'm';
-      return `<text x="${ex.toFixed(1)}" y="${ly.toFixed(1)}" text-anchor="middle" fill="${color}" font-size="8" font-family="'DM Mono',monospace" font-weight="500">${txt}</text>`
-        + `<circle cx="${ex.toFixed(1)}" cy="${ey.toFixed(1)}" r="2.5" fill="${color}"/>`;
-    }).join('');
-
-    // Hour ticks along bottom
-    const ticks = [];
-    const dayStart = series[0].time.getTime();
-    for (let h = 0; h <= 24; h += 6) {
-      const ms = dayStart + h * 3600000;
-      if (ms < t0 || ms > t1) continue;
-      const tx = x(ms);
-      ticks.push(`<line x1="${tx.toFixed(1)}" y1="${(PAD_T + plotH).toFixed(1)}" x2="${tx.toFixed(1)}" y2="${(PAD_T + plotH + 3).toFixed(1)}" stroke="var(--border)" stroke-width="0.5"/>`);
-      ticks.push(`<text x="${tx.toFixed(1)}" y="${(H).toFixed(1)}" text-anchor="middle" fill="var(--muted)" font-size="7" font-family="'DM Mono',monospace">${String(h).padStart(2,'0')}</text>`);
-    }
-
-    return `<svg width="100%" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="display:block;overflow:visible">
-      <path d="${fill}" fill="var(--brass)" opacity="0.07"/>
-      <path d="${path}" fill="none" stroke="var(--brass)" stroke-width="1.5" opacity="0.6"/>
-      ${ticks.join('')}
-      ${nowLine}
-      ${labels}
-    </svg>`;
-  }
-
-  // ── Render ──────────────────────────────────────────────────────────────────
   async function refresh() {
     const IS = typeof getLang === 'function' && getLang() === 'IS';
     const now = new Date();
@@ -279,81 +258,74 @@ function tideWidget(targetEl, { onData } = {}) {
     const series  = tideChartSeries(dateStr);
     const moon = moonPhase(isToday ? now : new Date(dateStr + 'T12:00:00Z'));
     const sun = await fetchSunTimes(TIDE_STATION.lat, TIDE_STATION.lon, dateStr);
-
-    // Current state (only meaningful for today)
-    let statusHtml = '';
-    if (isToday) {
-      const curH = tideHeight(now);
-      const soonH = tideHeight(new Date(now.getTime() + 600000));
-      const rising = soonH > curH;
-      const arrow = rising ? '↑' : '↓';
-      const color = rising ? 'var(--green,#2ecc71)' : 'var(--orange,#e67e22)';
-      const lbl = rising ? (IS ? 'Hækkandi' : 'Rising') : (IS ? 'Lækkandi' : 'Falling');
-      statusHtml = `<span style="color:${color};font-weight:600;font-size:13px">${arrow}</span>`
-        + `<span style="color:${color};font-size:11px;font-weight:500">${lbl}</span>`
-        + `<span style="font-size:12px;font-weight:600;color:var(--text);font-family:'DM Mono',monospace">${curH.toFixed(1)}m</span>`;
-    }
-
-    // Date label for nav
-    const dd = new Date(dateStr + 'T12:00:00Z');
-    const dayLabel = isToday
-      ? (IS ? 'Í dag' : 'Today')
-      : dd.toLocaleDateString(IS ? 'is-IS' : 'en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
-
-    // Sun row
-    const sunHtml = sun
-      ? `<span style="font-size:11px;color:var(--muted)">☀↑<b style="color:var(--text);margin:0 2px">${sun.sunrise || '–'}</b></span>`
-      + `<span style="font-size:11px;color:var(--muted)">☀↓<b style="color:var(--text);margin:0 2px">${sun.sunset || '–'}</b></span>`
-      : '';
-
-    const moonHtml = `<span style="font-size:13px">${moon.icon}</span><span style="font-size:10px;color:var(--muted)">${moon.label}</span>`;
-
-    const disclaimer = IS
-      ? 'Spá reiknuð úr harmónísku líkani — ekki birt gögn. Notið með varúð.'
-      : 'Predicted from harmonic model — not published data. Use with caution.';
-
-    // SVG
-    const svgHtml = _renderCurve(series, extrema, isToday ? now.getTime() : -1, 280, 70);
-
     if (onData) onData({ extrema, moon, sun, dateStr });
 
+    // Status (today only)
+    let statusHtml = '';
+    if (isToday) {
+      const curH = tideHeight(now), soonH = tideHeight(new Date(now.getTime() + 600000));
+      const up = soonH > curH;
+      const col = up ? 'var(--green,#2ecc71)' : 'var(--orange,#e67e22)';
+      const lbl = up ? (IS?'Hækkandi':'Rising') : (IS?'Lækkandi':'Falling');
+      statusHtml = `<span style="color:${col};font-weight:600;font-size:12px">${up?'↑':'↓'}</span>`
+        + `<span style="color:${col};font-size:10px;font-weight:500">${lbl}</span>`
+        + `<span style="font-size:11px;font-weight:600;color:var(--text);font-family:'DM Mono',monospace">${curH.toFixed(1)}m</span>`;
+    }
+
+    // Day label
+    const dd = new Date(dateStr + 'T12:00:00Z');
+    const dayLabel = isToday ? (IS?'Í dag':'Today')
+      : dd.toLocaleDateString(IS?'is-IS':'en-GB', { weekday:'short', day:'numeric', month:'short' });
+
+    // Today button (only when not on today)
+    const todayBtn = isToday ? ''
+      : `<button class="tide-today-btn" style="background:none;border:1px solid var(--border);color:var(--brass);border-radius:4px;padding:0 6px;font-size:9px;cursor:pointer;font-family:inherit;line-height:1.6;letter-spacing:.3px">${IS?'Í dag':'Today'}</button>`;
+
+    // Nav button style (shared)
+    const navStyle = 'background:none;border:1px solid var(--border);color:var(--muted);border-radius:4px;padding:0 6px;font-size:11px;cursor:pointer;font-family:inherit;line-height:1.6';
+
+    // Sun / moon
+    const sunHtml = sun
+      ? `<span style="font-size:10px;color:var(--muted)">☀↑ <b style="color:var(--text)">${sun.sunrise||'–'}</b></span>`
+      + `<span style="font-size:10px;color:var(--muted)">☀↓ <b style="color:var(--text)">${sun.sunset||'–'}</b></span>`
+      : '';
+    const moonHtml = `<span style="font-size:12px">${moon.icon}</span><span style="font-size:9px;color:var(--muted)">${moon.label}</span>`;
+
+    const disclaimer = IS
+      ? 'Harmónískt líkan — ekki birt gögn.'
+      : 'Harmonic model — not published data.';
+
+    // Chart
+    const svg = tideSvgChart(series, extrema, isToday ? now.getTime() : -1, 320, 90);
+
     targetEl.innerHTML = `
-      <div style="background:var(--card);border:1px solid var(--border);border-radius:10px;padding:12px 14px">
-        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
-          <div style="font-size:9px;color:var(--muted);letter-spacing:1.2px">${IS ? 'FLÓÐ · FAXAFLÓI' : 'TIDES · FAXAFLÓI'}</div>
-          <div style="display:flex;align-items:center;gap:5px">${statusHtml}</div>
+      <div style="background:var(--card);border:1px solid var(--border);border-radius:10px;padding:10px 12px">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
+          <div style="font-size:9px;color:var(--muted);letter-spacing:1.2px">${IS?'FLÓÐ · FAXAFLÓI':'TIDES · FAXAFLÓI'}</div>
+          <div style="display:flex;align-items:center;gap:4px">${statusHtml}</div>
         </div>
-        <div style="display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:4px">
-          <button class="tide-nav-btn" data-dir="-1" style="background:none;border:1px solid var(--border);color:var(--muted);border-radius:4px;padding:1px 7px;font-size:12px;cursor:pointer;font-family:inherit;line-height:1.4">◀</button>
-          <span style="font-size:11px;color:var(--text);font-weight:500;min-width:80px;text-align:center">${dayLabel}</span>
-          <button class="tide-nav-btn" data-dir="1" style="background:none;border:1px solid var(--border);color:var(--muted);border-radius:4px;padding:1px 7px;font-size:12px;cursor:pointer;font-family:inherit;line-height:1.4">▶</button>
+        <div style="display:flex;align-items:center;justify-content:center;gap:8px;margin-bottom:2px">
+          <button class="tide-nav-btn" data-dir="-1" style="${navStyle}">◀</button>
+          <span style="font-size:10px;color:var(--text);font-weight:500;min-width:70px;text-align:center">${dayLabel}</span>
+          <button class="tide-nav-btn" data-dir="1" style="${navStyle}">▶</button>
+          ${todayBtn}
         </div>
-        <div style="margin:0 -4px">${svgHtml}</div>
-        <div style="display:flex;flex-wrap:wrap;align-items:center;gap:4px 12px;margin-top:6px">
-          ${sunHtml}
-          ${moonHtml}
+        ${svg}
+        <div style="display:flex;align-items:center;gap:4px 10px;flex-wrap:wrap;margin-top:2px">
+          ${sunHtml}${moonHtml}
+          <span style="margin-left:auto;font-size:7px;color:var(--muted);opacity:.55">⚠ ${disclaimer}</span>
         </div>
-        <div style="margin-top:6px;font-size:8px;color:var(--muted);line-height:1.3;opacity:0.6">⚠ ${disclaimer}</div>
       </div>`;
 
-    // Wire nav buttons
-    targetEl.querySelectorAll('.tide-nav-btn').forEach(btn => {
-      btn.onclick = () => {
-        _dateOffset += parseInt(btn.dataset.dir);
-        refresh();
-      };
+    // Wire nav
+    targetEl.querySelectorAll('.tide-nav-btn').forEach(b => {
+      b.onclick = () => { _dateOffset += parseInt(b.dataset.dir); refresh(); };
     });
+    const tb = targetEl.querySelector('.tide-today-btn');
+    if (tb) tb.onclick = () => { _dateOffset = 0; refresh(); };
   }
 
-  function start(intervalMs) {
-    refresh();
-    timer = setInterval(refresh, intervalMs || 300000);
-    return { refresh, start, stop };
-  }
-
-  function stop() {
-    if (timer) { clearInterval(timer); timer = null; }
-  }
-
+  function start(ms) { refresh(); timer = setInterval(refresh, ms||300000); return { refresh, start, stop }; }
+  function stop() { if (timer) { clearInterval(timer); timer = null; } }
   return { refresh, start, stop };
 }


### PR DESCRIPTION
…labels

Redesign tideSvgChart() as shared SVG renderer matching the weather page's wind/pressure chart conventions:
- Past-time dark overlay (#0b1f38) + dashed white NOW marker + brass label
- 3-hour time axis ticks along bottom (00:00, 03:00, ... 24:00)
- High labels above peaks, low labels inside troughs (above dot, not below the curve) with card-color background rects for legibility
- #4a9eca curve with subtle area fill (matching wave chart palette)
- "Today" button appears in nav bar when viewing a different day
- Tighter padding, smaller fonts, shorter disclaimer on one line
- Daily log _renderDailyTide() now calls shared tideSvgChart() instead of duplicating SVG logic

https://claude.ai/code/session_014Co95J5tY9GgKkJm6bitSk