### PR TITLE
Fix assign credentials: invalidate cache on cert mutations

### DIFF
--- a/shared/api.js
+++ b/shared/api.js
@@ -24,10 +24,12 @@ async function apiPost(action, payload) {
   payload = payload || {};
   // Invalidate config cache when config is saved
   if (action === 'saveConfig' || action === 'saveMembers' || action === 'saveMember' ||
+      action === 'deleteMember' || action === 'saveMemberCert' ||
       action === 'importMembers' || action === 'deactivateMembers' ||
       action === 'saveActivityType' || action === 'deleteActivityType' ||
-      action === 'saveChecklistItem' || action === 'deleteChecklistItem') {
-    try { 
+      action === 'saveChecklistItem' || action === 'deleteChecklistItem' ||
+      action === 'saveCertDef' || action === 'deleteCertDef') {
+    try {
       sessionStorage.removeItem('ymir_getConfig_');
       sessionStorage.removeItem('ymir_getMembers_');
     } catch(e) {}

--- a/shared/certs.js
+++ b/shared/certs.js
@@ -56,7 +56,7 @@ function groupCerts(enrichedList) {
 
 function applyRankRule(certs, newCert, certDefs) {
   const def = certDefs.find(d => d.id === newCert.certId);
-  if (!def || !def.subcats.length) return certs;
+  if (!def || !def.subcats?.length) return certs;
   const newSub = def.subcats.find(s => s.key === newCert.sub);
   if (!newSub || newSub.rank == null) return certs;
   return certs.filter(c => {


### PR DESCRIPTION
saveMemberCert, deleteMember, saveCertDef, and deleteCertDef were missing from the apiPost cache invalidation list. After assigning credentials, the stale sessionStorage cache caused assignments to disappear on page reload. Also guard against undefined subcats in applyRankRule to prevent silent crashes.

https://claude.ai/code/session_01XLtbUZKECygd3y5A21D2Ec