### PR TITLE
Route dashboard via doPost as public endpoint (fixes CORS)

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -319,6 +319,8 @@ function doGet(e) {
 function doPost(e) {
   try {
     const b = JSON.parse(e.postData.contents);
+    // Public POST endpoints — no token required
+    if (b.action === 'dashboard') return publicDashboard_();
     if (!b.token || b.token !== API_TOKEN_) return failJ('Unauthorized', 401);
     return route_(b.action, b);
   } catch (err) { return failJ('Server error: ' + err.message, 500); }

--- a/public/index.html
+++ b/public/index.html
@@ -165,9 +165,11 @@ function applyStaticText() {
 }
 
 async function fetchDashboard() {
-  var res = await fetch(SCRIPT_URL_PUB + '?action=dashboard', {
-    method: 'GET',
+  var res = await fetch(SCRIPT_URL_PUB, {
+    method: 'POST',
     redirect: 'follow',
+    headers: { 'Content-Type': 'text/plain' },
+    body: JSON.stringify({ action: 'dashboard' }),
   });
   if (!res.ok) throw new Error('HTTP ' + res.status);
   var data = await res.json();


### PR DESCRIPTION
Google Apps Script GET endpoints redirect through Google's auth page when called cross-origin via fetch(), causing CORS failures. All other pages in the app use POST with Content-Type: text/plain. Added dashboard as a public (no-token) route in doPost to match.

https://claude.ai/code/session_01Ex17Hn53gMnFa38KFU6oDF