### PR TITLE
Route dashboard through standard auth path

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -394,6 +394,8 @@ function route_(action, b) {
     case 'snoozeAlert': return snoozeAlert_(b);
     case 'resolveAlert':  return resolveAlert_(b);
     case 'saveAlertConfig': return saveAlertConfig_(b);
+    // ── PUBLIC DASHBOARD ───────────────────────────────────────────────────────
+    case 'dashboard':         return publicDashboard_();
     // ── SHARE TOKENS ──────────────────────────────────────────────────────────
     case 'getShareTokens':    return getShareTokens_(b);
     case 'createShareToken':  return createShareToken_(b);

--- a/public/index.html
+++ b/public/index.html
@@ -169,7 +169,7 @@ async function fetchDashboard() {
     method: 'POST',
     redirect: 'follow',
     headers: { 'Content-Type': 'text/plain' },
-    body: JSON.stringify({ action: 'dashboard' }),
+    body: JSON.stringify({ action: 'dashboard', token: API_TOKEN }),
   });
   if (!res.ok) throw new Error('HTTP ' + res.status);
   var data = await res.json();


### PR DESCRIPTION
The token-bypass in doPost wasn't taking effect on the deployed script. Instead, send the API token (already loaded via api.js) and route through the normal switch in route_().

https://claude.ai/code/session_01Ex17Hn53gMnFa38KFU6oDF