### PR TITLE
Fix captain link: add defensive guards and graceful redirect

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -179,8 +179,8 @@
 
 <script>
 // ══ STATE ════════════════════════════════════════════════════════════════════
-const user = requireAuth(isCaptain);
-if (!user) throw new Error('Not a captain');
+const user = requireAuth();
+if (!user || !isCaptain(user)) { window.location.href = '../member/'; throw new Error('Not a captain'); }
 const L = getLang();
 
 let _boats = [], _locations = [], _allMaint = [], _allTrips = [], _myTrips = [];

--- a/member/index.html
+++ b/member/index.html
@@ -243,7 +243,9 @@ const L = getLang();
 document.addEventListener('DOMContentLoaded', async () => {
   buildHeader('member');
   applyStrings();
-  if (isCaptain(user)) document.getElementById('captainQBtn').style.display = '';
+  if (typeof isCaptain === 'function' && isCaptain(user)) {
+    document.getElementById('captainQBtn').style.display = '';
+  }
 
   document.getElementById('welcomeName').textContent = user.name || s('member.tabFleet');
   document.getElementById('welcomeSub').textContent  = user.kennitala || '';


### PR DESCRIPTION
- Guard isCaptain call on member page with typeof check to prevent ReferenceError if api.js is browser-cached without the function
- Captain page redirects to member hub instead of login for non-captains

https://claude.ai/code/session_01NkhxEs4QhpynKTj9vPz84e