### PR TITLE
Trip verification via handshake protocol with keelboat captain auto-v…

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -392,7 +392,9 @@ function route_(action, b) {
     case 'saveTrip': return saveTrip_(b);
     case 'setHelm': return setHelm_(b);
     case 'deleteTrip': return deleteTrip_(b.id);
-    case 'requestValidation': return requestValidation_(b);
+    case 'requestValidation': return requestVerification_(b);
+    case 'requestVerification': return requestVerification_(b);
+    case 'getVerificationRequests': return getVerificationRequests_();
     case 'getConfirmations': return getConfirmations_(b);
     case 'createConfirmation': return createConfirmation_(b);
     case 'respondConfirmation': return respondConfirmation_(b);
@@ -1701,6 +1703,7 @@ function requestValidation_(b) {
 //   'crew_join'      — member wants to join a trip    → skipper must confirm
 //   'helm'           — helm toggle requested          → other party confirms
 //   'student'        — skipper marks crew as student  → crew must confirm
+//   'verify'         — member requests trip verification → any staff confirms
 //
 // Status: 'pending' | 'confirmed' | 'rejected'
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1834,8 +1837,119 @@ function respondConfirmation_(b) {
         });
       }
     }
+    if (type === 'verify') {
+      // Staff confirmed a verification request — mark trip as verified
+      var verifyTripId = row.tripId;
+      if (verifyTripId) {
+        updateRow_('trips', 'id', verifyTripId, {
+          verified: true, verifiedBy: b.responderName || row.toName || '', verifiedAt: ts, updatedAt: ts
+        });
+      }
+    }
+
+    // Auto-verify: when a crew/helm/student handshake is confirmed, check if the
+    // trip's skipper is a keelboat captain and ALL handshakes for that checkout/trip
+    // are now resolved — if so, mark all linked trips as verified automatically.
+    if (type === 'crew_assigned' || type === 'crew_join' || type === 'helm' || type === 'student') {
+      tryAutoVerify_(row, ts);
+    }
   }
   return okJ({ updated: true, status: b.response });
+}
+
+// ── Auto-verify: keelboat-captain trips where all handshakes are resolved ────
+function tryAutoVerify_(conf, ts) {
+  // Find the skipper's trip via tripId or linkedCheckoutId
+  var tripId = conf.tripId, coId = conf.linkedCheckoutId;
+  var skipperTrip = tripId ? findOne_('trips', 'id', tripId) : null;
+  if (!skipperTrip && coId) {
+    var coTrips = readAll_('trips').filter(function(t) {
+      return String(t.linkedCheckoutId) === String(coId) && (t.role === 'skipper' || t.role === 'captain');
+    });
+    skipperTrip = coTrips[0] || null;
+  }
+  if (!skipperTrip) return;
+
+  // Check if the skipper is a keelboat division captain
+  var member = findOne_('members', 'kennitala', String(skipperTrip.kennitala));
+  if (!member) return;
+  var certs = [];
+  try { certs = JSON.parse(member.certifications || '[]'); } catch (e) { return; }
+  var isCaptain = certs.some(function(c) {
+    return c.certId === 'keelboat_crew' && c.sub === 'captain';
+  });
+  if (!isCaptain) return;
+
+  // Check if boat is a keelboat
+  var boatCat = (skipperTrip.boatCategory || '').toLowerCase();
+  if (boatCat !== 'keelboat') return;
+
+  // Check ALL confirmations for this trip/checkout are resolved (none pending)
+  var lookupId = coId || tripId;
+  var allConfs;
+  try { allConfs = readAll_('tripConfirmations'); } catch (e) { return; }
+  var related = allConfs.filter(function(c) {
+    return (coId && String(c.linkedCheckoutId) === String(coId)) ||
+           (tripId && String(c.tripId) === String(tripId));
+  });
+  var hasPending = related.some(function(c) { return c.status === 'pending'; });
+  if (hasPending) return;
+
+  // All resolved — auto-verify skipper trip + all linked crew trips
+  var allTrips = readAll_('trips');
+  var linkedTrips = allTrips.filter(function(t) {
+    return String(t.id) === String(skipperTrip.id) ||
+      (coId && String(t.linkedCheckoutId) === String(coId)) ||
+      (String(t.linkedTripId) === String(skipperTrip.id));
+  });
+  linkedTrips.forEach(function(t) {
+    if (!t.verified || t.verified === 'false') {
+      updateRow_('trips', 'id', t.id, {
+        verified: true, verifiedBy: '(auto)', verifiedAt: ts, updatedAt: ts
+      });
+    }
+  });
+}
+
+// ── Request verification (creates a 'verify' handshake to staff) ────────────
+function requestVerification_(b) {
+  if (!b.tripId) return failJ('tripId required');
+  var trip = findOne_('trips', 'id', b.tripId);
+  if (!trip) return failJ('Trip not found', 404);
+  if (trip.verified && trip.verified !== 'false') return failJ('Already verified');
+
+  // Mark the trip as validation-requested (backward compat)
+  updateRow_('trips', 'id', b.tripId, { validationRequested: true });
+
+  ensureConfirmationCols_();
+  var ts = now_(), id = uid_();
+  insertRow_('tripConfirmations', {
+    id: id, type: 'verify', status: 'pending',
+    fromKennitala: b.fromKennitala || trip.kennitala || '',
+    fromName: b.fromName || trip.memberName || '',
+    toKennitala: 'staff', toName: 'Staff',
+    tripId: b.tripId, linkedCheckoutId: trip.linkedCheckoutId || '',
+    boatId: trip.boatId || '', boatName: trip.boatName || '', boatCategory: trip.boatCategory || '',
+    locationId: trip.locationId || '', locationName: trip.locationName || '',
+    date: trip.date || '', timeOut: trip.timeOut || '', timeIn: trip.timeIn || '',
+    hoursDecimal: trip.hoursDecimal || '',
+    role: trip.role || '', helm: trip.helm || false,
+    crew: trip.crew || 1, skipperNote: trip.skipperNote || '',
+    beaufort: trip.beaufort || '', windDir: trip.windDir || '', wxSnapshot: trip.wxSnapshot || '',
+    rejectComment: '',
+    createdAt: ts, respondedAt: '',
+  });
+  return okJ({ id: id, created: true, requested: true });
+}
+
+// ── Get pending verification requests (for staff) ───────────────────────────
+function getVerificationRequests_() {
+  var all;
+  try { all = readAll_('tripConfirmations'); } catch(e) { all = []; }
+  var pending = all.filter(function(r) {
+    return r.type === 'verify' && r.status === 'pending' && !r.dismissed;
+  });
+  return okJ({ requests: pending });
 }
 
 function dismissConfirmation_(b) {

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -909,7 +909,7 @@ function tripCard(t){
           ${showHelm?`<span class="trip-badge badge-helm">${IS?'Stýri':'Helm'}</span>`:''}
           ${(t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)))?`<span class="trip-badge" style="background:#2e86c111;border:1px solid #2e86c155;color:#2e86c1;font-size:9px">${IS?'Nemi':'Student'}</span>`:''}
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':'' }
-          ${t.validationRequested && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ Validation pending</span>' : ''}
+          ${(t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ '+(IS?'Staðfesting í bið':'Verification pending')+'</span>' : ''}
           <span>${esc(dur)}</span>
           ${t.distanceNm?`<span>${esc(t.distanceNm)} nm</span>`:''}
           ${windLine?'<span class="flex-center" style="gap:3px">'+windLine+'</span>':''}
@@ -1935,12 +1935,16 @@ async function reload(){
 
 async function requestTripValidation(id) {
   try {
-    await apiPost('saveTrip', { id, validationRequested: true });
+    await apiPost('requestVerification', {
+      tripId: id,
+      fromKennitala: user.kennitala,
+      fromName: user.name
+    });
     // Update local trip data
     const t = myTrips.find(x => x.id === id);
     if (t) t.validationRequested = true;
     applyFilter();
-    showToast(IS ? 'Óskað eftir staðfestingu' : 'Validation requested');
+    showToast(IS ? 'Óskað eftir staðfestingu' : 'Verification requested');
   } catch(e) { showToast('Error: ' + e.message, 'err'); }
 }
 
@@ -1983,6 +1987,7 @@ function _confDesc(c){
   if(c.type==='crew_join') return s('member.crewJoin');
   if(c.type==='helm') return s('member.helmReq');
   if(c.type==='student') return IS?'Nemamerking':'Student badge';
+  if(c.type==='verify') return IS?'Staðfesting ferðar':'Trip verification';
   return c.type;
 }
 

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -511,6 +511,7 @@ const STRINGS = {
   'logrev.certModeByType':        { EN:'By credential',                                             IS:'Eftir skírteini'                                           },
   'logrev.certSelectType':        { EN:'— Select credential —',                                     IS:'— Veldu skírteini —'                                       },
   'logrev.certNoMatches':         { EN:'No members found with this credential.',                     IS:'Engir félagar fundust með þetta skírteini.'                },
+  'logrev.verifyRequest':         { EN:'VERIFICATION REQUEST',                                      IS:'STAÐFESTINGARBEIÐNI'                                       },
   
     // ── Admin panel ────────────────────────────────────────────────────────────
   'admin.tabMembers':      { EN:'Members',                 IS:'Félagar' },

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -202,6 +202,7 @@ let allTrips    = [];
 let filtered    = [];
 let _allMembers = [];   // single source of truth for member list
 let _certDefs   = [];   // single source of truth for cert definitions
+let _verifyReqs = [];   // pending 'verify' handshakes
 let _dataLoaded = false;
 
 // Currently selected member in the cert panel
@@ -230,14 +231,16 @@ document.addEventListener('DOMContentLoaded', () => {
 // ── Init: load trips + members + certDefs in one pass ────────────────────────
 async function init() {
   try {
-    const [tripsRes, membersRes, cfgRes] = await Promise.all([
+    const [tripsRes, membersRes, cfgRes, verifyRes] = await Promise.all([
       apiGet('getTrips', { limit: 200 }),
       apiGet('getMembers'),
       apiGet('getConfig'),
+      apiGet('getVerificationRequests'),
     ]);
 
     _allMembers = membersRes.members || [];
     _certDefs   = certDefsFromConfig(cfgRes.certDefs || []);
+    _verifyReqs = verifyRes.requests || [];
     _dataLoaded = true;
 
     // Populate cert-type dropdown once
@@ -282,8 +285,9 @@ function updateStats() {
   const yr  = new Date().getFullYear() + '';
   const ytd = allTrips.filter(t => (t.date || '').startsWith(yr));
 
+  const verifyTripIds = new Set(_verifyReqs.map(r => r.tripId).filter(Boolean));
   const requested = allTrips.filter(t =>
-    (t.validationRequested === true || t.validationRequested === 'true') &&
+    ((t.validationRequested === true || t.validationRequested === 'true') || verifyTripIds.has(t.id)) &&
     (!t.verified || t.verified === 'false')
   ).length;
   const verified = allTrips.filter(t => t.verified && t.verified !== 'false').length;
@@ -323,10 +327,14 @@ function applyFilters() {
   const to      = document.getElementById('filterTo').value;
   const showAll = document.getElementById('showAllTrips')?.checked ?? false;
 
+  // Build set of trip IDs with pending verify handshakes
+  const verifyTripIds = new Set(_verifyReqs.map(r => r.tripId).filter(Boolean));
+
   filtered = allTrips.filter(t => {
     if (!showAll &&
         t.validationRequested !== true &&
-        t.validationRequested !== 'true') return false;
+        t.validationRequested !== 'true' &&
+        !verifyTripIds.has(t.id)) return false;
     if (name && !(t.memberName || '').toLowerCase().includes(name)) return false;
     if (status === 'pending'  && (t.verified && t.verified !== 'false')) return false;
     if (status === 'verified' && (!t.verified || t.verified === 'false')) return false;
@@ -344,9 +352,11 @@ function renderTrips() {
     el.innerHTML = `<div class="empty-note">${s('logrev.noTrips')}</div>`;
     return;
   }
+  const verifyTripIds = new Set(_verifyReqs.map(r => r.tripId).filter(Boolean));
   el.innerHTML = filtered.map(t => {
     const isVer    = t.verified && t.verified !== 'false';
     const isLinked = t.isLinked === true || t.isLinked === 'true';
+    const hasVerifyReq = verifyTripIds.has(t.id);
     return `<div class="trip-card${isVer ? ' verified' : ''}" id="tc-${esc(t.id)}">
       <div class="trip-head">
         <div>
@@ -365,6 +375,7 @@ function renderTrips() {
             ${isVer ? ('✓ ' + s('logrev.verified')) : s('logrev.pending')}
           </span>
           ${isLinked ? `<span class="badge badge-linked">LINKED</span>` : ''}
+          ${hasVerifyReq && !isVer ? `<span class="badge" style="color:#2e86c1;border-color:#2e86c155;background:#2e86c111">${s('logrev.verifyRequest')}</span>` : ''}
         </div>
       </div>
       ${t.skipperNote ? `<div class="trip-notes text-brass">📋 ${esc(t.skipperNote)}</div>` : ''}
@@ -394,6 +405,13 @@ async function verifyTrip(id) {
   const btn = document.querySelector(`#tc-${id} .btn-primary`);
   if (btn) { btn.disabled = true; btn.textContent = '…'; }
   try {
+    // If there's a pending 'verify' handshake for this trip, respond via the protocol
+    const vr = _verifyReqs.find(r => r.tripId === id && r.status === 'pending');
+    if (vr) {
+      await apiPost('respondConfirmation', { id: vr.id, response: 'confirmed', responderName: user.name });
+      _verifyReqs = _verifyReqs.filter(r => r.id !== vr.id);
+    }
+    // Also update staffComment directly (handshake sets verified + verifiedBy)
     await apiPost('saveTrip', { id, verified: true, staffComment: comment, verifiedBy: user.name });
     const t = allTrips.find(x => x.id === id);
     if (t) Object.assign(t, { verified: 'true', staffComment: comment, verifiedBy: user.name });


### PR DESCRIPTION
…erify

Adds a 'verify' confirmation type to the handshake protocol so trip verification requests flow from members to staff as handshakes instead of bare flag-sets. When a keelboat division captain's trip has all crew/helm/ student handshakes resolved, the trip (and linked crew trips) are auto- verified. Staff logbook review now loads pending verification handshakes and responds through the protocol while still recording verifiedBy and verifiedAt. The verifier/timestamp are stored but not shown in the member logbook.

Closes #210

https://claude.ai/code/session_01SG6cWMZ2qBQgtDwKXwhPN7