### PR TITLE
Fix dashboard fetch to use GET (public endpoints require GET)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -152,11 +152,9 @@ function applyStaticText() {
 }
 
 async function fetchDashboard() {
-  var res = await fetch(SCRIPT_URL_PUB, {
-    method: 'POST',
+  var res = await fetch(SCRIPT_URL_PUB + '?action=dashboard', {
+    method: 'GET',
     redirect: 'follow',
-    headers: { 'Content-Type': 'text/plain' },
-    body: JSON.stringify({ action: 'dashboard' })
   });
   if (!res.ok) throw new Error('HTTP ' + res.status);
   var data = await res.json();


### PR DESCRIPTION
The publicDashboard_ endpoint is routed via doGet(), matching the pattern of all other public endpoints. POST requires API token auth.

https://claude.ai/code/session_01Ex17Hn53gMnFa38KFU6oDF