### PR TITLE
Fix admin settings tab not showing submenu content

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1019,9 +1019,13 @@ function showTopTab(top) {
   });
   document.getElementById('top-members').classList.toggle('hidden', top !== 'members');
   document.getElementById('top-settings').classList.toggle('hidden', top !== 'settings');
+  if (top === 'settings') {
+    const active = document.querySelector('#settingsTabBar .tab-btn.active');
+    showTab(active ? active.dataset.tab : 'boats');
+  }
   const url = new URL(window.location.href);
   url.searchParams.set('top', top);
-  url.searchParams.delete('tab');
+  if (top !== 'settings') url.searchParams.delete('tab');
   history.replaceState(null, '', url);
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }


### PR DESCRIPTION
When clicking the Settings top-level tab, showTopTab() revealed the settings container but never called showTab() to unhide the active sub-tab content. All sub-tab divs start hidden, so nothing appeared.

https://claude.ai/code/session_01PmFbAkPkbyS2bXge5msm1g