### PR TITLE
Add missing header element to logbook page for language toggle

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -135,6 +135,10 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 </style>
 </head>
 <body>
+<header id="ym-header">
+  <div class="header-left"></div>
+  <div class="header-right"></div>
+</header>
 <div class="page">
   <a class="back-nav" href="../member/">← Member Hub</a>
 


### PR DESCRIPTION
The logbook page called buildHeader('member') but had no <header id="ym-header"> element, so the header (with language toggle, weather link, and sign out button) was never rendered.

https://claude.ai/code/session_019d2krAaswKo3oWY9WUSidd