### PR TITLE
Add boat ownership (club/private) and charter system

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -578,6 +578,47 @@
         <input type="number" id="bLoa" min="0" step="0.1" placeholder="e.g. 34.0">
       </div>
     </div>
+    <!-- Ownership -->
+    <div class="field">
+      <label data-s="boat.ownership">Ownership</label>
+      <select id="bOwnership" onchange="updateOwnershipFields()">
+        <option value="club">Club boat</option>
+        <option value="private">Private boat</option>
+      </select>
+    </div>
+    <div class="field hidden" id="bOwnerField">
+      <label data-s="boat.owner">Owner</label>
+      <div style="position:relative">
+        <input type="text" id="bOwnerSearch" autocomplete="off" placeholder="Search member..." oninput="searchBoatOwner(this.value)">
+        <div id="bOwnerSuggestions" class="suggest-drop" style="position:relative"></div>
+        <input type="hidden" id="bOwnerId">
+        <div id="bOwnerName" style="font-size:10px;color:var(--muted);margin-top:3px"></div>
+      </div>
+    </div>
+    <!-- Charter (club boats only) -->
+    <div id="bCharterSection">
+      <div id="bCharterInfo" style="font-size:11px;color:var(--brass);margin-bottom:6px"></div>
+      <div id="bCharterForm" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px">
+        <div class="field">
+          <label data-s="boat.charterMember">Chartered to</label>
+          <div style="position:relative">
+            <input type="text" id="bCharterMemberSearch" autocomplete="off" placeholder="Search member..." oninput="searchCharterMember(this.value)">
+            <div id="bCharterMemberSuggestions" class="suggest-drop" style="position:relative"></div>
+            <input type="hidden" id="bCharterMemberKt">
+            <div id="bCharterMemberName" style="font-size:10px;color:var(--muted);margin-top:3px"></div>
+          </div>
+        </div>
+        <div class="grid2">
+          <div class="field"><label data-s="boat.charterStart">Start date</label><input type="date" id="bCharterStart"></div>
+          <div class="field"><label data-s="boat.charterEnd">End date</label><input type="date" id="bCharterEnd"></div>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-secondary" style="font-size:11px" onclick="cancelCharterForm()">Cancel</button>
+          <button class="btn btn-primary" style="font-size:11px" onclick="saveCharterFromModal()">Save Charter</button>
+        </div>
+      </div>
+      <div id="bCharterActions"></div>
+    </div>
     <div class="check-row">
       <input type="checkbox" id="bOOS"> <label for="bOOS">Out of service</label>
     </div>
@@ -1285,9 +1326,130 @@ function openBoatModal(id) {
   document.getElementById("bLoa").value        = b ? (b.loa || "")            : "";
   document.getElementById("bTypeModel").value  = b ? (b.typeModel || "")      : "";
   populateDefaultPortSelect(b ? (b.defaultPortId || "") : "");
+  // Ownership
+  document.getElementById("bOwnership").value = b && b.ownership === 'private' ? 'private' : 'club';
+  document.getElementById("bOwnerId").value   = b ? (b.ownerId || '') : '';
+  document.getElementById("bOwnerSearch").value = '';
+  document.getElementById("bOwnerName").textContent = b && b.ownerName ? b.ownerName : '';
+  document.getElementById("bOwnerSuggestions").innerHTML = '';
+  // Charter
+  document.getElementById("bCharterForm").classList.add("hidden");
+  document.getElementById("bCharterMemberKt").value = '';
+  document.getElementById("bCharterMemberSearch").value = '';
+  document.getElementById("bCharterMemberName").textContent = '';
+  document.getElementById("bCharterStart").value = '';
+  document.getElementById("bCharterEnd").value = '';
+  updateOwnershipFields();
+  renderCharterInfo(b);
   updateBoatModalFields();
   applyStrings(document.getElementById("boatModal"));
   openModal("boatModal");
+}
+
+// ── Ownership helpers ──────────────────────────────────────────────────────────
+function updateOwnershipFields() {
+  const isPrivate = document.getElementById("bOwnership").value === 'private';
+  document.getElementById("bOwnerField").classList.toggle("hidden", !isPrivate);
+  document.getElementById("bCharterSection").style.display = isPrivate ? 'none' : '';
+}
+
+function searchBoatOwner(q) {
+  const drop = document.getElementById("bOwnerSuggestions");
+  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
+  const ql = q.toLowerCase();
+  const hits = members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
+  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
+  drop.innerHTML = hits.map(m => `<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"
+    onclick="selectBoatOwner('${esc(m.kennitala)}','${esc(m.name)}')">${esc(m.name)}</div>`).join('');
+  drop.style.display = 'block';
+}
+
+function selectBoatOwner(kt, name) {
+  document.getElementById("bOwnerId").value = kt;
+  document.getElementById("bOwnerSearch").value = '';
+  document.getElementById("bOwnerName").textContent = name;
+  document.getElementById("bOwnerSuggestions").innerHTML = '';
+  document.getElementById("bOwnerSuggestions").style.display = 'none';
+}
+
+// ── Charter helpers ───────────────────────────────────────────────────────────
+function renderCharterInfo(boat) {
+  const infoEl = document.getElementById("bCharterInfo");
+  const actEl  = document.getElementById("bCharterActions");
+  if (!boat || boat.ownership === 'private') {
+    infoEl.textContent = '';
+    actEl.innerHTML = '';
+    return;
+  }
+  if (boat.charter && boat.charter.memberName) {
+    const ch = boat.charter;
+    infoEl.innerHTML = `${esc(s('fleet.charteredTo',{name:ch.memberName}))} ${esc(s('fleet.charteredUntil',{date:ch.endDate}))}`;
+    actEl.innerHTML = `<button class="btn btn-secondary" style="font-size:11px" onclick="showCharterForm()">${esc(s('boat.setCharter'))}</button> `
+                    + `<button class="btn btn-danger" style="font-size:11px" onclick="removeCharterFromModal()">${esc(s('boat.removeCharter'))}</button>`;
+  } else {
+    infoEl.textContent = '';
+    actEl.innerHTML = `<button class="btn btn-secondary" style="font-size:11px" onclick="showCharterForm()">${esc(s('boat.setCharter'))}</button>`;
+  }
+}
+
+function showCharterForm() {
+  document.getElementById("bCharterForm").classList.remove("hidden");
+}
+
+function cancelCharterForm() {
+  document.getElementById("bCharterForm").classList.add("hidden");
+}
+
+function searchCharterMember(q) {
+  const drop = document.getElementById("bCharterMemberSuggestions");
+  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
+  const ql = q.toLowerCase();
+  const hits = members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
+  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
+  drop.innerHTML = hits.map(m => `<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"
+    onclick="selectCharterMember('${esc(m.kennitala)}','${esc(m.name)}')">${esc(m.name)}</div>`).join('');
+  drop.style.display = 'block';
+}
+
+function selectCharterMember(kt, name) {
+  document.getElementById("bCharterMemberKt").value = kt;
+  document.getElementById("bCharterMemberSearch").value = '';
+  document.getElementById("bCharterMemberName").textContent = name;
+  document.getElementById("bCharterMemberSuggestions").innerHTML = '';
+  document.getElementById("bCharterMemberSuggestions").style.display = 'none';
+}
+
+async function saveCharterFromModal() {
+  const boatId = editingId;
+  if (!boatId) { toast("Save the boat first.", "err"); return; }
+  const kt   = document.getElementById("bCharterMemberKt").value;
+  const name = document.getElementById("bCharterMemberName").textContent;
+  const start = document.getElementById("bCharterStart").value;
+  const end   = document.getElementById("bCharterEnd").value;
+  if (!kt || !name) { toast("Select a member.", "err"); return; }
+  if (!start || !end) { toast("Set start and end dates.", "err"); return; }
+  try {
+    await apiPost('saveCharter', { boatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end });
+    // Update local boat data
+    const b = _allBoats.find(x => x.id === boatId);
+    if (b) b.charter = { memberKennitala: kt, memberName: name, startDate: start, endDate: end };
+    cancelCharterForm();
+    renderCharterInfo(b);
+    toast(s('boat.charterSaved'));
+  } catch(e) { toast("Error: " + e.message, "err"); }
+}
+
+async function removeCharterFromModal() {
+  const boatId = editingId;
+  if (!boatId) return;
+  if (!confirm(s('boat.removeCharter') + '?')) return;
+  try {
+    await apiPost('removeCharter', { boatId });
+    const b = _allBoats.find(x => x.id === boatId);
+    if (b) delete b.charter;
+    renderCharterInfo(b);
+    toast(s('boat.charterRemoved'));
+  } catch(e) { toast("Error: " + e.message, "err"); }
 }
 
 async function saveBoat() {
@@ -1296,6 +1458,7 @@ async function saveBoat() {
 
   const id  = editingId || ("boat_" + Date.now().toString(36));
   const cat = document.getElementById("bCategory").value;
+  const ownershipVal = document.getElementById("bOwnership").value;
   const payload = {
     id, name,
     category:      cat,
@@ -1307,6 +1470,10 @@ async function saveBoat() {
     // all boats
     typeModel:      document.getElementById("bTypeModel").value.trim(),
     loa:            parseFloat(document.getElementById("bLoa").value) || '',
+    // ownership
+    ownership:      ownershipVal,
+    ownerId:        ownershipVal === 'private' ? (document.getElementById("bOwnerId").value || '') : '',
+    ownerName:      ownershipVal === 'private' ? (document.getElementById("bOwnerName").textContent || '') : '',
   };
 
   const idx = _allBoats.findIndex(x => x.id === id);

--- a/code.gs
+++ b/code.gs
@@ -382,6 +382,8 @@ function route_(action, b) {
     case 'saveGroupCheckout': return saveGroupCheckout_(b);
     case 'groupCheckIn': return groupCheckIn_(b);
     case 'linkGroupCheckoutToActivity': return linkGroupCheckoutToActivity_(b);
+    case 'saveCharter': return saveCharter_(b);
+    case 'removeCharter': return removeCharter_(b);
     case 'getTrips': return getTrips_(b.kennitala, parseInt(b.limit) || 100, b);
     case 'saveTrip': return saveTrip_(b);
     case 'setHelm': return setHelm_(b);
@@ -1508,6 +1510,41 @@ function deleteCheckout_(id) {
   if (!id) return failJ('id required');
   const deleted = deleteRow_('checkouts', 'id', id);
   cDel_('checkouts'); return okJ({ deleted });
+}
+
+// ── Charter management ───────────────────────────────────────────────────────
+
+function saveCharter_(b) {
+  if (!b.boatId) return failJ('boatId required');
+  if (!b.memberKennitala || !b.memberName) return failJ('member required');
+  if (!b.startDate || !b.endDate) return failJ('startDate and endDate required');
+  const cfgMap = getConfigMap_();
+  let boats = [];
+  try { boats = JSON.parse(getConfigValue_('boats', cfgMap) || '[]'); } catch (e) { return failJ('Failed to parse boats'); }
+  const idx = boats.findIndex(x => x.id === b.boatId);
+  if (idx < 0) return failJ('Boat not found');
+  boats[idx].charter = {
+    memberKennitala: b.memberKennitala,
+    memberName: b.memberName,
+    startDate: b.startDate,
+    endDate: b.endDate,
+  };
+  setConfigSheetValue_('boats', JSON.stringify(boats));
+  cDel_('config');
+  return okJ({ updated: true, boat: boats[idx] });
+}
+
+function removeCharter_(b) {
+  if (!b.boatId) return failJ('boatId required');
+  const cfgMap = getConfigMap_();
+  let boats = [];
+  try { boats = JSON.parse(getConfigValue_('boats', cfgMap) || '[]'); } catch (e) { return failJ('Failed to parse boats'); }
+  const idx = boats.findIndex(x => x.id === b.boatId);
+  if (idx < 0) return failJ('Boat not found');
+  delete boats[idx].charter;
+  setConfigSheetValue_('boats', JSON.stringify(boats));
+  cDel_('config');
+  return okJ({ updated: true, boat: boats[idx] });
 }
 
 

--- a/member/index.html
+++ b/member/index.html
@@ -341,7 +341,7 @@ function openReturnModal(coId) {
 // Step 1 — boat picker
 function renderLaunchPicker(preselectedBoatId) {
   const active=checkouts.filter(c=>c.status==='out');
-  const avail=boats.filter(b=>!active.find(c=>c.boatId===b.id)&&!boolVal(b.oos));
+  const avail=boats.filter(b=>!active.find(c=>c.boatId===b.id)&&!boolVal(b.oos)&&!isChartered(b));
   if(!avail.length){
     document.getElementById('launchModalBody').innerHTML=`<div class="empty-note">${s('member.noBoats')}</div>`; return;
   }

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -82,6 +82,22 @@ function boatEmoji(cat) {
   return BOAT_EMOJI[(cat||"").toLowerCase()] || "⛵";
 }
 
+// ── Ownership / charter helpers ───────────────────────────────────────────────
+
+/** Returns true if the boat has an active charter (today falls within start–end). */
+function isChartered(boat) {
+  if (!boat || !boat.charter) return false;
+  const c = boat.charter;
+  if (!c.startDate || !c.endDate) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return today >= c.startDate && today <= c.endDate;
+}
+
+/** Returns true if the boat is privately owned. */
+function isPrivate(boat) {
+  return boat && boat.ownership === 'private';
+}
+
 function boatCatBadge(cat) {
   const key = (cat||"other").toLowerCase();
   const col = BOAT_CAT_COLORS[key] || BOAT_CAT_COLORS.other;
@@ -154,6 +170,21 @@ function renderBoatCard(boat, opts) {
   const locLine = (status==="avail" && boat.location)
     ? `<div style="font-size:11px;color:var(--muted);margin-top:2px">${_besc(boat.location)}</div>` : "";
 
+  // Ownership / charter info
+  const chartered = isChartered(boat);
+  const priv      = isPrivate(boat);
+  let ownerLine = "";
+  if (priv && boat.ownerName) {
+    ownerLine = `<div style="font-size:10px;color:var(--brass);margin-top:4px">${_besc(s("fleet.ownedBy",{name:boat.ownerName}))}</div>`;
+  }
+  let charterLine = "";
+  if (chartered) {
+    const ch = boat.charter;
+    charterLine = `<div style="font-size:10px;color:var(--brass);margin-top:4px">`
+                + `${_besc(s("fleet.charteredTo",{name:ch.memberName}))} ${_besc(s("fleet.charteredUntil",{date:ch.endDate}))}`
+                + `</div>`;
+  }
+
   // Use registry-based onclick to avoid JSON-in-attribute encoding problems
   const boatId = _besc(boat.id || "");
   const clickAttr = opts.onClickAction
@@ -162,13 +193,24 @@ function renderBoatCard(boat, opts) {
     ? ` style="cursor:pointer" onclick="${opts.onClick}"`
     : "";
 
-  return `<div class="bc-card bc-${status}"${clickAttr}>`
+  // Extra badge for chartered / private boats
+  let ownerBadge = "";
+  if (chartered) {
+    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeChartered"))}</span>`;
+  } else if (priv) {
+    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--muted);border-color:var(--border);background:var(--surface);margin-left:4px">${_besc(s("fleet.badgePrivate"))}</span>`;
+  }
+
+  // Muted card style for chartered boats visible to non-staff
+  const charteredMuted = (chartered && !opts.staffView) ? "opacity:.55;pointer-events:none;" : "";
+
+  return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}">`
        + `<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:4px">`
        + `<div style="font-size:14px;font-weight:500;color:var(--text)">${emoji} ${name}</div>`
-       + bdgHtml
+       + `<div style="display:flex;gap:4px;flex-shrink:0">${ownerBadge}${bdgHtml}</div>`
        + `</div>`
        + boatCatBadge(cat)
-       + locLine + infoLine + oosLine
+       + locLine + infoLine + oosLine + ownerLine + charterLine
        + (opts.extraHtml||"")
        + `</div>`;
 }
@@ -334,7 +376,8 @@ function renderFleetStatus(containerId, boats, active, opts) {
     const col      = BOAT_CAT_COLORS[key] || BOAT_CAT_COLORS.other;
     const emoji    = boatEmoji(key);
     const catBoats = boats.filter(b => (b.category||'').toLowerCase() === key);
-    const avail    = catBoats.filter(b => !boolVal(b.oos) && !activeByBoat.has(b.id));
+    const isStaff  = !!opts.staffView;
+    const avail    = catBoats.filter(b => !boolVal(b.oos) && !activeByBoat.has(b.id) && (isStaff || !isChartered(b)));
     const pct      = catBoats.length ? Math.round(avail.length / catBoats.length * 100) : 0;
     const catId    = containerId + '-fcat-' + encodeURIComponent(key);
 
@@ -342,10 +385,10 @@ function renderFleetStatus(containerId, boats, active, opts) {
       const co  = activeByBoat.get(b.id);
       const oos = boolVal(b.oos);
       const status = oos ? 'oos' : co ? (co.isOverdue ? 'overdue' : 'out') : 'avail';
-      const clickOpts = (status === 'avail' && onAvail)
+      const clickOpts = (status === 'avail' && onAvail && (isStaff || !isChartered(b)))
         ? { onClick: onAvail + "('${b.id}')".replace('${b.id}', _besc(b.id)) }
         : {};
-      return renderBoatCard(b, Object.assign({ status, checkoutData: co }, clickOpts));
+      return renderBoatCard(b, Object.assign({ status, checkoutData: co, staffView: isStaff }, clickOpts));
     }).join('');
 
     return `<div class="fleet-status-block">

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -801,6 +801,27 @@ const STRINGS = {
   'fleet.outTime':           { EN:'Out {t}',                               IS:'Út {t}' },
   'fleet.checkIn':           { EN:'Check In',                              IS:'Skrá inn' },
   'fleet.delete':            { EN:'Delete',                                IS:'Eyða' },
+  'fleet.badgeChartered':    { EN:'CHARTERED',                             IS:'LEIGÐUR' },
+  'fleet.badgePrivate':      { EN:'PRIVATE',                               IS:'EINKABÁTUR' },
+  'fleet.charteredTo':       { EN:'Chartered to {name}',                   IS:'Leigður til {name}' },
+  'fleet.charteredUntil':    { EN:'until {date}',                          IS:'til {date}' },
+  'fleet.ownedBy':           { EN:'Owner: {name}',                         IS:'Eigandi: {name}' },
+  'fleet.charterOverride':   { EN:'This boat is chartered to {name} until {date}. Override and check out anyway?',
+                               IS:'Þessi bátur er leigður til {name} til {date}. Viltu taka hann út samt?' },
+
+  // ── Boat ownership & charter ──────────────────────────────────────────────
+  'boat.ownership':          { EN:'Ownership',                             IS:'Eignarhald' },
+  'boat.ownershipClub':      { EN:'Club boat',                             IS:'Klúbbsbátur' },
+  'boat.ownershipPrivate':   { EN:'Private boat',                          IS:'Einkabátur' },
+  'boat.owner':              { EN:'Owner',                                 IS:'Eigandi' },
+  'boat.charter':            { EN:'Charter',                               IS:'Leiga' },
+  'boat.charterMember':      { EN:'Chartered to',                          IS:'Leigður til' },
+  'boat.charterStart':       { EN:'Start date',                            IS:'Upphafsdagur' },
+  'boat.charterEnd':         { EN:'End date',                              IS:'Lokadagur' },
+  'boat.setCharter':         { EN:'Set Charter',                           IS:'Skrá leigu' },
+  'boat.removeCharter':      { EN:'Remove Charter',                        IS:'Fjarlægja leigu' },
+  'boat.charterSaved':       { EN:'Charter saved',                         IS:'Leiga vistuð' },
+  'boat.charterRemoved':     { EN:'Charter removed',                       IS:'Leiga fjarlægð' },
 
   // ── Public dashboard ──────────────────────────────────────────────────────
   'pub.dash.title':          { EN:'Club Dashboard',                        IS:'Yfirlit klúbbs' },

--- a/staff/index.html
+++ b/staff/index.html
@@ -562,7 +562,10 @@ function populateSelects() {
   const active = checkouts.filter(c => c.status === 'out');
   boats.filter(b => !active.find(c => c.boatId === b.id) && !boolVal(b.oos))
     .forEach(b => {
-      const o = document.createElement('option'); o.value=b.id; o.textContent=b.name; bSel.appendChild(o);
+      const o = document.createElement('option'); o.value=b.id;
+      const chartered = isChartered(b);
+      o.textContent = b.name + (chartered ? ' [' + s('fleet.badgeChartered') + ']' : '');
+      bSel.appendChild(o);
     });
   const lSel = document.getElementById('coLocation');
   locations.filter(l => l.type !== 'port').forEach(l => {
@@ -608,6 +611,7 @@ function renderFleet() {
     onAvailClick: 'selectBoatForCheckout',
     toggleFn:     'toggleFleetCat',
     collapsed:    true,
+    staffView:    true,
   });
 }
 
@@ -835,6 +839,11 @@ async function submitCheckout() {
   const boat     = boats.find(b => b.id === bid) || {};
   const location = locations.find(l => l.id === lid) || {};
   const member   = members.find(m => m.kennitala === kt) || {};
+  // Charter override warning for staff
+  if (isChartered(boat)) {
+    const ch = boat.charter;
+    if (!confirm(s('fleet.charterOverride', { name: ch.memberName, date: ch.endDate }))) return;
+  }
   const snap     = (typeof wxSnapshot === 'function') ? wxSnapshot(wxData) : null;
   try {
     const res = await apiPost('saveCheckout', {
@@ -1112,6 +1121,7 @@ function openGroupModal() {
     btn.dataset.id = b.id;
     if (boolVal(b.oos)) { btn.disabled = true; btn.style.opacity='.35'; btn.title = 'Out of service'; }
     else if (out) { btn.disabled = true; btn.style.opacity='.35'; btn.title = 'Already out'; }
+    else if (isChartered(b)) { btn.style.opacity='.55'; btn.title = s('fleet.charteredTo',{name:b.charter.memberName}); btn.addEventListener('click', function() { if(confirm(s('fleet.charterOverride',{name:b.charter.memberName,date:b.charter.endDate}))) toggleGmBoat(this); }); }
     else btn.addEventListener('click', function() { toggleGmBoat(this); });
     grid.appendChild(btn);
   });


### PR DESCRIPTION
Boats can now be set as club or private. Private boats are linked to a member owner. Club boats can be chartered to a member by admin with start/end dates. Chartered boats appear muted and unavailable to members, while staff get a confirmation modal warning before overriding.

Closes #118

https://claude.ai/code/session_01G5FhqVBooMoCmCpeuyV8C7