### PR TITLE
Add staff boat action card and unify fleet status container

### DIFF
--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -330,9 +330,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     toggleFilter(btn.dataset.group, btn.dataset.value);
   });
 
-  // Auto-open new request modal if navigated here with ?new=1
-  if (new URLSearchParams(window.location.search).get("new") === "1") {
+  // Auto-open new request modal if navigated here with ?new=1 or ?prefillBoat=<id>
+  const _qs = new URLSearchParams(window.location.search);
+  if (_qs.get("new") === "1") {
     openNewRequest();
+  } else if (_qs.get("prefillBoat")) {
+    openNewRequest({ category: 'boat', boatId: _qs.get("prefillBoat") });
   }
 });
 

--- a/member/index.html
+++ b/member/index.html
@@ -176,7 +176,7 @@
   <!-- ═══ FLEET ═══ -->
   <div id="tab-fleet" class="mt-16">
     <div class="section-label" style="letter-spacing:1.5px;margin-bottom:10px" data-s="member.fleetAvail"></div>
-    <div id="fleetByCat"></div>
+    <div id="fleetStatus"></div>
   </div>
 
 
@@ -297,7 +297,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 // ══ FLEET BY CATEGORY ════════════════════════════════════════════════════════
 function renderFleetByCat() {
   const active = checkouts.filter(c => c.status === 'out');
-  renderFleetStatus('fleetByCat', boats, active, { onAvailClick:'launchBoatById', toggleFn:'toggleFleetCat', collapsed:true });
+  renderFleetStatus('fleetStatus', boats, active, { onAvailClick:'launchBoatById', toggleFn:'toggleFleetCat', collapsed:true });
 }
 function toggleCat(el) { toggleFleetCat(el); }
 function toggleFleetCat(toggle) {

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -366,7 +366,8 @@ function renderFleetStatus(containerId, boats, active, opts) {
   }
 
   // Group by category preserving insertion order (or sort alpha)
-  const cats = [...new Set(boats.map(b => b.category).filter(Boolean))].sort();
+  const cats = [...new Set(boats.map(b => b.category).filter(Boolean))]
+    .sort((a, b) => _boatCatLabel(a.toLowerCase()).localeCompare(_boatCatLabel(b.toLowerCase())));
 
   const activeByBoat = new Map();
   active.forEach(c => { activeByBoat.set(c.boatId, c); });
@@ -381,13 +382,19 @@ function renderFleetStatus(containerId, boats, active, opts) {
     const pct      = catBoats.length ? Math.round(avail.length / catBoats.length * 100) : 0;
     const catId    = containerId + '-fcat-' + encodeURIComponent(key);
 
+    const onClickAct = opts.onClickAction || null;
+
     const cards = catBoats.map(b => {
       const co  = activeByBoat.get(b.id);
       const oos = boolVal(b.oos);
       const status = oos ? 'oos' : co ? (co.isOverdue ? 'overdue' : 'out') : 'avail';
-      const clickOpts = (status === 'avail' && onAvail && (isStaff || !isChartered(b)))
-        ? { onClick: onAvail + "('${b.id}')".replace('${b.id}', _besc(b.id)) }
-        : {};
+      let clickOpts = {};
+      if (onClickAct) {
+        // onClickAction receives the full boat object via registry — always clickable
+        clickOpts = { onClickAction: onClickAct };
+      } else if (status === 'avail' && onAvail && (isStaff || !isChartered(b))) {
+        clickOpts = { onClick: onAvail + "('${b.id}')".replace('${b.id}', _besc(b.id)) };
+      }
       return renderBoatCard(b, Object.assign({ status, checkoutData: co, staffView: isStaff }, clickOpts));
     }).join('');
 

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -865,6 +865,12 @@ const STRINGS = {
   'fleet.charterOverride':   { EN:'This boat is chartered to {name} until {date}. Override and check out anyway?',
                                IS:'Þessi bátur er leigður til {name} til {date}. Viltu taka hann út samt?' },
 
+  // ── Fleet action popover (staff) ────────────────────────────────────────────
+  'fleet.actionCheckout':    { EN:'Check Out',                              IS:'Útskrá' },
+  'fleet.actionMaint':       { EN:'Request Maintenance',                    IS:'Beiðni um viðhald' },
+  'fleet.actionMarkOos':     { EN:'Mark Unavailable',                       IS:'Merkja ótiltækan' },
+  'fleet.actionMarkAvail':   { EN:'Mark Available',                         IS:'Merkja tiltækan' },
+
   // ── Boat ownership & charter ──────────────────────────────────────────────
   'boat.ownership':          { EN:'Ownership',                             IS:'Eignarhald' },
   'boat.ownershipClub':      { EN:'Club boat',                             IS:'Klúbbsbátur' },

--- a/staff/index.html
+++ b/staff/index.html
@@ -632,10 +632,10 @@ function renderStats() {
 function renderFleet() {
   const active = checkouts.filter(c => c.status === 'out');
   renderFleetStatus('fleetStatus', boats, active, {
-    onAvailClick: 'selectBoatForCheckout',
-    toggleFn:     'toggleFleetCat',
-    collapsed:    true,
-    staffView:    true,
+    onClickAction: 'openBoatActionCard',
+    toggleFn:      'toggleFleetCat',
+    collapsed:     true,
+    staffView:     true,
   });
 }
 
@@ -1121,6 +1121,78 @@ function selectBoatForCheckout(boatId) {
   }, 80);
 }
 
+
+// ── Boat action card (fleet status click) ─────────────────────────────────────
+function openBoatActionCard(boat) {
+  // Close any existing action card
+  closeBoatActionCard();
+  if (!boat) return;
+
+  const oos = boolVal(boat.oos);
+  const co  = checkouts.find(c => c.status === 'out' && c.boatId === boat.id);
+
+  const overlay = document.createElement('div');
+  overlay.id = 'boatActionOverlay';
+  overlay.className = 'modal-overlay';
+  overlay.style.cssText = 'display:flex;align-items:center;justify-content:center;z-index:9999';
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeBoatActionCard(); });
+
+  const emoji = boatEmoji((boat.category||'').toLowerCase());
+  const name  = esc(boat.name || boat.id || '');
+
+  // Build action buttons — checkout only if available (not OOS and not currently out)
+  const canCheckout = !oos && !co;
+  const checkoutBtn = canCheckout
+    ? `<button class="btn btn-primary" style="width:100%;font-size:13px;padding:10px" onclick="closeBoatActionCard();selectBoatForCheckout('${esc(boat.id)}')">${s('fleet.actionCheckout')}</button>`
+    : '';
+  const maintBtn = `<button class="btn btn-secondary" style="width:100%;font-size:13px;padding:10px" onclick="closeBoatActionCard();openBoatMaintRequest('${esc(boat.id)}','${esc(boat.name||'')}')">${s('fleet.actionMaint')}</button>`;
+  const toggleLabel = oos ? s('fleet.actionMarkAvail') : s('fleet.actionMarkOos');
+  const toggleBtn = `<button class="btn btn-secondary" style="width:100%;font-size:13px;padding:10px" onclick="closeBoatActionCard();toggleBoatAvailability('${esc(boat.id)}')">${toggleLabel}</button>`;
+
+  overlay.innerHTML = `<div class="modal" style="max-width:320px;padding:20px">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
+      <div style="font-size:15px;font-weight:600">${emoji} ${name}</div>
+      <button style="background:none;border:none;cursor:pointer;font-size:20px;color:var(--muted);padding:0 2px;line-height:1" onclick="closeBoatActionCard()">&times;</button>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:8px">
+      ${checkoutBtn}
+      ${maintBtn}
+      ${toggleBtn}
+    </div>
+  </div>`;
+
+  document.body.appendChild(overlay);
+}
+
+function closeBoatActionCard() {
+  const el = document.getElementById('boatActionOverlay');
+  if (el) el.remove();
+}
+
+function openBoatMaintRequest(boatId, boatName) {
+  // Navigate to maintenance page with boat pre-selected
+  window.location.href = '../maintenance/?prefillBoat=' + encodeURIComponent(boatId);
+}
+
+async function toggleBoatAvailability(boatId) {
+  try {
+    const cfgRes = await apiGet('getConfig');
+    const allBoats = cfgRes.boats || [];
+    const idx = allBoats.findIndex(b => b.id === boatId);
+    if (idx < 0) { showToast('Boat not found.', 'err'); return; }
+    const wasOos = boolVal(allBoats[idx].oos);
+    allBoats[idx] = Object.assign({}, allBoats[idx], {
+      oos: !wasOos,
+      oosReason: wasOos ? '' : (allBoats[idx].oosReason || ''),
+    });
+    await apiPost('saveConfig', { boats: allBoats });
+    boats = allBoats.filter(b => b.active !== false && b.active !== 'false');
+    renderAll();
+    showToast(wasOos ? s('fleet.actionMarkAvail') + ' ✓' : s('fleet.actionMarkOos') + ' ✓');
+  } catch(e) {
+    showToast('Error: ' + e.message, 'err');
+  }
+}
 
 // ══ GROUP CHECKOUT ═══════════════════════════════════════════════════════════
 let _groupBoats = new Set();


### PR DESCRIPTION
- Rename member page fleet container from fleetByCat to fleetStatus to match the staff hub naming convention
- Add boat action card on staff fleet view: clicking any boat shows a modal with Check Out, Request Maintenance, and Toggle Availability
- Sort fleet categories by translated label instead of raw key
- Add maintenance page prefill support via ?prefillBoat= URL param
- Add i18n strings for new action labels (EN + IS)

https://claude.ai/code/session_01So8QGkCPB1UFUqB7CL6Pet