### PR TITLE
Replace native alert/confirm/prompt with themed custom modals

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1252,7 +1252,7 @@ async function saveMember() {
 }
 
 async function deactivateMember(id) {
-  if (!confirm("Deactivate this member?")) return;
+  if (!await ymConfirm("Deactivate this member?")) return;
   try {
     await apiPost("deleteMember", { id });
     members = members.filter(m => m.id !== id);
@@ -1331,7 +1331,7 @@ async function saveBoatCat() {
 
 async function deleteBoatCat() {
   const key = _bcEditingId;
-  if (!key || !confirm("Remove this category? Boats assigned to it will still exist but may show under 'other'.")) return;
+  if (!key || !await ymConfirm("Remove this category? Boats assigned to it will still exist but may show under 'other'.")) return;
   _allBoatCats = _allBoatCats.map(c => c.key === key ? { ...c, active: false } : c);
   try {
     await apiPost("saveConfig", { boatCategories: _allBoatCats });
@@ -1561,7 +1561,7 @@ async function saveCharterFromModal() {
 async function removeCharterFromModal() {
   const boatId = editingId;
   if (!boatId) return;
-  if (!confirm(s('boat.removeCharter') + '?')) return;
+  if (!await ymConfirm(s('boat.removeCharter') + '?')) return;
   try {
     await apiPost('removeCharter', { boatId });
     const b = _allBoats.find(x => x.id === boatId);
@@ -1610,7 +1610,7 @@ async function saveBoat() {
 
 async function deleteBoat(id) {
   const _id = id || editingId;
-  if (!confirm("Delete this boat?")) return;
+  if (!await ymConfirm("Delete this boat?")) return;
   _allBoats = _allBoats.map(b => b.id === _id ? { ...b, active: false } : b);
   try {
     await apiPost("saveConfig", { boats: _allBoats });
@@ -1700,7 +1700,7 @@ async function saveLocation() {
 
 async function deleteLocation(id) {
   const _id = id || editingId;
-  if (!confirm("Delete this location?")) return;
+  if (!await ymConfirm("Delete this location?")) return;
   _allLocations = _allLocations.map(l => l.id === _id ? { ...l, active: false } : l);
   try {
     await apiPost("saveConfig", { locations: _allLocations });
@@ -1775,7 +1775,7 @@ async function saveCLItem() {
 
 async function deleteCLItem(id) {
   const _id = id || editingId;
-  if (!confirm("Delete this item?")) return;
+  if (!await ymConfirm("Delete this item?")) return;
   try {
     await apiPost("deleteChecklistItem", { id: _id });
     clItems = clItems.filter(i => i.id !== _id);
@@ -1865,7 +1865,7 @@ async function deleteLaunchCLItem(cat, phase, id) {
     phase = document.getElementById("lcPhase").value;
     id    = _lcEditingId;
   }
-  if (!confirm("Delete this item?")) return;
+  if (!await ymConfirm("Delete this item?")) return;
   if (_launchCLs[cat]?.[phase]) {
     _launchCLs[cat][phase] = _launchCLs[cat][phase].filter(x => x.id !== id);
   }
@@ -1939,7 +1939,7 @@ async function saveActType() {
 
 async function deleteActType(id) {
   const _id = id || editingId;
-  if (!confirm("Delete this activity type?")) return;
+  if (!await ymConfirm("Delete this activity type?")) return;
   try {
     await apiPost("deleteActivityType", { id: _id });
     actTypes = actTypes.filter(a => a.id !== _id);
@@ -2026,7 +2026,7 @@ async function addCertCategory() {
 }
 
 async function removeCertCategory(idx) {
-  if (!confirm("Remove this category?")) return;
+  if (!await ymConfirm("Remove this category?")) return;
   certCategories.splice(idx, 1);
   try {
     await apiPost("saveCertCategories", { categories: certCategories });
@@ -2171,7 +2171,7 @@ async function saveCertDef() {
 }
 
 async function deleteCertDef() {
-  if (!certEditId || !confirm("Delete this credential type? This won't remove existing assignments.")) return;
+  if (!certEditId || !await ymConfirm("Delete this credential type? This won't remove existing assignments.")) return;
   try {
     await apiPost("deleteCertDef", { id: certEditId });
     certDefs = certDefs.filter(d => d.id !== certEditId);
@@ -2183,7 +2183,7 @@ async function deleteCertDef() {
 }
 
 async function deleteCertDefById(id) {
-  if (!confirm("Delete this credential type? This won't remove existing assignments.")) return;
+  if (!await ymConfirm("Delete this credential type? This won't remove existing assignments.")) return;
   try {
     await apiPost("deleteCertDef", { id });
     certDefs = certDefs.filter(d => d.id !== id);
@@ -2349,7 +2349,7 @@ function populateMcmCategories() {
 function onMcmCategoryChange() {
   const sel = document.getElementById("mcmCategory");
   if (sel.value === "__add__") {
-    const name = prompt("Enter new category name:");
+    const name = await ymPrompt("Enter new category name:");
     if (name && name.trim()) {
       const cat = name.trim();
       if (!certCategories.includes(cat)) {
@@ -2524,7 +2524,7 @@ async function assignMemberCert() {
 }
 
 async function removeMemberCert(key, sub) {
-  if (!confirm("Remove this credential?")) return;
+  if (!await ymConfirm("Remove this credential?")) return;
   const m = members.find(x => String(x.id) === String(mcmMemberId));
   if (!m) return;
   let certs = parseJson(m.certifications, []);
@@ -2681,7 +2681,7 @@ async function saveFlagConfig(){
   var cfg=getFlagFormValues(),errs=validateFlagConfig(cfg);if(errs.length){errEl.textContent=errs.join(' ');errEl.style.display='block';return;}
   try{await apiPost('saveConfig',{flagConfig:cfg});if(typeof wxLoadFlagConfig==='function')wxLoadFlagConfig(cfg);updateFlagPreview();msgEl.style.color='var(--green)';msgEl.textContent='✓ Saved';setTimeout(function(){msgEl.textContent='';},3000);}catch(e){msgEl.style.color='var(--red)';msgEl.textContent='Save failed: '+e.message;}
 }
-function resetFlagConfig(){if(!confirm('Reset all flag settings to defaults?'))return;loadFlagConfigPanel(null);}
+async function resetFlagConfig(){if(!await ymConfirm('Reset all flag settings to defaults?'))return;loadFlagConfigPanel(null);}
 
 // ══ CSV IMPORT ════════════════════════════════════════════════════════════════
 

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -547,7 +547,7 @@ async function meSave(){
 }
 async function meDelete(){
   if(!_editId)return;
-  if(!confirm(s('payroll.deleteConfirm')))return;
+  if(!await ymConfirm(s('payroll.deleteConfirm')))return;
   try{await apiPost('adminDeleteTime',{id:_editId});prCloseModal();showToast(s('toast.deleted'));prLoadTsEntries();}
   catch(e){document.getElementById('meErr').textContent=e.message;}
 }
@@ -800,7 +800,7 @@ function prAddLine(empId){
 async function prApprovePeriod(){
   var from=document.getElementById('prPeriodFrom').value,to=document.getElementById('prPeriodTo').value,payDate=document.getElementById('prPaymentDate').value;
   if(!from||!to){showToast(s('payroll.noPeriodDefined'),'err');return;}
-  if(!confirm(s('payroll.approveConfirm')))return;
+  if(!await ymConfirm(s('payroll.approveConfirm')))return;
   var msg=document.getElementById('prApproveMsg');
   if(msg){msg.textContent=s('lbl.loading');msg.style.color='var(--muted)';}
   var rows=Object.keys(_previewData.employees||{}).map(function(empId){

--- a/captain/index.html
+++ b/captain/index.html
@@ -810,7 +810,7 @@ async function _cqEditNote(tripId, field) {
   if (!t) return;
   var current = field === 'skipperNote' ? (t.skipperNote||'') : (t.notes||'');
   var label = field === 'skipperNote' ? 'Skipper note (visible to crew):' : 'Private note (only you):';
-  var val = prompt(label, current);
+  var val = await ymPrompt(label, current);
   if (val === null) return;
   try {
     await apiPost('saveTrip', { id: tripId, [field]: val });
@@ -1108,10 +1108,10 @@ function selectCqCredMember(id) {
   sel.style.display = '';
 }
 
-function onCqCredCategoryChange() {
+async function onCqCredCategoryChange() {
   var sel = document.getElementById('cqCredCategory');
   if (sel.value === '__add__') {
-    var name = prompt('Enter new category name:');
+    var name = await ymPrompt('Enter new category name:');
     if (name && name.trim()) {
       var cat = name.trim();
       if (_cqCertCategories.indexOf(cat) === -1) {

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -1034,7 +1034,7 @@ async function signOffDay() {
   const done = pmItems.filter(i => pmChecks[i.id]).length;
   if (done < pmItems.length) {
     const msg = s('daily.signOffConfirm').replace('{done}',done).replace('{total}',pmItems.length);
-    if (!confirm(msg)) return;
+    if (!await ymConfirm(msg)) return;
   }
   await doSave(true);
 }

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -1789,7 +1789,7 @@ async function toggleHelm(tripId, checked) {
 }
 
 async function deleteTripTrack(tripId) {
-  if (!confirm(IS ? 'Ertu viss um að þú viljir eyða GPS-leiðinni?' : 'Delete this GPS track?')) return;
+  if (!await ymConfirm(IS ? 'Ertu viss um að þú viljir eyða GPS-leiðinni?' : 'Delete this GPS track?')) return;
   try {
     await apiPost('deleteTripFile', { tripId, kennitala: user.kennitala, fileType: 'track' });
     const t = myTrips.find(x => x.id === tripId);
@@ -1800,7 +1800,7 @@ async function deleteTripTrack(tripId) {
 }
 
 async function deleteTripPhoto(tripId, photoUrl) {
-  if (!confirm(IS ? 'Eyða þessari mynd?' : 'Delete this photo?')) return;
+  if (!await ymConfirm(IS ? 'Eyða þessari mynd?' : 'Delete this photo?')) return;
   try {
     await apiPost('deleteTripFile', { tripId, kennitala: user.kennitala, fileType: 'photo', photoUrl });
     const t = myTrips.find(x => x.id === tripId);
@@ -1877,7 +1877,7 @@ function copyShareLink(tokenId){
   });
 }
 async function revokeShareToken(tokenId){
-  if(!confirm(IS?'Afturkalla þennan hlekk?':'Revoke this link?'))return;
+  if(!await ymConfirm(IS?'Afturkalla þennan hlekk?':'Revoke this link?'))return;
   try{
     await apiPost('revokeShareToken',{tokenId:tokenId,kennitala:user.kennitala});
     showToast(IS?'Hlekkur afturkallaður.':'Link revoked.');
@@ -2099,8 +2099,8 @@ async function respondConf(confId,response,rejectComment){
   }catch(e){showToast(s('toast.error')+': '+e.message,'err');}
 }
 
-function promptRejectConf(confId){
-  var comment=prompt(s('member.rejectReason'));
+async function promptRejectConf(confId){
+  var comment=await ymPrompt(s('member.rejectReason'));
   if(comment===null) return;
   respondConf(confId,'rejected',comment);
 }
@@ -2113,7 +2113,7 @@ async function editNote(tripId, field) {
   const label = field === 'skipperNote'
     ? (IS ? 'Skipstjóraskýring (sýnilegt áhöfn):' : 'Skipper note (visible to crew):')
     : (IS ? 'Athugasemd (aðeins þú sérð):' : 'Private note (only you):');
-  const val = prompt(label, current);
+  const val = await ymPrompt(label, current);
   if (val === null) return;
   try {
     const update = {};

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -472,7 +472,7 @@ function renderCard(r) {
 
 // ── Actions ────────────────────────────────────────────────────────────────────
 async function resolveRequest(id) {
-  if (!confirm("Mark this request as resolved?")) return;
+  if (!await ymConfirm("Mark this request as resolved?")) return;
   const r = allRequests.find(x => x.id === id);
   if (!r) return;
   try {
@@ -489,7 +489,7 @@ async function resolveRequest(id) {
       } catch(e2) { console.warn("Could not clear OOS:", e2.message); }
     }
     renderStats(); renderList(); toast("✓ Resolved.");
-  } catch(e) { alert("Error: " + e.message); }
+  } catch(e) { ymAlert("Error: " + e.message); }
 }
 
 async function addComment(id) {
@@ -506,7 +506,7 @@ async function addComment(id) {
       r.comments = JSON.stringify(comments);
     }
     renderList(); toast("Comment added.");
-  } catch(e) { alert("Error: " + e.message); }
+  } catch(e) { ymAlert("Error: " + e.message); }
 }
 
 function viewPhoto(url) {

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -444,7 +444,7 @@ function maintRenderRow(m) {
  * Both those functions must exist on the page.
  */
 async function maintResolve(id) {
-  if (!confirm("Mark this request as resolved?")) return;
+  if (!await ymConfirm("Mark this request as resolved?")) return;
   const r = (window._maintRequests || []).find(x => x.id === id);
   if (!r) return;
   try {
@@ -456,7 +456,7 @@ async function maintResolve(id) {
     if (typeof renderStats === "function") renderStats();
     if (typeof renderList  === "function") renderList();
     toast("✓ Resolved.");
-  } catch(e) { alert("Error: " + e.message); }
+  } catch(e) { ymAlert("Error: " + e.message); }
 }
 
 /**
@@ -478,7 +478,7 @@ async function maintAddComment(id) {
     }
     if (typeof renderList === "function") renderList();
     toast("Comment added.");
-  } catch(e) { alert("Error: " + e.message); }
+  } catch(e) { ymAlert("Error: " + e.message); }
 }
 
 /**
@@ -497,7 +497,7 @@ async function maintResolveRow(id, checked) {
     } catch(e) {
       item._done = false;
       if (typeof renderDlMaintenance === "function") renderDlMaintenance();
-      alert("Could not resolve: " + e.message);
+      ymAlert("Could not resolve: " + e.message);
     }
   }
 }

--- a/shared/style.css
+++ b/shared/style.css
@@ -367,6 +367,9 @@ textarea { min-height: 70px; }
   line-height: 1;
 }
 
+/* ── SYSTEM DIALOG BUTTONS ────────────────────────────────────────────────────── */
+.ym-dialog-btns { display: flex; justify-content: flex-end; gap: 10px; }
+
 /* ── MISC ─────────────────────────────────────────────────────────────────────── */
 
 .divider { height: 1px; background: var(--border); margin: 16px 0; }

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -105,6 +105,122 @@ document.addEventListener('keydown', function (e) {
   top.classList.add('hidden');
 });
 
+// ── SYSTEM DIALOGS (ymAlert / ymConfirm / ymPrompt) ──────────────────────────
+// Promise-based replacements for native alert(), confirm(), prompt().
+// Reuse .modal-overlay + .modal CSS; lazy-create a single shared DOM element.
+;(function () {
+  let _overlay = null;
+  let _resolve = null;
+
+  function ensureOverlay() {
+    if (_overlay) return _overlay;
+    _overlay = document.createElement('div');
+    _overlay.id = 'ym-dialog';
+    _overlay.className = 'modal-overlay hidden';
+    _overlay.style.zIndex = '300';
+    _overlay.addEventListener('click', function (e) {
+      if (e.target === _overlay) dismiss();
+    });
+    document.body.appendChild(_overlay);
+    return _overlay;
+  }
+
+  function dismiss(value) {
+    if (!_resolve) return;
+    _overlay.classList.add('hidden');
+    var fn = _resolve;
+    _resolve = null;
+    fn(value);
+  }
+
+  function show(html) {
+    var el = ensureOverlay();
+    el.innerHTML = '<div class="modal" style="max-width:400px">' + html + '</div>';
+    el.classList.remove('hidden');
+    // watch for Escape (global handler adds .hidden)
+    var obs = new MutationObserver(function () {
+      if (el.classList.contains('hidden') && _resolve) dismiss(undefined);
+    });
+    obs.observe(el, { attributes: true, attributeFilter: ['class'] });
+    return new Promise(function (resolve) {
+      _resolve = resolve;
+    }).finally(function () { obs.disconnect(); });
+  }
+
+  var label = function (key, fallback) {
+    return (typeof s === 'function') ? s(key) : fallback;
+  };
+
+  window.ymAlert = function (msg) {
+    return show(
+      '<p style="margin:0 0 18px;white-space:pre-wrap">' + esc(msg) + '</p>' +
+      '<div class="ym-dialog-btns">' +
+        '<button class="btn-primary" onclick="document.querySelector(\'#ym-dialog .btn-primary\').blur()" id="ym-dlg-ok">' + label('btn.close', 'OK') + '</button>' +
+      '</div>'
+    ).then(function () {
+      // void — alert returns nothing
+    }).finally(function () {
+      // re-wire after render
+    });
+  };
+  // wire click after innerHTML render
+  var wireOk = function (val) {
+    var b = document.getElementById('ym-dlg-ok');
+    if (b) b.onclick = function () { dismiss(val); };
+  };
+
+  window.ymAlert = function (msg) {
+    var p = show(
+      '<p style="margin:0 0 18px;white-space:pre-wrap">' + esc(msg) + '</p>' +
+      '<div class="ym-dialog-btns">' +
+        '<button class="btn-primary" id="ym-dlg-ok">' + label('btn.close', 'OK') + '</button>' +
+      '</div>'
+    );
+    wireOk(undefined);
+    return p;
+  };
+
+  window.ymConfirm = function (msg) {
+    var p = show(
+      '<p style="margin:0 0 18px;white-space:pre-wrap">' + esc(msg) + '</p>' +
+      '<div class="ym-dialog-btns">' +
+        '<button class="btn-ghost" id="ym-dlg-cancel">' + label('btn.cancel', 'Cancel') + '</button>' +
+        '<button class="btn-primary" id="ym-dlg-ok">' + label('btn.confirm', 'Confirm') + '</button>' +
+      '</div>'
+    );
+    wireOk(true);
+    var bc = document.getElementById('ym-dlg-cancel');
+    if (bc) bc.onclick = function () { dismiss(false); };
+    return p.then(function (v) { return v === true; });
+  };
+
+  window.ymPrompt = function (msg, defaultVal) {
+    var p = show(
+      '<label style="display:block;margin-bottom:12px;white-space:pre-wrap">' + esc(msg) + '</label>' +
+      '<input type="text" id="ym-dlg-input" class="input" value="' + esc(defaultVal || '') + '" style="width:100%;margin-bottom:18px">' +
+      '<div class="ym-dialog-btns">' +
+        '<button class="btn-ghost" id="ym-dlg-cancel">' + label('btn.cancel', 'Cancel') + '</button>' +
+        '<button class="btn-primary" id="ym-dlg-ok">' + label('btn.confirm', 'OK') + '</button>' +
+      '</div>'
+    );
+    var inp = document.getElementById('ym-dlg-input');
+    if (inp) { inp.focus(); inp.select(); }
+    wireOk('__submit__');
+    var bc = document.getElementById('ym-dlg-cancel');
+    if (bc) bc.onclick = function () { dismiss(null); };
+    if (inp) inp.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') dismiss('__submit__');
+    });
+    return p.then(function (v) {
+      if (v === '__submit__') {
+        var el = document.getElementById('ym-dlg-input');
+        return el ? el.value : '';
+      }
+      return null;
+    });
+  };
+})();
+
 // ── STANDARD HEADER ────────────────────────────────────────────────────────────
 window.buildHeader = function (page) {
   const user = (typeof getUser === 'function') ? getUser() : null;

--- a/staff/index.html
+++ b/staff/index.html
@@ -872,7 +872,7 @@ async function submitCheckout() {
   // Charter override warning for staff
   if (isChartered(boat)) {
     const ch = boat.charter;
-    if (!confirm(s('fleet.charterOverride', { name: ch.memberName, date: ch.endDate }))) return;
+    if (!await ymConfirm(s('fleet.charterOverride', { name: ch.memberName, date: ch.endDate }))) return;
   }
   const snap     = (typeof wxSnapshot === 'function') ? wxSnapshot(wxData) : null;
   try {
@@ -950,17 +950,17 @@ async function staffCheckIn(id) {
     if (localCo) { localCo.status = 'in'; localCo.checkedInAt = timeIn; }
     renderAll();
     showToast(s('toast.checkedIn'));
-  } catch(e) { alert(s('toast.error') + ': ' + e.message); }
+  } catch(e) { ymAlert(s('toast.error') + ': ' + e.message); }
 }
 
 async function staffDeleteCheckout(id, boatName) {
-  if (!confirm(`${s('staff.deleteCheckout')}: ${boatName||''}?`)) return;
+  if (!await ymConfirm(`${s('staff.deleteCheckout')}: ${boatName||''}?`)) return;
   try {
     await apiPost('deleteCheckout', { id });
     checkouts = checkouts.filter(c => c.id !== id);
     renderAll();
     showToast(s('toast.deleted'));
-  } catch(e) { alert(s('toast.error')+': '+e.message); }
+  } catch(e) { ymAlert(s('toast.error')+': '+e.message); }
 }
 
 // ── Checkout detail modal ─────────────────────────────────────────────────────
@@ -1039,7 +1039,7 @@ async function resolveAlertAction(checkoutId, op, btnEl) {
     setTimeout(() => load(), 1500);
   } catch(e) {
     btnEl.disabled = false;
-    alert(gs_('error') + ': ' + e.message);
+    ymAlert(gs_('error') + ': ' + e.message);
   }
 }
 
@@ -1223,7 +1223,7 @@ function openGroupModal() {
     btn.dataset.id = b.id;
     if (boolVal(b.oos)) { btn.disabled = true; btn.style.opacity='.35'; btn.title = 'Out of service'; }
     else if (out) { btn.disabled = true; btn.style.opacity='.35'; btn.title = 'Already out'; }
-    else if (isChartered(b)) { btn.style.opacity='.55'; btn.title = s('fleet.charteredTo',{name:b.charter.memberName}); btn.addEventListener('click', function() { if(confirm(s('fleet.charterOverride',{name:b.charter.memberName,date:b.charter.endDate}))) toggleGmBoat(this); }); }
+    else if (isChartered(b)) { btn.style.opacity='.55'; btn.title = s('fleet.charteredTo',{name:b.charter.memberName}); btn.addEventListener('click', async function() { if(await ymConfirm(s('fleet.charterOverride',{name:b.charter.memberName,date:b.charter.endDate}))) toggleGmBoat(this); }); }
     else btn.addEventListener('click', function() { toggleGmBoat(this); });
     grid.appendChild(btn);
   });
@@ -1367,7 +1367,7 @@ async function staffGroupCheckIn(id) {
     checkouts = (await apiGet('getActiveCheckouts')).checkouts || [];
     renderAll();
     showToast(s('toast.checkedIn'));
-  } catch(e) { alert(s('toast.error') + ': ' + e.message); }
+  } catch(e) { ymAlert(s('toast.error') + ': ' + e.message); }
 }
 
 function renderGroupCard(c) {

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -635,7 +635,7 @@ async function tcmAssign() {
 
 async function deleteCert(certId, subcatKey) {
   if (!_certMember) return;
-  if (!confirm('Remove this credential?')) return;
+  if (!await ymConfirm('Remove this credential?')) return;
 
   const m = _allMembers.find(x => x.id === _certMember.id);
   if (!m) return;


### PR DESCRIPTION
All ~30 browser-native dialog calls (which showed "skarfur.github.io says") are replaced with ymConfirm(), ymAlert(), and ymPrompt() — Promise-based utilities that reuse the existing .modal-overlay + .modal CSS system to match the site's dark nautical theme.

https://claude.ai/code/session_01BZfbTCEkvpnLTLEVi74tGH