### PR TITLE
Fix unclosed div tag breaking admin settings tab DOM structure

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -195,7 +195,7 @@
               <div class="text-sm text-muted mb-4">Admin/staff roles never overwritten.</div>
               <div class="import-summary" id="importSummary"></div>
               <div id="importLists"></div>
-              <div id="importError" class="text-red text-md mb-8 hidden" style="padding:8px;background:#e74c3c11;border-radius:4px;border:1px solid var(--red)44">
+              <div id="importError" class="text-red text-md mb-8 hidden" style="padding:8px;background:#e74c3c11;border-radius:4px;border:1px solid var(--red)44"></div>
               <div class="btn-row mt-14">
                 <button class="btn btn-secondary" onclick="resetImport()" data-s="admin.backToList"></button>
                 <button class="btn btn-primary" onclick="confirmImport()" id="confirmImportBtn" data-s="admin.confirmImport"></button>


### PR DESCRIPTION
The importError div was missing its closing </div> tag after a CSS refactor (commit 57ff150). This caused the browser's HTML parser to nest all subsequent siblings—including the entire #top-settings container—inside the hidden importError div, making the settings sub-tabs invisible.

https://claude.ai/code/session_01PmFbAkPkbyS2bXge5msm1g