### PR TITLE
Improve checkout modals, crew display, student badges, and confirmati…

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1661,6 +1661,7 @@ function requestValidation_(b) {
 //   'crew_assigned'  — skipper assigned a crew member → crew must confirm
 //   'crew_join'      — member wants to join a trip    → skipper must confirm
 //   'helm'           — helm toggle requested          → other party confirms
+//   'student'        — skipper marks crew as student  → crew must confirm
 //
 // Status: 'pending' | 'confirmed' | 'rejected'
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1776,6 +1777,20 @@ function respondConfirmation_(b) {
       // Set helm on the specified trip
       if (row.tripId) {
         updateRow_('trips', 'id', row.tripId, { helm: true, updatedAt: ts });
+      }
+    }
+    if (type === 'student') {
+      // Set student flag on the crew member's trip for this checkout
+      var stuKt = row.toKennitala;
+      var coId = row.linkedCheckoutId;
+      if (stuKt && coId) {
+        addColIfMissing_('trips', 'student');
+        var stuTrips = readAll_('trips').filter(function(t) {
+          return String(t.kennitala) === String(stuKt) && String(t.linkedCheckoutId) === String(coId);
+        });
+        stuTrips.forEach(function(t) {
+          updateRow_('trips', 'id', t.id, { student: true, updatedAt: ts });
+        });
       }
     }
   }

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -662,14 +662,31 @@ function tripCard(t){
   const helmLabel = IS?'Stýri':'Helm';
   const guestLabel = IS?'Gestur':'Guest';
   const guestBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:2px">'+guestLabel+'</span>';
+  const studentLabel = IS?'Nemi':'Student';
+  const studentBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid #2e86c155;background:#2e86c111;color:#2e86c1;margin-left:2px">'+studentLabel+'</span>';
   const pendingTag = `<span class="conf-status pending" style="font-size:9px;padding:1px 6px">${IS?'í bið':'pending'}</span>`;
+  // Check for pending/confirmed student confirmations
+  const studentConfs = _confirmations.outgoing.filter(c =>
+    c.type==='student' && c.status==='confirmed' &&
+    (c.tripId===t.id || (t.linkedCheckoutId && c.linkedCheckoutId===t.linkedCheckoutId))
+  );
+  const pendingStudentConfs = _confirmations.outgoing.filter(c =>
+    c.type==='student' && c.status==='pending' &&
+    (c.tripId===t.id || (t.linkedCheckoutId && c.linkedCheckoutId===t.linkedCheckoutId))
+  );
+  const pendingStudentIn = _confirmations.incoming.filter(c =>
+    c.type==='student' && c.status==='pending' &&
+    (c.tripId===t.id || (t.linkedCheckoutId && c.linkedCheckoutId===t.linkedCheckoutId))
+  );
   const crewNames = linkedCrew.length ? linkedCrew.map(x=>{
     const name = esc(x.memberName||x.crewMemberName||'?');
     const xHelm = x.helm && x.helm!=='false';
+    const xStudent = (x.student && x.student!=='false') || studentConfs.some(c=>String(c.toKennitala)===String(x.kennitala));
     const xMember = allMembers.find(m=>String(m.kennitala)===String(x.kennitala));
     const isGuest = xMember && xMember.role==='guest';
     let badges = '';
     if (xHelm) badges += ' <span style="font-size:9px;color:var(--brass);border:1px solid var(--brass)55;border-radius:4px;padding:0 3px;margin-left:2px">'+helmLabel+'</span>';
+    if (xStudent) badges += studentBadge;
     if (isGuest) badges += guestBadge;
     return name + badges;
   }).join(', ') : esc(t.crew||1);
@@ -796,6 +813,7 @@ function tripCard(t){
         <div class="trip-meta">
           <span class="trip-badge ${isSki?'badge-skipper':'badge-crew'}">${isSki?(IS?'Skipari':'Skipper'):(IS?'Áhöfn':'Crew')}</span>
           ${showHelm?`<span class="trip-badge badge-helm">${IS?'Stýri':'Helm'}</span>`:''}
+          ${(t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)))?`<span class="trip-badge" style="background:#2e86c111;border:1px solid #2e86c155;color:#2e86c1;font-size:9px">${IS?'Nemi':'Student'}</span>`:''}
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':'' }
           ${t.validationRequested && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ Validation pending</span>' : ''}
           <span>${esc(dur)}</span>
@@ -817,11 +835,11 @@ function tripCard(t){
           const toplineTrip =
               (t.timeOut?'<div class="trip-exp-row"><span class="trip-exp-lbl">'+(IS?'Brottfarartími':'Departed')+'</span><span class="trip-exp-val">'+esc(t.timeOut)+'</span></div>':'')
             + (t.timeIn?'<div class="trip-exp-row"><span class="trip-exp-lbl">'+(IS?'Komutími':'Returned')+'</span><span class="trip-exp-val">'+esc(t.timeIn)+'</span></div>':'')
-            + portRow;
+            + portRow + crewNamesRow + helmRow;
           const detailTrip =
               (t.locationName?'<div class="trip-exp-row"><span class="trip-exp-lbl">'+(IS?'Siglingasvæði':'Sailing area')+'</span><span class="trip-exp-val">'+esc(t.locationName)+'</span></div>':'')
             + (t.hoursDecimal?'<div class="trip-exp-row"><span class="trip-exp-lbl">'+(IS?'Tímalengd':'Duration')+'</span><span class="trip-exp-val">'+dur+'</span></div>':'')
-            + distRow + skipperNameRow + crewCountRow + crewNamesRow + helmRow;
+            + distRow + skipperNameRow + crewCountRow;
           return (hasDetailTrip
             ? '<div class="exp-section-hdr expandable" onclick="event.stopPropagation();toggleSectionDetail(this)">'+(IS?'Upplýsingar um ferð':'Trip Details')+' <span class="exp-chevron">▾</span></div>'
               + (toplineTrip ? '<div class="trip-expand-grid">'+toplineTrip+'</div>' : '')
@@ -1809,6 +1827,7 @@ function _confDesc(c){
   if(c.type==='crew_assigned') return s('member.crewAssigned');
   if(c.type==='crew_join') return s('member.crewJoin');
   if(c.type==='helm') return s('member.helmReq');
+  if(c.type==='student') return IS?'Nemamerking':'Student badge';
   return c.type;
 }
 
@@ -1831,49 +1850,75 @@ function renderConfirmations(){
   dismissAllEl = document.getElementById('confDismissAll');
   if (dismissAllEl) dismissAllEl.innerHTML = dismissAllBtn;
 
+  // Group incoming confirmations by trip (linkedCheckoutId or tripId)
   var incoming=_confirmations.incoming.sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
   if(!incoming.length){
     inEl.innerHTML='<div class="empty-note">'+s('member.noIncoming')+'</div>';
   }else{
-    inEl.innerHTML=incoming.map(function(c){
-      var isPending=c.status==='pending';
-      return '<div class="conf-card">'+
-        '<div class="conf-line">'+
-          '<span class="conf-name">'+esc(c.fromName||'?')+'</span>'+
-          '<span class="conf-type">'+_confDesc(c)+'</span>'+
-          '<span class="conf-boat-info">'+esc(c.boatName||'')+'</span>'+
-          '<span class="conf-date-info">'+esc(c.date||'')+(c.timeOut?' '+esc(c.timeOut):'')+'</span>'+
-        '</div>'+
-        (isPending?
-          '<div class="conf-actions">'+
-            '<button class="btn-confirm" onclick="respondConf(\''+esc(c.id)+'\',\'confirmed\')">'+s('member.confirmBtn')+'</button>'+
-            '<button class="btn-reject" onclick="promptRejectConf(\''+esc(c.id)+'\')">'+s('member.rejectBtn')+'</button>'+
-          '</div>':
-          '<div style="margin-top:4px;display:flex;align-items:center;gap:6px"><span class="conf-status '+c.status+'">'+s('member.status'+c.status.charAt(0).toUpperCase()+c.status.slice(1))+'</span>'+
-          '<button class="trip-more-btn" onclick="dismissConf(\''+esc(c.id)+'\')" style="font-size:9px;padding:2px 8px;margin:0">'+(IS?'Fjarlægja':'Dismiss')+'</button>'+
-          (c.rejectComment?' <span style="font-size:10px;color:var(--muted)">'+esc(c.rejectComment)+'</span>':'')+
-          '</div>'
-        )+'</div>';
+    var inGroups={}, inOrder=[];
+    incoming.forEach(function(c){
+      var key=c.linkedCheckoutId||c.tripId||c.id;
+      if(!inGroups[key]){inGroups[key]=[];inOrder.push(key);}
+      inGroups[key].push(c);
+    });
+    inEl.innerHTML=inOrder.map(function(key){
+      var group=inGroups[key];
+      var first=group[0];
+      var header='<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:6px">'+
+        '<span class="conf-boat-info" style="font-weight:500">'+esc(first.boatName||'')+'</span>'+
+        '<span class="conf-date-info">'+esc(first.date||'')+(first.timeOut?' '+esc(first.timeOut):'')+'</span>'+
+        '<span class="conf-name" style="font-size:10px;color:var(--muted)">'+(IS?'frá':'from')+' '+esc(first.fromName||'?')+'</span>'+
+      '</div>';
+      var items=group.map(function(c){
+        var isPending=c.status==='pending';
+        return '<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;padding:4px 0;border-top:1px solid var(--border)22">'+
+          '<span class="conf-type" style="flex-shrink:0">'+_confDesc(c)+'</span>'+
+          (isPending?
+            '<div style="display:flex;gap:4px;margin-left:auto">'+
+              '<button class="btn-confirm" onclick="respondConf(\''+esc(c.id)+'\',\'confirmed\')" style="font-size:10px;font-family:inherit;padding:3px 8px;border-radius:5px;cursor:pointer;border:1px solid">'+s('member.confirmBtn')+'</button>'+
+              '<button class="btn-reject" onclick="promptRejectConf(\''+esc(c.id)+'\')" style="font-size:10px;font-family:inherit;padding:3px 8px;border-radius:5px;cursor:pointer;border:1px solid">'+s('member.rejectBtn')+'</button>'+
+            '</div>':
+            '<div style="display:flex;align-items:center;gap:4px;margin-left:auto">'+
+              '<span class="conf-status '+c.status+'">'+s('member.status'+c.status.charAt(0).toUpperCase()+c.status.slice(1))+'</span>'+
+              '<button class="trip-more-btn" onclick="dismissConf(\''+esc(c.id)+'\')" style="font-size:9px;padding:2px 6px;margin:0">'+(IS?'Fjarlægja':'Dismiss')+'</button>'+
+              (c.rejectComment?' <span style="font-size:10px;color:var(--muted)">'+esc(c.rejectComment)+'</span>':'')+
+            '</div>'
+          )+
+        '</div>';
+      }).join('');
+      return '<div class="conf-card">'+header+items+'</div>';
     }).join('');
   }
 
+  // Group outgoing confirmations by trip
   var outgoing=_confirmations.outgoing.sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
   if(!outgoing.length){
     outEl.innerHTML='<div class="empty-note">'+s('member.noOutgoing')+'</div>';
   }else{
-    outEl.innerHTML=outgoing.map(function(c){
-      var isPending=c.status==='pending';
-      return '<div class="conf-card">'+
-        '<div class="conf-line">'+
-          '<span class="conf-name">'+esc(c.toName||'?')+'</span>'+
+    var outGroups={}, outOrder=[];
+    outgoing.forEach(function(c){
+      var key=c.linkedCheckoutId||c.tripId||c.id;
+      if(!outGroups[key]){outGroups[key]=[];outOrder.push(key);}
+      outGroups[key].push(c);
+    });
+    outEl.innerHTML=outOrder.map(function(key){
+      var group=outGroups[key];
+      var first=group[0];
+      var header='<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:6px">'+
+        '<span class="conf-boat-info" style="font-weight:500">'+esc(first.boatName||'')+'</span>'+
+        '<span class="conf-date-info">'+esc(first.date||'')+(first.timeOut?' '+esc(first.timeOut):'')+'</span>'+
+      '</div>';
+      var items=group.map(function(c){
+        var isPending=c.status==='pending';
+        return '<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;padding:4px 0;border-top:1px solid var(--border)22">'+
+          '<span class="conf-name" style="font-weight:500;font-size:11px">'+esc(c.toName||'?')+'</span>'+
           '<span class="conf-type">'+_confDesc(c)+'</span>'+
-          '<span class="conf-boat-info">'+esc(c.boatName||'')+'</span>'+
-          '<span class="conf-date-info">'+esc(c.date||'')+(c.timeOut?' '+esc(c.timeOut):'')+'</span>'+
-          '<span class="conf-status '+c.status+'">'+s('member.status'+c.status.charAt(0).toUpperCase()+c.status.slice(1))+'</span>'+
-          (!isPending?'<button class="trip-more-btn" onclick="dismissConf(\''+esc(c.id)+'\')" style="font-size:9px;padding:2px 8px;margin:0">'+(IS?'Fjarlægja':'Dismiss')+'</button>':'')+
-        '</div>'+
-        (c.rejectComment?'<div style="font-size:10px;color:var(--muted);margin-top:2px;padding-left:2px">'+esc(c.rejectComment)+'</div>':'')+
+          '<span class="conf-status '+c.status+'" style="margin-left:auto">'+s('member.status'+c.status.charAt(0).toUpperCase()+c.status.slice(1))+'</span>'+
+          (!isPending?'<button class="trip-more-btn" onclick="dismissConf(\''+esc(c.id)+'\')" style="font-size:9px;padding:2px 6px;margin:0">'+(IS?'Fjarlægja':'Dismiss')+'</button>':'')+
+          (c.rejectComment?'<span style="font-size:10px;color:var(--muted)">'+esc(c.rejectComment)+'</span>':'')+
         '</div>';
+      }).join('');
+      return '<div class="conf-card">'+header+items+'</div>';
     }).join('');
   }
 }

--- a/member/index.html
+++ b/member/index.html
@@ -447,8 +447,8 @@ function advanceToLaunchChecklist() {
     tout: document.getElementById('launchTimeOut')?.value||'',
     ret:  document.getElementById('launchReturnBy')?.value||'',
     crew: window._launchCrewCount||1,
-    crewNames: Array.from(document.querySelectorAll('#launchCrewInputs input'))
-      .map(i=>({name:i.value.trim(),kennitala:i.dataset.kennitala||''}))
+    crewNames: Array.from(document.querySelectorAll('#launchCrewInputs input[type="text"]'))
+      .map(function(i){var cb=document.querySelector('.crew-student-toggle[data-crew-idx="'+i.dataset.crewIdx+'"]');return{name:i.value.trim(),kennitala:i.dataset.kennitala||'',student:cb?cb.checked:false};})
       .filter(c=>c.name),
     departurePort: (document.getElementById('launchDeparturePort')?.value||'').trim(),
   };
@@ -503,15 +503,24 @@ function renderCrewInputs() {
   wrap.innerHTML='';
   for(let i=0;i<n;i++){
     const row=document.createElement('div'); row.style.cssText='position:relative;margin-bottom:6px';
+    const inputRow=document.createElement('div'); inputRow.style.cssText='display:flex;align-items:center;gap:6px';
     const inp=document.createElement('input');
     inp.type='text'; inp.placeholder='Crew member '+(i+1)+' name…'; inp.value=existing[i]||'';
     inp.dataset.crewIdx=i;
-    inp.style.cssText='width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:6px 8px';
+    inp.style.cssText='flex:1;min-width:0;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:6px 8px';
+    const stuLabel=document.createElement('label');
+    stuLabel.style.cssText='display:flex;align-items:center;gap:3px;font-size:9px;color:var(--muted);white-space:nowrap;cursor:pointer;flex-shrink:0';
+    const stuCb=document.createElement('input');
+    stuCb.type='checkbox'; stuCb.className='crew-student-toggle'; stuCb.dataset.crewIdx=i;
+    stuCb.style.cssText='width:13px;height:13px;accent-color:var(--brass)';
+    stuLabel.appendChild(stuCb);
+    stuLabel.appendChild(document.createTextNode(getLang()==='IS'?'Nemi':'Student'));
     const drop=document.createElement('div'); drop.id='crewDrop'+i;
     drop.style.cssText='position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 6px 6px;z-index:100;max-height:160px;overflow-y:auto;display:none';
     inp.addEventListener('input',function(){searchCrewMembers(this,drop);});
     inp.addEventListener('blur', function(){setTimeout(()=>{drop.style.display='none';},200);});
-    row.appendChild(inp); row.appendChild(drop); wrap.appendChild(row);
+    inputRow.appendChild(inp); inputRow.appendChild(stuLabel);
+    row.appendChild(inputRow); row.appendChild(drop); wrap.appendChild(row);
   }
 }
 function searchCrewMembers(inp,drop) {
@@ -584,6 +593,20 @@ async function submitLaunch() {
           role:'crew', wxSnapshot:snap,
         }).catch(function(e2){console.warn('crew confirmation:',cn,e2.message);});
       }));
+      // Create student confirmations for crew marked as student
+      var studentCrew=crewNames.filter(function(cn){return cn.student&&cn.kennitala;});
+      if(studentCrew.length){
+        await Promise.all(studentCrew.map(function(cn){
+          return apiPost('createConfirmation',{
+            type:'student',
+            fromKennitala:user.kennitala, fromName:user.name,
+            toKennitala:cn.kennitala, toName:cn.name,
+            linkedCheckoutId:_coId,
+            boatId:launchBoat.id, boatName:launchBoat.name, boatCategory:launchBoat.category||'',
+            date:new Date().toISOString().slice(0,10), timeOut:tout,
+          }).catch(function(e2){console.warn('student confirmation:',cn,e2.message);});
+        }));
+      }
     }
     window._launchFormValues=null;
     closeModal('launchModal'); renderActiveCheckouts(); renderFleetByCat();
@@ -777,7 +800,7 @@ function renderLandingChecklist() {
       '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--red);border-color:var(--red)55" onclick="openInlineReport(\'incident\')">&#128680; '+(IS?'Tilkynna atvik':'Report incident')+'</button>'+
     '</div>'+
     '<div id="reportFlagNote" style="display:none;font-size:11px;padding:5px 8px;border-radius:4px;background:var(--surface);margin-bottom:8px"></div>'+
-    ((returnCo.crew||1)>1?'<div id="helmSection" style="margin-bottom:14px">'+
+    (((returnCo.crew||1)>1&&/^(keelboat|dinghy)$/.test((returnCo.boatCategory||'').toLowerCase()))?'<div id="helmSection" style="margin-bottom:14px">'+
       '<div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:8px">'+(IS?'STÝRI':'HELM')+'</div>'+
       '<div id="helmToggles">'+
         '<label style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
@@ -786,6 +809,10 @@ function renderLandingChecklist() {
         '</label>'+
         '<div id="helmCrewToggles" style="color:var(--muted);font-size:11px;padding:4px 0">'+(IS?'Hleður áhöfn…':'Loading crew…')+'</div>'+
       '</div>'+
+    '</div>':'')+
+    ((returnCo.crew||1)>1?'<div id="studentSection" style="margin-bottom:14px">'+
+      '<div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:8px">'+(IS?'NEMAR':'STUDENTS')+'</div>'+
+      '<div id="studentToggles" style="color:var(--muted);font-size:11px;padding:4px 0">'+(IS?'Hleður áhöfn…':'Loading crew…')+'</div>'+
     '</div>':'')+
     portDistRow+uploadRow+distStandaloneRow+
     '<div class="field" style="margin-bottom:14px">'+
@@ -807,18 +834,31 @@ function renderLandingChecklist() {
 
 function _renderHelmSection(){
   var el=document.getElementById('helmCrewToggles');
-  if(!el) return;
   var IS=getLang()==='IS';
   var entries=window._retCrewTrips||[];
-  if(!entries.length){el.textContent=IS?'Engin nefnd áhöfn':'No named crew';return;}
   var mems=window._launchMembers||[];
-  el.innerHTML=entries.map(function(t){
-    var mem=mems.find(function(m){return String(m.kennitala)===String(t.kennitala);});
-    var gTag=(mem&&mem.role==='guest')?' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:4px">'+(IS?'Gestur':'Guest')+'</span>':'';
-    return '<label style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
-      '<input type="checkbox" class="helm-toggle" data-helm-kt="'+esc(t.kennitala||'')+'" data-helm-name="'+esc(t.memberName||'')+'" style="width:16px;height:16px;accent-color:var(--brass)">'+
-      '<span>'+esc(t.memberName||'?')+gTag+'</span></label>';
-  }).join('');
+  if(el){
+    if(!entries.length){el.textContent=IS?'Engin nefnd áhöfn':'No named crew';}
+    else{el.innerHTML=entries.map(function(t){
+      var mem=mems.find(function(m){return String(m.kennitala)===String(t.kennitala);});
+      var gTag=(mem&&mem.role==='guest')?' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:4px">'+(IS?'Gestur':'Guest')+'</span>':'';
+      return '<label style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
+        '<input type="checkbox" class="helm-toggle" data-helm-kt="'+esc(t.kennitala||'')+'" data-helm-name="'+esc(t.memberName||'')+'" style="width:16px;height:16px;accent-color:var(--brass)">'+
+        '<span>'+esc(t.memberName||'?')+gTag+'</span></label>';
+    }).join('');}
+  }
+  // Also render student toggles
+  var stuEl=document.getElementById('studentToggles');
+  if(stuEl){
+    if(!entries.length){stuEl.textContent=IS?'Engin nefnd áhöfn':'No named crew';}
+    else{stuEl.innerHTML=entries.map(function(t){
+      var mem=mems.find(function(m){return String(m.kennitala)===String(t.kennitala);});
+      var gTag=(mem&&mem.role==='guest')?' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:4px">'+(IS?'Gestur':'Guest')+'</span>':'';
+      return '<label style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)44;cursor:pointer;font-size:13px">'+
+        '<input type="checkbox" class="student-toggle" data-stu-kt="'+esc(t.kennitala||'')+'" data-stu-name="'+esc(t.memberName||'')+'" style="width:16px;height:16px;accent-color:var(--brass)">'+
+        '<span>'+esc(t.memberName||'?')+gTag+'</span></label>';
+    }).join('');}
+  }
 }
 
 function _handleRetTrack(input){
@@ -999,6 +1039,21 @@ async function confirmCheckIn(coId) {
       }).catch(function(){}));
     });
     if(helmRequests.length) await Promise.all(helmRequests);
+    // Create student confirmation requests for crew members
+    var studentRequests=[];
+    document.querySelectorAll('.student-toggle').forEach(function(cb){
+      if(!cb.checked) return;
+      studentRequests.push(apiPost('createConfirmation',{
+        type:'student',
+        fromKennitala:user.kennitala, fromName:user.name,
+        toKennitala:cb.dataset.stuKt||'',
+        toName:cb.dataset.stuName||'',
+        linkedCheckoutId:coId,
+        boatId:co.boatId, boatName:co.boatName, boatCategory:co.boatCategory||'',
+        date:today,
+      }).catch(function(){}));
+    });
+    if(studentRequests.length) await Promise.all(studentRequests);
     window._retCrewTrips=[]; window._retCrewTripsFetched=false;
     checkouts=checkouts.filter(function(c){return c.id!==coId;});
     closeModal('returnModal'); renderActiveCheckouts(); renderFleetByCat();


### PR DESCRIPTION
…on grouping

- Restrict helm option to keelboats and dinghies only in return modal
- Move crew names and helm info to always-visible section in trip card details
- Add Student badge toggle when naming crew at checkout and at check-in
- Implement student confirmation handshake protocol in backend (code.gs)
- Display student badges in trip cards (card face + crew names in expanded view)
- Group all confirmations for a given trip into a single card with individual confirm/reject buttons for cleaner UI

https://claude.ai/code/session_01Bq7fFVHWdtpnFCSgGqqHZK