### PR TITLE
Add helm tracking for trip cards

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -381,6 +381,7 @@ function route_(action, b) {
     case 'linkGroupCheckoutToActivity': return linkGroupCheckoutToActivity_(b);
     case 'getTrips': return getTrips_(b.kennitala, parseInt(b.limit) || 100, b);
     case 'saveTrip': return saveTrip_(b);
+    case 'setHelm': return setHelm_(b);
     case 'deleteTrip': return deleteTrip_(b.id);
     case 'requestValidation': return requestValidation_(b);
     case 'uploadTripFile': return uploadTripFile_(b);
@@ -1506,7 +1507,7 @@ function deleteCheckout_(id) {
 function getTrips_(kennitala, limit, p) {
   p = p || {};
   const all = readAll_('trips');
-  const filtered = all.filter(t => (!kennitala || String(t.kennitala) === String(kennitala)) && (!p.date || (t.timeIn || t.date || '').slice(0, 10) === p.date));
+  const filtered = all.filter(t => (!kennitala || String(t.kennitala) === String(kennitala)) && (!p.date || (t.timeIn || t.date || '').slice(0, 10) === p.date) && (!p.linkedCheckoutId || String(t.linkedCheckoutId) === String(p.linkedCheckoutId)));
   const sorted = filtered.sort((a, b) => (b.date || '') > (a.date || '') ? 1 : -1);
   return okJ({ trips: sorted.slice(0, limit || 100) });
 }
@@ -1523,7 +1524,7 @@ function saveTrip_(b) {
       'crew','role','beaufort','windDir','wxSnapshot','notes',
       'isLinked','linkedCheckoutId','linkedTripId',
       'verified','verifiedBy','verifiedAt','staffComment',
-      'validationRequested',
+      'validationRequested','helm',
       'distanceNm','departurePort','arrivalPort',
       'trackFileUrl','trackSimplified','trackSource',
       'photoUrls',
@@ -1546,13 +1547,19 @@ function saveTrip_(b) {
     notes: b.notes || '', isLinked: b.isLinked || false,
     linkedCheckoutId: b.linkedCheckoutId || '', linkedTripId: b.linkedTripId || '',
     verified: false, verifiedBy: '', verifiedAt: '', staffComment: '',
-    validationRequested: b.validationRequested || false,
+    validationRequested: b.validationRequested || false, helm: b.helm || false,
     distanceNm: b.distanceNm || '', departurePort: b.departurePort || '', arrivalPort: b.arrivalPort || '',
     trackFileUrl: b.trackFileUrl || '', trackSimplified: b.trackSimplified || '', trackSource: b.trackSource || '',
     photoUrls: b.photoUrls || '',
     createdAt: ts,
   });
   return okJ({ id, created: true });
+}
+
+function setHelm_(b) {
+  if (!b.tripId) return failJ('tripId required');
+  updateRow_('trips', 'id', b.tripId, { helm: !!b.helm, updatedAt: now_() });
+  return okJ({ updated: true });
 }
 
 function deleteTrip_(id) {
@@ -2733,6 +2740,8 @@ function pubTripTableHtml_(trips, allTrips, boats, opts) {
     var isSki = !t.role || t.role === 'skipper';
     var roleEN = isSki ? 'Skipper' : 'Crew';
     var roleIS = isSki ? 'Skipari' : 'Áhöfn';
+    var isHelm = t.helm && t.helm !== 'false' && t.helm !== false && parseInt(t.crew || 1) > 1;
+    if (isHelm) { roleEN += ' · Helm'; roleIS += ' · Stýri'; }
     var catCol = pubCatColor_(t.boatCategory || (boat ? boat.category : ''));
 
     // Captain name for crew trips
@@ -3436,7 +3445,7 @@ var SCHEMA_ = {
     'crew','role','beaufort','windDir','wxSnapshot','notes',
     'isLinked','linkedCheckoutId','linkedTripId',
     'verified','verifiedBy','verifiedAt','staffComment',
-    'validationRequested',
+    'validationRequested','helm',
     // keelboat Phase-1 (v6)
     'distanceNm','departurePort','arrivalPort',
     'trackFileUrl','trackSimplified','trackSource',

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -50,6 +50,7 @@
 .badge-skipper{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
 .badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}
 .badge-verified{color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111}
+.badge-helm{color:var(--text);border-color:var(--border);background:var(--surface)}
 .trip-expand-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:4px 12px;font-size:11px;border-top:1px solid var(--border);padding-top:10px;margin-top:2px}
 .trip-exp-row{display:flex;flex-direction:column;gap:1px;padding:4px 0}
 .trip-exp-lbl{font-size:9px;color:var(--muted);letter-spacing:.6px;text-transform:uppercase}
@@ -444,6 +445,8 @@ function tripCard(t){
   const dur = t.hoursDecimal ? (parseFloat(t.hoursDecimal)||0).toFixed(1)+'h' : '—';
   const isSki = !t.role || t.role==='skipper';
   const isVer = t.verified && t.verified!=='false';
+  const isHelm = t.helm && t.helm!=='false';
+  const showHelm = isHelm && parseInt(t.crew||1)>1;
 
   // Parse wx snapshot
   let wx = null;
@@ -491,9 +494,31 @@ function tripCard(t){
   const linkedCrew = myTrips.filter(x =>
     x.linkedCheckoutId && x.linkedCheckoutId === t.linkedCheckoutId && x.id !== t.id && x.role==='crew'
   );
-  const crewRow = `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Áhöfn um borð':'Crew aboard'}</span><span class="trip-exp-val">${
-    linkedCrew.length ? linkedCrew.map(x=>esc(x.memberName||x.crewMemberName||'?')).join(', ') : esc(t.crew||1)
-  }</span></div>`;
+  const helmLabel = IS?'Stýri':'Helm';
+  const crewNames = linkedCrew.length ? linkedCrew.map(x=>{
+    const name = esc(x.memberName||x.crewMemberName||'?');
+    const xHelm = x.helm && x.helm!=='false';
+    return xHelm ? name+' <span style="font-size:9px;color:var(--brass);border:1px solid var(--brass)55;border-radius:4px;padding:0 3px;margin-left:2px">'+helmLabel+'</span>' : name;
+  }).join(', ') : esc(t.crew||1);
+  const crewRow = `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Áhöfn um borð':'Crew aboard'}</span><span class="trip-exp-val">${crewNames}</span></div>`;
+
+  // Helm assignment row — shown to the skipper when crew > 1, allows toggling after the fact
+  const canEditHelm = isSki && isOwner && parseInt(t.crew||1) > 1;
+  const helmRow = canEditHelm ? `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Stýri':'Helm'}</span><span class="trip-exp-val">
+    <div style="display:flex;flex-direction:column;gap:4px">
+      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:11px" onclick="event.stopPropagation()">
+        <input type="checkbox" ${isHelm?'checked':''} onchange="toggleHelm('${esc(t.id)}',this.checked)" style="accent-color:var(--brass)">
+        ${esc(t.memberName||'')} <span style="opacity:.5">(${IS?'þú':'you'})</span>
+      </label>
+      ${linkedCrew.map(x=>{
+        const xHelm=x.helm&&x.helm!=='false';
+        return `<label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:11px" onclick="event.stopPropagation()">
+          <input type="checkbox" ${xHelm?'checked':''} onchange="toggleHelm('${esc(x.id)}',this.checked)" style="accent-color:var(--brass)">
+          ${esc(x.memberName||x.crewMemberName||'?')}
+        </label>`;
+      }).join('')}
+    </div>
+  </span></div>` : '';
 
   // Vessel/boat detail rows from boats config
   const kboat = allBoats.find(b=>b.id===t.boatId);
@@ -538,7 +563,7 @@ function tripCard(t){
   const hasWeather = !!(eWs||eDir||eGust||eCond||eAir||eFeel||eSst||eWv||ePres);
   const hasNotes   = !!(notesRow||photosRow||trackRow);
   const hasDetailWx = !!(eDir||eGust||eAir||eFeel||eSst||ePres);
-  const hasDetailed = !!(t.locationName||crewRow||distRow||t.hoursDecimal||hasDetailWx);
+  const hasDetailed = !!(t.locationName||crewRow||distRow||t.hoursDecimal||hasDetailWx||helmRow);
 
   return `<div class="trip-card" style="border-left:3px solid ${catCol.color}" onclick="toggleTripCard(this)">
     <div class="trip-card-main">
@@ -551,6 +576,7 @@ function tripCard(t){
         <div class="trip-boat">${esc(t.boatName||'—')}</div>
         <div class="trip-meta">
           <span class="trip-badge ${isSki?'badge-skipper':'badge-crew'}">${isSki?(IS?'Skipari':'Skipper'):(IS?'Áhöfn':'Crew')}</span>
+          ${showHelm?`<span class="trip-badge badge-helm">${IS?'Stýri':'Helm'}</span>`:''}
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':'' }
           ${t.validationRequested && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ Validation pending</span>' : ''}
           <span>${esc(dur)}</span>
@@ -582,7 +608,7 @@ function tripCard(t){
           ${(t.locationName||crewRow||distRow||t.hoursDecimal)?`<div class="exp-section-hdr" style="margin-top:8px">${IS?'Upplýsingar um ferð':'Trip Details'}</div><div class="trip-expand-grid">
             ${t.locationName?`<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Siglingasvæði':'Sailing area'}</span><span class="trip-exp-val">${esc(t.locationName)}</span></div>`:''}
             ${t.hoursDecimal?`<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Tímalengd':'Duration'}</span><span class="trip-exp-val">${dur}</span></div>`:''}
-            ${distRow}${crewRow}
+            ${distRow}${crewRow}${helmRow}
           </div>`:''}
           ${hasDetailWx?`<div class="exp-section-hdr">${IS?'Veður':'Weather'}</div><div class="trip-expand-grid">${eDir}${eGust}${eAir}${eFeel}${eSst}${ePres}</div>`:''}
         </div>
@@ -1207,6 +1233,16 @@ document.addEventListener('keydown', function(e) {
 });
 
 // ── Delete trip files ────────────────────────────────────────────────────────
+async function toggleHelm(tripId, checked) {
+  try {
+    await apiPost('setHelm', { tripId, helm: checked });
+    // Update local data
+    const t = myTrips.find(x => x.id === tripId);
+    if (t) t.helm = checked;
+    applyFilter();
+  } catch(e) { showToast('Error: ' + e.message, 'err'); }
+}
+
 async function deleteTripTrack(tripId) {
   if (!confirm(IS ? 'Ertu viss um að þú viljir eyða GPS-leiðinni?' : 'Delete this GPS track?')) return;
   try {

--- a/member/index.html
+++ b/member/index.html
@@ -315,6 +315,7 @@ function openCheckInPicker() {
 }
 function openReturnModal(coId) {
   returnCo=checkouts.find(c=>c.id===coId)||null;
+  window._retCrewTrips=[]; window._retCrewTripsFetched=false;
   openModal('returnModal'); renderReturnForm();
 }
 
@@ -660,6 +661,7 @@ function renderLandingChecklist() {
   if(!returnCo) return;
   // Reset pending upload state each time this step is rendered
   window._retPendingTrack=null; window._retPendingPhotos=[];
+  window._retHelmSelf=false; window._retCrewTrips=window._retCrewTrips||[];
   document.getElementById('returnModalTitle').textContent=s('member.checkInTitle')+' — '+(returnCo.boatName||'');
   var IS=getLang()==='IS';
   var cat=(returnCo.boatCategory||'other').toLowerCase();
@@ -670,6 +672,15 @@ function renderLandingChecklist() {
     '<label style="display:flex;align-items:center;gap:10px;padding:8px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
     '<input type="checkbox" class="land-check" style="width:16px;height:16px;accent-color:var(--brass)">'+
     '<span>'+esc(_clItemLabel(it))+'</span></label>').join('');
+
+  // Fetch linked crew trips for helm assignment (if crew > 1)
+  if((returnCo.crew||1)>1 && !window._retCrewTripsFetched){
+    window._retCrewTripsFetched=true;
+    apiGet('getTrips',{linkedCheckoutId:returnCo.id}).then(function(r){
+      window._retCrewTrips=(r.trips||[]).filter(function(t){return t.role==='crew';});
+      _renderHelmSection();
+    }).catch(function(){});
+  }
 
   // Resolve home/departure port name for keelboats
   var homePt='';
@@ -732,6 +743,16 @@ function renderLandingChecklist() {
       '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--red);border-color:var(--red)55" onclick="openInlineReport(\'incident\')">&#128680; '+(IS?'Tilkynna atvik':'Report incident')+'</button>'+
     '</div>'+
     '<div id="reportFlagNote" style="display:none;font-size:11px;padding:5px 8px;border-radius:4px;background:var(--surface);margin-bottom:8px"></div>'+
+    ((returnCo.crew||1)>1?'<div id="helmSection" style="margin-bottom:14px">'+
+      '<div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:8px">'+(IS?'STÝRI':'HELM')+'</div>'+
+      '<div id="helmToggles">'+
+        '<label style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
+          '<input type="checkbox" class="helm-toggle" data-helm-self="1" style="width:16px;height:16px;accent-color:var(--brass)" onchange="window._retHelmSelf=this.checked">'+
+          '<span>'+esc(user.name||'')+' <span style="font-size:10px;color:var(--muted)">'+(IS?'(þú)':'(you)')+'</span></span>'+
+        '</label>'+
+        '<div id="helmCrewToggles" style="color:var(--muted);font-size:11px;padding:4px 0">'+(IS?'Hleður áhöfn…':'Loading crew…')+'</div>'+
+      '</div>'+
+    '</div>':'')+
     portDistRow+uploadRow+distStandaloneRow+
     '<div class="field" style="margin-bottom:14px">'+
       '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">'+(IS?'PERSÓNULEGAR SKÝRINGAR':'PERSONAL NOTE')+'</label>'+
@@ -741,6 +762,19 @@ function renderLandingChecklist() {
       '<button class="btn btn-secondary" onclick="renderReturnForm()">&#8592; '+(IS?'Til baka':'Back')+'</button>'+
       '<button class="btn btn-primary" id="retSubmitBtn" onclick="confirmCheckIn(\''+returnCo.id+'\')">&#10003; '+(IS?'Skrá inn':'Check In')+'</button>'+
     '</div>';
+}
+
+function _renderHelmSection(){
+  var el=document.getElementById('helmCrewToggles');
+  if(!el) return;
+  var IS=getLang()==='IS';
+  var trips=window._retCrewTrips||[];
+  if(!trips.length){el.textContent=IS?'Engin nefnd áhöfn':'No named crew';return;}
+  el.innerHTML=trips.map(function(t){
+    return '<label style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
+      '<input type="checkbox" class="helm-toggle" data-helm-trip-id="'+esc(t.id)+'" style="width:16px;height:16px;accent-color:var(--brass)">'+
+      '<span>'+esc(t.memberName||'?')+'</span></label>';
+  }).join('');
 }
 
 function _handleRetTrack(input){
@@ -887,6 +921,13 @@ async function confirmCheckIn(coId) {
     }catch(e){showToast((IS?'Mynda upphal mistókst: ':'Photo upload failed: ')+e.message,'warn');}
   }));
 
+  // Collect helm toggle states
+  var helmSelf=!!window._retHelmSelf;
+  var helmCrewMap={};
+  document.querySelectorAll('.helm-toggle[data-helm-trip-id]').forEach(function(cb){
+    helmCrewMap[cb.dataset.helmTripId]=cb.checked;
+  });
+
   try {
     await Promise.all([
       apiPost('checkIn',{id:coId,timeIn,kennitala:user.kennitala,memberName:user.name,boatId:co.boatId,boatName:co.boatName}),
@@ -896,11 +937,18 @@ async function confirmCheckIn(coId) {
       timeOut:tout,timeIn,hoursDecimal:h>0?h.toFixed(2):'0',crew:co.crew||1,
       beaufort:tripSnap?tripSnap.bft:null,windDir:tripSnap?(tripSnap.dir||tripSnap.wDir||''):'',
       wxSnapshot:tripSnap?JSON.stringify(tripSnap):null,notes,role:'skipper',linkedCheckoutId:coId,isLinked:true,
+      helm:helmSelf,
       departurePort:co.departurePort||'',arrivalPort,
       distanceNm,trackFileUrl,trackSimplified,trackSource,
       photoUrls:photoUrls.length?JSON.stringify(photoUrls):'',
       }),
     ]);
+    // Update helm on crew trips
+    var helmUpdates=Object.keys(helmCrewMap).map(function(tid){
+      return apiPost('setHelm',{tripId:tid,helm:helmCrewMap[tid]}).catch(function(){});
+    });
+    if(helmUpdates.length) await Promise.all(helmUpdates);
+    window._retCrewTrips=[]; window._retCrewTripsFetched=false;
     checkouts=checkouts.filter(function(c){return c.id!==coId;});
     closeModal('returnModal'); renderActiveCheckouts(); renderFleetByCat();
     logbookLoaded=false; showToast(s('toast.checkedIn'));


### PR DESCRIPTION
Adds a "helm" boolean field to trip records, allowing skippers/captains to indicate which crew members were at the helm during multi-crew trips.

- Backend: helm field in saveTrip_, setHelm_ endpoint, getTrips_ filter by linkedCheckoutId, schema update
- Check-in modal: helm toggles for skipper + named crew (crew > 1)
- Logbook: helm badge on trip cards, captain can toggle helm after the fact in expanded trip details
- Public record: helm indicator in role column

Closes #81

https://claude.ai/code/session_01PnCqrJqTXBr9y6KWqUrNdV