### PR TITLE
Fix captain detection: match sub='captain' instead of hardcoded certId

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1925,7 +1925,7 @@ function tryAutoVerify_(conf, ts) {
   var certs = [];
   try { certs = JSON.parse(member.certifications || '[]'); } catch (e) { return; }
   var isCaptain = certs.some(function(c) {
-    return c.certId === 'keelboat_crew' && c.sub === 'captain';
+    return c.sub === 'captain';
   });
   if (!isCaptain) return;
 
@@ -3455,7 +3455,7 @@ function publicDashboard_() {
     var certs = [];
     try { certs = typeof m.certifications === 'string' ? JSON.parse(m.certifications) : (m.certifications || []); } catch(e) { return; }
     if (!Array.isArray(certs)) return;
-    var isCaptain = certs.some(function(c) { return c.certId === 'keelboat_crew' && c.sub === 'captain'; });
+    var isCaptain = certs.some(function(c) { return c.sub === 'captain'; });
     if (!isCaptain) return;
 
     // Build cert labels

--- a/member/index.html
+++ b/member/index.html
@@ -243,19 +243,6 @@ const L = getLang();
 document.addEventListener('DOMContentLoaded', async () => {
   buildHeader('member');
   applyStrings();
-  // DEBUG — remove after confirming captain detection works
-  var _cqDebug = document.createElement('div');
-  _cqDebug.style.cssText = 'background:#1a1a2e;border:1px solid #d4af37;border-radius:6px;padding:10px 14px;margin-bottom:12px;font-size:11px;color:#ccc;word-break:break-all';
-  var _cqCerts = user.certifications;
-  var _cqParsed = typeof _cqCerts === 'string' ? parseJson(_cqCerts, []) : (_cqCerts || []);
-  var _cqHasCaptain = Array.isArray(_cqParsed) && _cqParsed.some(function(c){ return c.certId === 'keelboat_crew' && c.sub === 'captain'; });
-  _cqDebug.innerHTML = '<b style="color:#d4af37">Captain Debug</b><br>'
-    + 'certifications type: <b>' + typeof _cqCerts + '</b><br>'
-    + 'certifications value: <b>' + esc(String(_cqCerts || '(empty)').slice(0, 300)) + '</b><br>'
-    + 'parsed array length: <b>' + (Array.isArray(_cqParsed) ? _cqParsed.length : 'NOT ARRAY') + '</b><br>'
-    + 'isCaptain result: <b style="color:' + (_cqHasCaptain ? '#2ecc71' : '#e74c3c') + '">' + _cqHasCaptain + '</b>';
-  document.querySelector('.page-content').insertBefore(_cqDebug, document.querySelector('.page-content').firstChild);
-
   if (typeof isCaptain === 'function' && isCaptain(user)) {
     document.getElementById('captainQBtn').style.display = '';
   }

--- a/shared/api.js
+++ b/shared/api.js
@@ -70,7 +70,7 @@ function isAdmin(u) { return u && u.role === "admin"; }
 function isCaptain(u) {
   if (!u || !u.certifications) return false;
   var certs = typeof u.certifications === 'string' ? parseJson(u.certifications, []) : (u.certifications || []);
-  return Array.isArray(certs) && certs.some(function(c) { return c.certId === 'keelboat_crew' && c.sub === 'captain'; });
+  return Array.isArray(certs) && certs.some(function(c) { return c.sub === 'captain'; });
 }
 
 function signOut() {


### PR DESCRIPTION
The cert ID for keelboat crew is auto-generated (e.g. cert_mn9l9294) when admins customize cert definitions, not the default 'keelboat_crew'. Match on sub='captain' which is the subcategory key regardless of the parent cert's ID. Fixes detection on member page, header nav, public dashboard, and trip auto-verification.

https://claude.ai/code/session_01NkhxEs4QhpynKTj9vPz84e