### PR TITLE
Add responsive mobile styles for all pages

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -110,6 +110,20 @@
       border:1px solid #f1c40f44; border-radius:3px; padding:1px 5px; }
     .oos-badge   { font-size:10px; background:var(--red)22; color:var(--red);
       border:1px solid var(--red)44; border-radius:3px; padding:1px 5px; }
+
+    /* ── Responsive ── */
+    @media(max-width:600px){
+      .tab-btn{padding:8px 10px;font-size:10px;letter-spacing:.5px}
+      .member-kt{width:auto}
+      .cl-phase{width:40px;font-size:9px}
+      .col-hint-field{width:auto}
+      .col-hint-row{flex-direction:column;gap:2px}
+      .boat-grid{grid-template-columns:repeat(auto-fill,minmax(140px,1fr))}
+      .boat-card-actions{flex-wrap:wrap}
+      .import-ambig{flex-direction:column;gap:6px}
+      .col-body{padding:10px 12px}
+      .search-bar{min-width:0!important}
+    }
   </style>
 </head>
 <body>

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -104,6 +104,15 @@
 .dl-drow:last-child { border-bottom:none; }
 .dl-dlbl { font-size:9px; color:var(--muted); letter-spacing:.8px; width:90px; flex-shrink:0; padding-top:2px; }
 .dl-dval { flex:1; color:var(--text); }
+
+/* ── Responsive ── */
+@media(max-width:600px){
+  .wx-snap-grid{grid-template-columns:1fr}
+  .save-bar{padding:8px 12px}
+  .dl-drow{flex-direction:column;gap:2px}
+  .dl-dlbl{width:auto;padding-top:0}
+  .incident-btn{padding:10px 12px}
+}
 </style>
 </head>
 <body>

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -43,6 +43,12 @@
     .note-meta  { color:var(--muted); font-size:11px; margin-top:3px; }
 
     .page { max-width:720px; margin:0 auto; padding:16px 16px 60px; }
+
+    /* ── Responsive ── */
+    @media(max-width:600px){
+      .page{padding:12px 12px 60px}
+      .incident-row{padding:10px 0}
+    }
   </style>
 </head>
 <body>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -180,6 +180,33 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .photo-sharing-badge.shared{color:var(--green);border:1px solid var(--green)55;background:var(--green)11}
 .photo-sharing-badge.private{color:var(--muted);border:1px solid var(--border);background:var(--surface)}
 .photo-sharing-badge.club{color:var(--brass);border:1px solid var(--brass)55;background:var(--brass)11}
+
+/* ── Responsive ── */
+@media(max-width:600px){
+  .page{padding:16px 12px 60px}
+  .stat-strip{grid-template-columns:repeat(2,1fr)}
+  .filter-bar{grid-template-columns:1fr 1fr}
+  .trip-expand-grid{grid-template-columns:1fr 1fr}
+  .form-row{grid-template-columns:1fr}
+  .wx-row{grid-template-columns:1fr 1fr}
+  .modal-sheet{border-radius:14px 14px 0 0;padding:16px 14px 32px;max-height:95vh}
+  .upload-thumb-wrap,.upload-thumb-wrap .photo-thumb{width:56px;height:56px}
+  .photo-thumb{width:48px;height:48px}
+  .photo-thumb-link{width:48px;height:48px}
+  .gm-row{grid-template-columns:1fr}
+  .trip-card-main{grid-template-columns:44px 1fr auto}
+  .trip-date-col{padding:8px 4px}
+  .trip-date-day{font-size:14px}
+  .trip-date-mon{font-size:12px}
+  .trip-body{padding:8px 10px}
+  .lightbox-nav{padding:6px 10px;font-size:20px}
+}
+@media(max-width:400px){
+  .stat-strip{grid-template-columns:1fr 1fr}
+  .filter-bar{grid-template-columns:1fr}
+  .trip-expand-grid{grid-template-columns:1fr}
+  .wx-row{grid-template-columns:1fr}
+}
 </style>
 </head>
 <body>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -118,6 +118,13 @@
       display:flex; align-items:center; justify-content:center; cursor:pointer; }
     .photo-overlay.hidden { display:none; }
     .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:8px; }
+
+    /* ── Responsive ── */
+    @media(max-width:600px){
+      .filter-group-label{min-width:0;width:100%}
+      .filter-btn{padding:6px 10px;font-size:10px}
+      .req-card{padding:12px}
+    }
   </style>
 </head>
 <body>

--- a/member/index.html
+++ b/member/index.html
@@ -126,6 +126,15 @@
 .conf-badge { display:inline-flex; align-items:center; justify-content:center;
   min-width:16px; height:16px; border-radius:8px; background:var(--red);
   color:#fff; font-size:9px; font-weight:600; margin-left:4px; padding:0 4px; }
+
+/* ── Responsive ── */
+@media(max-width:600px){
+  .fsb-bar-wrap{flex:1;width:auto}
+  .ir-type-grid{grid-template-columns:1fr}
+  .member-actions .act-btn{min-width:70px;padding:8px 8px;font-size:10px}
+  .pub-trip{padding:10px 12px}
+  .stat-box .sn{font-size:20px}
+}
 </style>
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -115,6 +115,7 @@ footer{text-align:center;padding:16px 20px;font-size:10px;color:var(--muted);bor
   #map-container{height:260px}
   .captain-grid{grid-template-columns:1fr}
   .subtitle{display:none}
+  .water-grid{grid-template-columns:1fr}
 }
 </style>
 </head>

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -97,6 +97,11 @@
       display:flex; align-items:center; justify-content:center; cursor:pointer; }
     .photo-overlay.hidden { display:none; }
     .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:8px; }
+
+    /* ── Responsive ── */
+    @media(max-width:600px){
+      .cat-btns .cat-btn{min-width:60px;padding:6px 4px;font-size:10px}
+    }
   </style>
 </head>
 <body>

--- a/shared/style.css
+++ b/shared/style.css
@@ -724,3 +724,88 @@ textarea { min-height: 70px; }
 .cfg-line-hdr{display:grid;grid-template-columns:1fr 1fr 80px 80px 28px;gap:6px;font-size:9px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:4px}
 .cfg-ot-row{display:grid;grid-template-columns:2fr 70px 70px 70px 28px;gap:6px;align-items:center;margin-bottom:4px;font-size:11px}
 .cfg-ot-hdr{display:grid;grid-template-columns:2fr 70px 70px 70px 28px;gap:6px;font-size:9px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4pxerit;display:block}
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   RESPONSIVE — Mobile (≤ 600px)
+   ══════════════════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 600px) {
+  /* ── Header ── */
+  header { padding: 10px 12px; gap: 8px; }
+  .logo { font-size: 15px; }
+  .hbtn { padding: 6px 8px; font-size: 11px; }
+  .header-left { gap: 8px; }
+  .header-right { gap: 6px; }
+  .page-title { font-size: 11px; padding-left: 8px; }
+
+  /* ── Layout ── */
+  main { padding: 16px 12px; }
+  .page-content { padding: 12px 12px 80px; }
+
+  /* ── Cards ── */
+  .card { padding: 14px 12px; }
+
+  /* ── Buttons — touch-friendly ── */
+  .btn { min-height: 44px; padding: 10px 16px; }
+  .btn-row .btn { flex: 1 1 auto; min-width: 0; }
+  .btn-ghost { min-height: 36px; }
+
+  /* ── Forms — touch-friendly ── */
+  input[type=text], input[type=number], input[type=email],
+  input[type=tel], input[type=date], input[type=time],
+  input[type=password], input[type=file], select, textarea {
+    padding: 10px 12px; font-size: 16px;
+  }
+
+  /* ── Modals ── */
+  .modal-overlay { padding: 10px; align-items: flex-end; }
+  .modal { max-width: 100%; border-radius: 14px 14px 0 0; padding: 20px 16px; max-height: 90vh; }
+
+  /* ── Tables — horizontal scroll ── */
+  .tbl-wrap { margin: 0 -12px; padding: 0 12px; }
+  .tbl { font-size: 12px; }
+  .tbl th, .tbl td { padding: 8px 8px; }
+
+  /* ── Payroll ── */
+  .cal-cell { min-height: 52px; padding: 3px; }
+  .cal-pill { font-size: 9px; padding: 1px 4px; }
+  .cal-day-num { font-size: 10px; }
+  .cal-dows { gap: 1px; }
+  .cal-days { gap: 1px; }
+  .cal-month { font-size: 13px; min-width: 120px; }
+
+  .cfg-line-row, .cfg-line-hdr { grid-template-columns: 1fr 1fr 60px 60px 28px; gap: 4px; }
+  .cfg-ot-row, .cfg-ot-hdr { grid-template-columns: 1fr 50px 50px 50px 28px; gap: 4px; }
+  .emp-row { gap: 8px; }
+  .emp-name { min-width: 0; }
+  .emp-kt { width: auto; }
+  .emp-fields { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+
+  .ts-table, .psc-table, .lm-table { font-size: 11px; }
+  .ts-table th, .ts-table td,
+  .psc-table th, .psc-table td,
+  .lm-table th, .lm-table td { padding: 4px 6px; }
+
+  .psc-samtolur-grid { grid-template-columns: 1fr auto auto; gap: 2px 10px; font-size: 11px; }
+  .psc-hrs input { width: 48px; }
+  .modal-box { min-width: 0; width: 95vw; max-width: 95vw; padding: 18px 16px; }
+  .confirm-emp { min-width: 0; }
+  .ml-row { grid-template-columns: 1fr 1fr 60px 28px; gap: 4px; }
+  .period-filter-card { gap: 4px; }
+
+  /* ── Utility adjustments ── */
+  .detail-field-label { font-size: 9px; }
+  .section-heading { margin: 16px 0 8px; }
+  .info-panel { padding: 12px; }
+  .input-row { flex-wrap: wrap; }
+}
+
+@media (max-width: 400px) {
+  .grid2, .grid3 { gap: 10px; }
+  .btn-row { gap: 6px; }
+  .card { padding: 12px 10px; }
+  header { padding: 8px 10px; }
+  .hbtn { padding: 5px 6px; font-size: 10px; }
+  main { padding: 12px 10px; }
+  .page-content { padding: 10px 10px 80px; }
+}

--- a/staff/index.html
+++ b/staff/index.html
@@ -238,6 +238,30 @@ border-bottom:1px solid var(--border)44; }
 .dl-act-card.selected{border-color:var(--brass);background:var(--card)}
 .dl-act-name{font-size:13px;font-weight:500}
 .dl-act-meta{font-size:11px;color:var(--muted);margin-top:2px}
+
+/* ── Responsive ── */
+@media(max-width:600px){
+  .nav-grid{grid-template-columns:1fr}
+  .stat-row{grid-template-columns:repeat(2,1fr)}
+  .inline-fields{grid-template-columns:1fr}
+  .recent-row{display:flex;flex-wrap:wrap;gap:4px 8px;font-size:11px}
+  .recent-header{display:none}
+  .recent-time{min-width:42px}
+  .recent-name,.recent-boat,.recent-loc{min-width:0;overflow:hidden;text-overflow:ellipsis}
+  .recent-dur{margin-left:auto}
+  .dl-drow{flex-direction:column;gap:2px}
+  .dl-dlbl{width:auto;padding-top:0}
+  .gm-row{grid-template-columns:1fr}
+  .ob-alert{padding:10px 12px;gap:10px}
+  .ob-title{font-size:13px}
+  .ob-meta{font-size:11px}
+  .group-modal-sheet{padding:16px 14px 28px}
+  .guest-modal{width:95%;padding:16px}
+}
+@media(max-width:400px){
+  .stat-row{grid-template-columns:1fr}
+  .nav-card{padding:12px 10px}
+}
 </style>
 </head>
 <body>

--- a/weather/index.html
+++ b/weather/index.html
@@ -100,6 +100,10 @@ svg.chart { width:100%; overflow:visible; display:block; }
   .info-3 { grid-template-columns:1fr 1fr; }
   .wind-ms, .dir-arrow { font-size:40px; }
 }
+@media(max-width:600px){
+  .wind-cols{flex-direction:column}
+  .hourly-strip{gap:10px}
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
Add comprehensive mobile breakpoints (600px, 400px) to shared/style.css and page-specific responsive rules to all 11 page files. Key changes:
- Header: tighter spacing, smaller buttons on mobile
- Grids: collapse multi-column layouts to fewer/single columns
- Forms: 16px font-size for iOS zoom prevention, touch-friendly sizing
- Modals: full-width bottom sheets on mobile
- Tables: reduced padding, payroll tables scroll horizontally
- Cards: reduced padding for more content space

Closes #84

https://claude.ai/code/session_01FofqAuTGSsgDwDXgZbFNis