### PR TITLE
Add unit-aware manual weather entry with Beaufort support

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1458,8 +1458,10 @@ function saveCheckout_(b) {
   if (b.wxSnapshot) {
     try {
       const w = typeof b.wxSnapshot === 'string' ? JSON.parse(b.wxSnapshot) : b.wxSnapshot;
+      // ws may be a range string like "5.5-8.0" from Beaufort-only entries — preserve as-is
+      var wsVal = (typeof w.ws === 'string' && w.ws.indexOf('-') !== -1) ? w.ws : (w.ws != null ? Math.round(w.ws) : 0);
       wxSnap = JSON.stringify({
-        bft: Math.round(w.bft || 0), ws: Math.round(w.ws || 0), wg: Math.round(w.wg || 0),
+        bft: Math.round(w.bft || 0), ws: wsVal, wg: Math.round(w.wg || 0),
         dir: w.dir || w.wDir || '',
         wv: w.wv != null ? parseFloat(w.wv.toFixed ? w.wv.toFixed(1) : w.wv) : (w.waveH != null ? parseFloat(parseFloat(w.waveH).toFixed(1)) : null),
         flag: w.flag || w.flagKey || '',
@@ -1491,8 +1493,9 @@ function saveGroupCheckout_(b) {
   if (b.wxSnapshot) {
     try {
       const w = typeof b.wxSnapshot === 'string' ? JSON.parse(b.wxSnapshot) : b.wxSnapshot;
+      var wsVal2 = (typeof w.ws === 'string' && w.ws.indexOf('-') !== -1) ? w.ws : (w.ws != null ? Math.round(w.ws) : 0);
       wxSnap = JSON.stringify({
-        bft: Math.round(w.bft||0), ws: Math.round(w.ws||0), wg: Math.round(w.wg||0),
+        bft: Math.round(w.bft||0), ws: wsVal2, wg: Math.round(w.wg||0),
         dir: w.dir||w.wDir||'',
         wv: w.wv != null ? parseFloat(parseFloat(w.wv).toFixed(1)) : null,
         flag: w.flag||'', tc: w.tc != null ? Math.round(w.tc) : null, ts: w.ts||ts.slice(0,16),
@@ -3092,7 +3095,10 @@ function pubTripTableHtml_(trips, allTrips, boats, opts) {
     var hasTopWx = (wx && wx.ws != null) || t.beaufort || (wx && wx.wv != null) || (wx && wx.cond && wx.cond.desc);
     if (hasTopWx) {
       html += '<div class="detail-section"><div class="detail-section-hdr">' + dl_('pub.lbl.weather') + '</div><div class="detail-grid">';
-      if (wx && wx.ws != null) html += '<div class="detail-row"><span class="detail-lbl">' + dl_('pub.lbl.wind') + '</span><span class="detail-val">' + Math.round(wx.ws) + ' m/s' + (wx.bft != null ? ' · Force ' + wx.bft : '') + '</span></div>';
+      if (wx && wx.ws != null) {
+        var wsDisp = (typeof wx.ws === 'string' && wx.ws.indexOf('-') !== -1) ? wx.ws.split('-').map(function(v){return Math.round(v);}).join('–') + ' m/s' : Math.round(wx.ws) + ' m/s';
+        html += '<div class="detail-row"><span class="detail-lbl">' + dl_('pub.lbl.wind') + '</span><span class="detail-val">' + wsDisp + (wx.bft != null ? ' · Force ' + wx.bft : '') + '</span></div>';
+      }
       else if (t.beaufort) html += '<div class="detail-row"><span class="detail-lbl">' + dl_('pub.lbl.wind') + '</span><span class="detail-val">Force ' + esc_(t.beaufort) + '</span></div>';
       if (wx && wx.wv != null) html += '<div class="detail-row"><span class="detail-lbl">' + dl_('pub.lbl.waveHeight') + '</span><span class="detail-val">' + Number(wx.wv).toFixed(1) + ' m</span></div>';
       if (wx && wx.cond && wx.cond.desc) html += '<div class="detail-row"><span class="detail-lbl">' + dl_('pub.lbl.conditions') + '</span><span class="detail-val">' + (wx.cond.icon || '') + ' ' + esc_(wx.cond.desc) + '</span></div>';

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -583,7 +583,7 @@ function renderWxLog() {
     card.className = "wx-snap-card";
     var time = snap.time || (snap.ts ? snap.ts.slice(11,16) : "");
     var cells = [
-      { lbl:"WIND",     val: (snap.dir||"") + " " + (snap.ws!=null ? snap.ws+"m/s · Force "+snap.bft : "—") },
+      { lbl:"WIND",     val: (snap.dir||"") + " " + (snap.ws!=null ? (typeof snap.ws==='string'&&snap.ws.indexOf('-')!==-1?snap.ws.split('-').map(function(v){return Math.round(v);}).join('–'):snap.ws)+"m/s · Force "+snap.bft : "—") },
       { lbl:"GUSTS",    val: (snap.wg!=null && snap.wg!==snap.ws) ? snap.wg+"m/s" : null },
       { lbl:"WAVES",    val: snap.wv!=null ? snap.wv+"m"+(snap.waveDir?" "+snap.waveDir:"") : null },
       { lbl:"SEA TEMP", val: snap.sst!=null ? snap.sst+"°C" : null },

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -415,7 +415,19 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
       <!-- Weather -->
       <div class="section-label" style="margin:12px 0 8px">WEATHER (OPTIONAL)</div>
       <div class="wx-row">
-        <div class="form-field"><label>Wind (m/s)</label><input type="number" id="mWindMs" min="0" step="0.1" placeholder="e.g. 8"></div>
+        <div class="form-field"><label>Beaufort</label>
+          <select id="mBft" onchange="onBftChange()">
+            <option value="">—</option>
+            <option value="0">0 – Calm</option><option value="1">1 – Light air</option>
+            <option value="2">2 – Light breeze</option><option value="3">3 – Gentle</option>
+            <option value="4">4 – Moderate</option><option value="5">5 – Fresh</option>
+            <option value="6">6 – Strong</option><option value="7">7 – Near gale</option>
+            <option value="8">8 – Gale</option><option value="9">9 – Strong gale</option>
+            <option value="10">10 – Storm</option><option value="11">11 – Violent storm</option>
+            <option value="12">12 – Hurricane</option>
+          </select>
+        </div>
+        <div class="form-field"><label id="mWindLabel">Wind (m/s)</label><input type="number" id="mWindMs" min="0" step="0.1" placeholder="e.g. 8" oninput="onWindInput()"></div>
         <div class="form-field"><label>Direction</label>
           <select id="mWindDir">
             <option value="">—</option>
@@ -423,6 +435,9 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
             <option>S</option><option>SW</option><option>W</option><option>NW</option>
           </select>
         </div>
+      </div>
+      <div class="wx-row">
+        <div class="form-field"><label id="mGustLabel">Gusts (m/s)</label><input type="number" id="mWindGust" min="0" step="0.1" placeholder="" oninput="onGustInput()"></div>
         <div class="form-field"><label>Wave ht (m)</label><input type="number" id="mWave" min="0" step="0.1" placeholder="0.0"></div>
       </div>
       <details class="mb-8">
@@ -430,23 +445,12 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
           <span class="exp-chevron" style="font-size:8px">▾</span> More weather details
         </summary>
         <div class="wx-row mt-8">
-          <div class="form-field"><label>Gusts (m/s)</label><input type="number" id="mWindGust" min="0" step="0.1" placeholder=""></div>
           <div class="form-field"><label>Air temp (°C)</label><input type="number" id="mAirTemp" step="0.5" placeholder=""></div>
           <div class="form-field"><label>Feels like (°C)</label><input type="number" id="mFeelsLike" step="0.5" placeholder=""></div>
+          <div class="form-field"><label>Sea temp (°C)</label><input type="number" id="mSeaTemp" step="0.5" placeholder=""></div>
         </div>
         <div class="wx-row">
-          <div class="form-field"><label>Sea temp (°C)</label><input type="number" id="mSeaTemp" step="0.5" placeholder=""></div>
           <div class="form-field"><label>Pressure (hPa)</label><input type="number" id="mPressure" min="900" max="1100" placeholder=""></div>
-          <div class="form-field"><label>Beaufort</label>
-            <select id="mBft">
-              <option value="">—</option>
-              <option value="0">0 – Calm</option><option value="1">1 – Light air</option>
-              <option value="2">2 – Light breeze</option><option value="3">3 – Gentle</option>
-              <option value="4">4 – Moderate</option><option value="5">5 – Fresh</option>
-              <option value="6">6 – Strong</option><option value="7">7 – Near gale</option>
-              <option value="8">8 – Gale</option><option value="9">9+</option>
-            </select>
-          </div>
         </div>
       </details>
       <!-- GPS Track upload -->
@@ -668,7 +672,8 @@ function tripCard(t){
 
   // Expanded wx cells — order: wind speed, direction, gusts, conditions, air temp, feels like, sea temp, wave height, pressure
   const _expWind = formatWindValue(wx?.ws, t.beaufort, _windUnit);
-  const _expExtra = wx?.ws!=null && _windUnit!=='bft' ? ' · Force '+(wx.bft!=null?wx.bft:bftFromMs(wx.ws)) : (_windUnit==='bft' && t.beaufort ? ' <small class="text-muted">'+bftLabel(t.beaufort)+'</small>' : '');
+  const _wsNum = wx?.ws != null ? parseWsValue(wx.ws) : null;
+  const _expExtra = _wsNum!=null && _windUnit!=='bft' ? ' · Force '+(wx.bft!=null?wx.bft:bftFromMs(_wsNum)) : (_windUnit==='bft' && t.beaufort ? ' <small class="text-muted">'+bftLabel(t.beaufort)+'</small>' : '');
   const eWs = _expWind ? `<div class="trip-exp-row"><span class="trip-exp-lbl">Wind speed</span><span class="trip-exp-val">${esc(_expWind)}${_expExtra}</span></div>` : '';
   const eDir  = (wx?.dir||t.windDir) ? `<div class="trip-exp-row"><span class="trip-exp-lbl">Direction</span><span class="trip-exp-val">${dirArrow(wx?.dir||t.windDir)} ${esc(wx?.dir||t.windDir)}</span></div>` : '';
   const eGust = wx?.wg!=null  ? `<div class="trip-exp-row"><span class="trip-exp-lbl">Gusts</span><span class="trip-exp-val">${_windUnit==='bft'?'Force '+bftFromMs(wx.wg):convertWind(wx.wg,_windUnit)+' '+windUnitLabel(_windUnit)}</span></div>` : '';
@@ -1088,6 +1093,8 @@ function showManualForm(){
   document.getElementById('mCrewInputs').innerHTML='';
   document.getElementById('mWindMs').value='';
   document.getElementById('mWindGust').value='';
+  document.getElementById('mBft').value='';
+  initWindUnitLabels();
   document.getElementById('mAirTemp').value='';
   document.getElementById('mFeelsLike').value='';
   document.getElementById('mSeaTemp').value='';
@@ -1096,6 +1103,56 @@ function showManualForm(){
   const pd=document.getElementById('portDetails');
   pd.removeAttribute('open');
   onBoatChange();
+}
+
+// ── Wind unit + Beaufort sync helpers ────────────────────────────────────────
+// Determine the numeric wind unit for manual inputs (bft pref → default to m/s for inputs)
+let _mWindUnit = (function(){ var p = getPref('windUnit','bft'); return p === 'bft' ? 'ms' : p; })();
+let _bftSyncing = false; // prevent circular updates
+
+function initWindUnitLabels(){
+  const pref = getPref('windUnit', 'bft');
+  // For input fields we use a numeric unit; if pref is 'bft', default inputs to m/s
+  _mWindUnit = (pref === 'bft') ? 'ms' : pref;
+  const label = windUnitLabel(_mWindUnit);
+  document.getElementById('mWindLabel').textContent = 'Wind (' + label + ')';
+  document.getElementById('mGustLabel').textContent = 'Gusts (' + label + ')';
+  // Adjust step for knots/kmh/mph (whole numbers more common)
+  const step = (_mWindUnit === 'ms') ? '0.1' : '0.1';
+  document.getElementById('mWindMs').step = step;
+  document.getElementById('mWindGust').step = step;
+}
+
+function onBftChange(){
+  if(_bftSyncing) return;
+  _bftSyncing = true;
+  const bft = document.getElementById('mBft').value;
+  const windEl = document.getElementById('mWindMs');
+  if(bft !== ''){
+    // Auto-fill wind speed with midpoint of Beaufort range, in user's unit
+    const midMs = bftToMsMid(parseInt(bft));
+    if(midMs != null && !windEl.value){
+      windEl.value = convertWind(midMs, _mWindUnit);
+    }
+  }
+  _bftSyncing = false;
+}
+
+function onWindInput(){
+  if(_bftSyncing) return;
+  _bftSyncing = true;
+  const val = parseFloat(document.getElementById('mWindMs').value);
+  if(!isNaN(val)){
+    const ms = convertToMs(val, _mWindUnit);
+    document.getElementById('mBft').value = bftFromMs(ms);
+  } else {
+    document.getElementById('mBft').value = '';
+  }
+  _bftSyncing = false;
+}
+
+function onGustInput(){
+  // No auto-sync needed for gusts, but placeholder for future use
 }
 
 function populatePortsDatalist(){
@@ -1422,8 +1479,11 @@ async function submitManual(){
   const bft       = document.getElementById('mBft').value;
   const wdir      = document.getElementById('mWindDir').value;
   const wave      = document.getElementById('mWave').value;
-  const windMs    = document.getElementById('mWindMs').value;
-  const windGust  = document.getElementById('mWindGust').value;
+  const windRaw   = document.getElementById('mWindMs').value;
+  const gustRaw   = document.getElementById('mWindGust').value;
+  // Convert from user's display unit back to m/s for storage
+  const windMs    = windRaw ? convertToMs(parseFloat(windRaw), _mWindUnit).toFixed(1) : '';
+  const windGust  = gustRaw ? convertToMs(parseFloat(gustRaw), _mWindUnit).toFixed(1) : '';
   const airTemp   = document.getElementById('mAirTemp').value;
   const feelsLike = document.getElementById('mFeelsLike').value;
   const seaTemp   = document.getElementById('mSeaTemp').value;
@@ -1469,10 +1529,17 @@ async function submitManual(){
     hoursDecimal=+(mins/60).toFixed(2);
   }
 
-  // Build wxSnapshot from all weather fields
+  // Build wxSnapshot from all weather fields (always stored in m/s)
   let wxSnapshot='';
   const wxObj={};
-  if(windMs)    wxObj.ws=parseFloat(windMs)||0;
+  if(bft)       wxObj.bft=parseInt(bft);
+  if(windMs){
+    wxObj.ws=parseFloat(windMs)||0;
+  } else if(bft){
+    // Beaufort-only: save m/s range so it can be converted to other units
+    const range=bftToMsRange(parseInt(bft));
+    if(range) wxObj.ws=range[0]+'-'+range[1];
+  }
   if(wdir)      wxObj.dir=wdir;
   if(windGust)  wxObj.wg=parseFloat(windGust)||0;
   if(wave)      wxObj.wv=parseFloat(wave)||0;
@@ -1480,7 +1547,6 @@ async function submitManual(){
   if(feelsLike) wxObj.feels=parseFloat(feelsLike);
   if(seaTemp)   wxObj.sst=parseFloat(seaTemp);
   if(pressure)  wxObj.pres=parseFloat(pressure);
-  if(bft)       wxObj.bft=parseInt(bft);
   if(Object.keys(wxObj).length) wxSnapshot=JSON.stringify(wxObj);
 
   // Disable submit while uploading
@@ -2113,7 +2179,11 @@ function openEditTrip(tripId) {
   });
   // Weather
   let wx = null; try { wx = t.wxSnapshot ? JSON.parse(t.wxSnapshot) : null; } catch(e) {}
-  document.getElementById('etWindMs').value = wx?.ws ?? '';
+  // Display wind in user's preferred unit; parse range values to midpoint
+  const etWsRaw = wx?.ws;
+  const etWsMs = etWsRaw != null ? parseWsValue(etWsRaw) : null;
+  document.getElementById('etWindMs').value = etWsMs != null ? convertWind(etWsMs, _mWindUnit) : '';
+  document.getElementById('etWindLabel').textContent = 'Wind (' + windUnitLabel(_mWindUnit) + ')';
   document.getElementById('etWindDir').value = wx?.dir || t.windDir || '';
   document.getElementById('etBft').value = wx?.bft ?? t.beaufort ?? '';
   document.getElementById('etErr').style.display = 'none';
@@ -2148,8 +2218,9 @@ async function submitEditTrip() {
   let arrPort = document.getElementById('etArrivalPort').value.trim();
   if (!arrPort && depPort) arrPort = depPort;
   const skipperNote = document.getElementById('etSkipperNote').value.trim();
-  // Weather
-  const windMs = document.getElementById('etWindMs').value.trim();
+  // Weather — convert from user's unit to m/s
+  const windRaw = document.getElementById('etWindMs').value.trim();
+  const windMsVal = windRaw ? convertToMs(parseFloat(windRaw), _mWindUnit) : null;
   const windDir = document.getElementById('etWindDir').value;
   const bft = document.getElementById('etBft').value;
   // Validate
@@ -2169,9 +2240,14 @@ async function submitEditTrip() {
   // Build wx
   let wxSnapshot = '';
   const wxObj = {};
-  if (windMs) wxObj.ws = parseFloat(windMs) || 0;
-  if (windDir) wxObj.dir = windDir;
   if (bft) wxObj.bft = parseInt(bft);
+  if (windMsVal != null && !isNaN(windMsVal)) {
+    wxObj.ws = +windMsVal.toFixed(1);
+  } else if (bft) {
+    const range = bftToMsRange(parseInt(bft));
+    if (range) wxObj.ws = range[0] + '-' + range[1];
+  }
+  if (windDir) wxObj.dir = windDir;
   if (Object.keys(wxObj).length) wxSnapshot = JSON.stringify(wxObj);
 
   const btn = document.getElementById('etSubmitBtn');
@@ -2349,7 +2425,7 @@ setTimeout(loadConfirmations,1500);
     </div>
     <div class="section-label" style="margin:12px 0 8px">WEATHER</div>
     <div class="wx-row">
-      <div class="form-field"><label>Wind (m/s)</label><input type="number" id="etWindMs" min="0" step="0.1"></div>
+      <div class="form-field"><label id="etWindLabel">Wind (m/s)</label><input type="number" id="etWindMs" min="0" step="0.1"></div>
       <div class="form-field"><label>Direction</label>
         <select id="etWindDir"><option value="">—</option>
           <option>N</option><option>NE</option><option>E</option><option>SE</option>

--- a/member/index.html
+++ b/member/index.html
@@ -640,7 +640,7 @@ function _wxSnapHtml(snap) {
   var dir=snap.dir||snap.wDir||"", wv=snap.wv!=null?snap.wv:snap.waveH, tc=snap.tc!=null?snap.tc:snap.airT, feels=snap.feels!=null?snap.feels:snap.apparentT;
   var fi={green:"🟢",yellow:"🟡",orange:"🟠",red:"🔴"}, rows=[];
   if(snap.flag)           rows.push([fi[snap.flag]||"",snap.flag.toUpperCase()]);
-  if(snap.bft!=null)      rows.push(["💨",dir+" "+(snap.ws!=null?snap.ws+"m/s ":"")+"Force "+snap.bft+(snap.wg!=null?" (gusts "+snap.wg+"m/s)":"")]);
+  if(snap.bft!=null){var wsStr=snap.ws!=null?(typeof snap.ws==='string'&&snap.ws.indexOf('-')!==-1?snap.ws.split('-').map(function(v){return Math.round(v);}).join('–')+'m/s ':snap.ws+'m/s '):'';rows.push(["💨",dir+" "+wsStr+"Force "+snap.bft+(snap.wg!=null?" (gusts "+snap.wg+"m/s)":"")]);}
   if(wv!=null)            rows.push(["🌊",wv+"m"+(snap.waveDir?" "+snap.waveDir:"")]);
   if(tc!=null)            rows.push(["🌡",tc+"°C"+(feels!=null?" / feels "+feels+"°C":"")]);
   if(snap.sst!=null)      rows.push(["🌊","Sea "+snap.sst+"°C"]);
@@ -649,6 +649,9 @@ function _wxSnapHtml(snap) {
   if(!rows.length)        rows.push(["","No detail available"]);
   return rows.map(r=>'<div class="flex-center gap-6 text-sm" style="padding:2px 0"><span style="width:16px;flex-shrink:0;text-align:center">'+r[0]+'</span><span style="color:var(--text)">'+esc(String(r[1]).trim())+'</span></div>').join('');
 }
+// Preferred wind unit for manual entry (non-bft → use directly; bft → default to m/s)
+var _retWindUnit = (function(){ var p = getPref('windUnit','bft'); return p === 'bft' ? 'ms' : p; })();
+
 function _updateWxDisplay() {
   var sel=document.querySelector('[name="wxChoice"]:checked'), choice=sel?sel.value:"checkout";
   var panel=document.getElementById("wxDetailPanel"), snap=null;
@@ -657,7 +660,8 @@ function _updateWxDisplay() {
   else if(choice==="manual"){
     var gn=id=>{var el=document.getElementById(id);return el&&el.value!==""?parseFloat(el.value):null;};
     var gs=id=>{var el=document.getElementById(id);return el?el.value.trim():"";};
-    snap={bft:gn("manBft"),dir:gs("manDir"),ws:gn("manWs"),wg:gn("manWg"),wv:gn("manWv"),waveDir:gs("manWaveDir"),tc:gn("manTc"),feels:gn("manFeels"),pres:gn("manPres"),sst:gn("manSst"),flag:null,cond:null};
+    var rawWs=gn("manWs"),rawWg=gn("manWg");
+    snap={bft:gn("manBft"),dir:gs("manDir"),ws:rawWs!=null?+convertToMs(rawWs,_retWindUnit).toFixed(1):null,wg:rawWg!=null?+convertToMs(rawWg,_retWindUnit).toFixed(1):null,wv:gn("manWv"),waveDir:gs("manWaveDir"),tc:gn("manTc"),feels:gn("manFeels"),pres:gn("manPres"),sst:gn("manSst"),flag:null,cond:null};
   }
   if(panel) panel.innerHTML=_wxSnapHtml(snap);
   var mf=document.getElementById("wxManualFields"); if(mf) mf.style.display=choice==="manual"?"grid":"none";
@@ -670,7 +674,7 @@ function renderReturnForm() {
   var nowSnap=currentWx?wxSnapshot(currentWx):null;
   if(coSnap&&nowSnap){["waveDir","sst","feels","pres","presTrend","cond"].forEach(k=>{if(coSnap[k]==null&&nowSnap[k]!=null)coSnap[k]=nowSnap[k];});}
   window._retCoSnap=coSnap; window._retTimeIn=null; window._retWxSnap=null;
-  function shortDesc(sn){if(!sn)return'No data';var d=sn.dir||sn.wDir||'',w=sn.ws!=null?sn.ws+'m/s ':'';return(d+' '+w+'Force '+(sn.bft||'?')).trim();}
+  function shortDesc(sn){if(!sn)return'No data';var d=sn.dir||sn.wDir||'',wsv=sn.ws,w='';if(wsv!=null){w=(typeof wsv==='string'&&wsv.indexOf('-')!==-1)?wsv.split('-').map(function(v){return Math.round(v);}).join('–')+'m/s ':wsv+'m/s ';}return(d+' '+w+'Force '+(sn.bft||'?')).trim();}
   var def=coSnap?'checkout':nowSnap?'now':'manual';
   var coR=coSnap?'<label style="display:flex;align-items:flex-start;gap:8px;cursor:pointer;font-size:12px"><input type="radio" name="wxChoice" value="checkout" '+(def==='checkout'?'checked':'')+' style="margin-top:2px;accent-color:var(--brass)" onchange="_updateWxDisplay()"><span><b>At launch:</b> '+esc(shortDesc(coSnap))+'</span></label>':'';
   var nowR=nowSnap?'<label style="display:flex;align-items:flex-start;gap:8px;cursor:pointer;font-size:12px"><input type="radio" name="wxChoice" value="now" '+(def==='now'?'checked':'')+' style="margin-top:2px;accent-color:var(--brass)" onchange="_updateWxDisplay()"><span><b>Current:</b> '+esc(shortDesc(nowSnap))+'</span></label>':'';
@@ -678,8 +682,8 @@ function renderReturnForm() {
   var manF='<div id="wxManualFields" style="display:'+(def==='manual'?'grid':'none')+';grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">'
     +'<div class="field"><label>Force (0-12)</label><input type="number" id="manBft" min="0" max="12" oninput="_updateWxDisplay()"></div>'
     +'<div class="field"><label>Direction</label><input type="text" id="manDir" placeholder="N/NE/SW" maxlength="4" oninput="_updateWxDisplay()"></div>'
-    +'<div class="field"><label>Wind m/s</label><input type="number" id="manWs" min="0" max="50" step="0.5" oninput="_updateWxDisplay()"></div>'
-    +'<div class="field"><label>Gusts m/s</label><input type="number" id="manWg" min="0" max="80" step="0.5" oninput="_updateWxDisplay()"></div>'
+    +'<div class="field"><label>Wind '+windUnitLabel(_retWindUnit)+'</label><input type="number" id="manWs" min="0" max="200" step="0.5" oninput="_updateWxDisplay()"></div>'
+    +'<div class="field"><label>Gusts '+windUnitLabel(_retWindUnit)+'</label><input type="number" id="manWg" min="0" max="200" step="0.5" oninput="_updateWxDisplay()"></div>'
     +'<div class="field"><label>Waves m</label><input type="number" id="manWv" min="0" max="15" step="0.1" oninput="_updateWxDisplay()"></div>'
     +'<div class="field"><label>Wave dir</label><input type="text" id="manWaveDir" placeholder="N/SW" maxlength="4" oninput="_updateWxDisplay()"></div>'
     +'<div class="field"><label>Air °C</label><input type="number" id="manTc" step="0.5" oninput="_updateWxDisplay()"></div>'
@@ -706,8 +710,8 @@ function renderReturnForm() {
     var wx=currentWx; if(!wx) return;
     function sf(id,v){var el=document.getElementById(id);if(el&&v!=null&&v!=='')el.value=v;}
     sf('manBft',wx.bft); sf('manDir',wx.wDir||wx.dir||'');
-    sf('manWs',  wx.ws!=null?Math.round(wx.ws*10)/10:null);
-    sf('manWg',  wx.wg!=null?Math.round(wx.wg*10)/10:null);
+    sf('manWs',  wx.ws!=null?convertWind(wx.ws,_retWindUnit):null);
+    sf('manWg',  wx.wg!=null?convertWind(wx.wg,_retWindUnit):null);
     sf('manWv',  wx.waveH!=null?Math.round(wx.waveH*10)/10:null);
     sf('manWaveDir',wx.waveDir||'');
     sf('manTc',  wx.airT!=null?Math.round(wx.airT*10)/10:null);
@@ -726,7 +730,8 @@ function advanceToChecklist() {
   else {
     var mn=id=>{var el=document.getElementById(id);return el&&el.value!==''?parseFloat(el.value):null;};
     var ms=id=>{var el=document.getElementById(id);return el?el.value.trim():'';};
-    window._retWxSnap={bft:mn('manBft'),dir:ms('manDir'),ws:mn('manWs'),wg:mn('manWg'),wv:mn('manWv'),waveDir:ms('manWaveDir'),tc:mn('manTc'),feels:mn('manFeels'),pres:mn('manPres'),sst:mn('manSst'),flag:null,cond:null};
+    var rawWs2=mn('manWs'),rawWg2=mn('manWg');
+    window._retWxSnap={bft:mn('manBft'),dir:ms('manDir'),ws:rawWs2!=null?+convertToMs(rawWs2,_retWindUnit).toFixed(1):null,wg:rawWg2!=null?+convertToMs(rawWg2,_retWindUnit).toFixed(1):null,wv:mn('manWv'),waveDir:ms('manWaveDir'),tc:mn('manTc'),feels:mn('manFeels'),pres:mn('manPres'),sst:mn('manSst'),flag:null,cond:null};
   }
   renderLandingChecklist();
 }

--- a/shared/api.js
+++ b/shared/api.js
@@ -122,8 +122,67 @@ function bftFromMs(ms) {
   if (m < 24.5) return 9; if (m < 28.5) return 10; if (m < 32.7) return 11;
   return 12;
 }
+// Convert from any supported unit back to m/s
+function convertToMs(val, unit) {
+  if (val == null || isNaN(val)) return NaN;
+  var v = parseFloat(val);
+  switch (unit) {
+    case 'kts': return v / 1.94384;
+    case 'kmh': return v / 3.6;
+    case 'mph': return v / 2.23694;
+    case 'ms':  return v;
+    default:    return v;
+  }
+}
+
+// Beaufort scale boundaries in m/s (index = Beaufort number)
+var BFT_BOUNDARIES = [0, 0.3, 1.6, 3.4, 5.5, 8.0, 10.8, 13.9, 17.2, 20.8, 24.5, 28.5, 32.7];
+
+// Return [min, max] m/s range for a Beaufort number.
+// For Force 12 the upper bound is null (open-ended), stored as 99.
+function bftToMsRange(bft) {
+  var b = parseInt(bft);
+  if (isNaN(b) || b < 0 || b > 12) return null;
+  var lo = BFT_BOUNDARIES[b];
+  var hi = b < 12 ? BFT_BOUNDARIES[b + 1] : 99;
+  return [lo, hi];
+}
+
+// Midpoint of Beaufort range in m/s (useful for auto-filling from Beaufort)
+function bftToMsMid(bft) {
+  var r = bftToMsRange(bft);
+  if (!r) return null;
+  if (r[1] === 99) return r[0]; // Force 12: just use lower bound
+  return +((r[0] + r[1]) / 2).toFixed(1);
+}
+
+// Parse a ws value that may be a number or a range string like "5.5-8.0".
+// Returns the midpoint as a number, or null if invalid.
+function parseWsValue(ws) {
+  if (ws == null) return null;
+  if (typeof ws === 'number') return ws;
+  var s = String(ws);
+  if (s.indexOf('-') !== -1) {
+    var parts = s.split('-').map(Number);
+    if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
+      return (parts[0] + parts[1]) / 2;
+    }
+  }
+  var n = parseFloat(s);
+  return isNaN(n) ? null : n;
+}
+
 function formatWindValue(ms, beaufort, unit) {
   unit = unit || getPref('windUnit', 'bft');
+  // Handle range values like "5.5-8.0" (from Beaufort-only entry)
+  if (typeof ms === 'string' && ms.indexOf('-') !== -1) {
+    var parts = ms.split('-').map(Number);
+    if (unit === 'bft') {
+      var b = beaufort != null ? beaufort : bftFromMs(parts[0]);
+      return b != null ? 'Force ' + b : '';
+    }
+    return convertWind(parts[0], unit) + '–' + convertWind(parts[1], unit) + ' ' + windUnitLabel(unit);
+  }
   if (unit === 'bft') {
     var b = beaufort != null ? beaufort : (ms != null ? bftFromMs(ms) : null);
     return b != null ? 'Force ' + b : '';

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -274,7 +274,7 @@ function renderCheckoutCard(co, opts) {
     try {
       const w = typeof co.wxSnapshot==="string" ? JSON.parse(co.wxSnapshot) : co.wxSnapshot;
       wxHtml = `<div style="font-size:10px;color:var(--muted);margin-top:4px;display:flex;gap:8px;flex-wrap:wrap">`
-             + `· Bft ${w.bft} · ${w.ws} m/s ${w.dir||""}`
+             + `· Bft ${w.bft} · ${typeof w.ws==='string'&&w.ws.indexOf('-')!==-1?w.ws.split('-').map(v=>Math.round(v)).join('–'):w.ws} m/s ${w.dir||""}`
              + `${w.wv!=null?" · < "+w.wv+"m":""}`
              + `</div>`;
     } catch(e) {}


### PR DESCRIPTION
Manual wind speed and gust inputs now default to the user's preferred unit (kts, km/h, mph, m/s) instead of always showing m/s. Beaufort selector is promoted to the primary weather row alongside wind speed.

When Beaufort is changed it auto-fills the wind speed midpoint (in the user's unit); when wind speed is typed it auto-syncs the Beaufort selector. All values are converted to m/s on save.

If only a Beaufort force is selected with no precise wind speed, the m/s range (e.g. "5.5-8.0") is stored in wxSnapshot.ws so it can be converted to other units on display. All display code across logbook, member hub, daily log, boats panel, and the public page now handles range strings gracefully.

New shared utilities: convertToMs(), bftToMsRange(), bftToMsMid(), parseWsValue().

Closes #175

https://claude.ai/code/session_019jCckNPhNc2naBsYjFsR3i