### PR TITLE
Fix admin page loading bug by embedding payroll as iframe tab

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -506,6 +506,11 @@
     </div><!-- /tab-flags -->
     </div><!-- /top-settings -->
 
+    <!-- ══ TOP: PAYROLL (embedded) ═══════════════════════════════════════════ -->
+    <div id="top-payroll" class="hidden">
+      <iframe id="payrollFrame" src="about:blank" style="width:100%;border:none;min-height:80vh"></iframe>
+    </div>
+
 <!-- ══ MODALS ════════════════════════════════════════════════════════════════ -->
 
 <!-- Member modal -->
@@ -1012,6 +1017,13 @@ let boatCats     = [];   // active only
 let _bcEditingId = null;
 
 // ── Init ───────────────────────────────────────────────────────────────────────
+window.addEventListener('message', e => {
+  if (e.data && e.data.type === 'payroll-resize') {
+    const frame = document.getElementById('payrollFrame');
+    if (frame) frame.style.height = e.data.height + 'px';
+  }
+});
+
 document.addEventListener("DOMContentLoaded", () => {
   buildHeader('admin');
   applyStrings();
@@ -1106,15 +1118,21 @@ function toggleSection(head) {
 
 // ── Top-level tab switching ────────────────────────────────────────────────────
 function showTopTab(top) {
-  if (top === 'payroll') { location.href = 'payroll/'; return; }
   document.querySelectorAll('#topTabBar .tab-btn').forEach(b => {
     b.classList.toggle('active', b.dataset.top === top);
   });
   document.getElementById('top-members').classList.toggle('hidden', top !== 'members');
   document.getElementById('top-settings').classList.toggle('hidden', top !== 'settings');
+  document.getElementById('top-payroll').classList.toggle('hidden', top !== 'payroll');
   if (top === 'settings') {
     const active = document.querySelector('#settingsTabBar .tab-btn.active');
     showTab(active ? active.dataset.tab : 'boats');
+  }
+  if (top === 'payroll') {
+    const frame = document.getElementById('payrollFrame');
+    if (frame.src === 'about:blank' || !frame.src.includes('payroll/')) {
+      frame.src = 'payroll/?embed=1';
+    }
   }
   const url = new URL(window.location.href);
   url.searchParams.set('top', top);

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -11,10 +11,11 @@
   <script src="../../shared/payroll.js"></script>
   </head>
 <body>
+<script>var _embedded=new URLSearchParams(window.location.search).get('embed')==='1';</script>
 <div class="page">
-  <header id="ym-header"><div class="header-left"></div><div class="header-right"></div></header>
+  <header id="ym-header" class="pr-standalone-only"><div class="header-left"></div><div class="header-right"></div></header>
   <main>
-    <div style="display:flex;align-items:baseline;gap:12px;margin-bottom:20px">
+    <div class="pr-standalone-only" style="display:flex;align-items:baseline;gap:12px;margin-bottom:20px">
       <h2 style="margin:0;font-size:18px" data-s="admin.tabPayroll"></h2>
       <a href="../" style="font-size:11px;color:var(--muted);text-decoration:none">&#8592; Admin</a>
     </div>
@@ -210,7 +211,18 @@ function prToggleId(id){var el=document.getElementById(id);if(el)el.classList.to
 
 /* == Bootstrap == */
 var user=requireAuth(isAdmin);
-if(user){buildHeader('payroll');applyStrings(document.body);}
+if(user){
+  if(!_embedded) buildHeader('payroll');
+  applyStrings(document.body);
+  if(_embedded){
+    document.querySelectorAll('.pr-standalone-only').forEach(function(el){el.style.display='none';});
+    document.body.style.margin='0';document.body.style.padding='0';
+    new ResizeObserver(function(){
+      var h=document.documentElement.scrollHeight;
+      if(window.parent!==window) window.parent.postMessage({type:'payroll-resize',height:h},'*');
+    }).observe(document.body);
+  }
+}
 var _members=[],_empData={},_empByMember={},_previewData={},_tsEmployees=[],_closedPeriods=new Set();
 var _tsEntries=[],_calYear=new Date().getFullYear(),_calMonth=new Date().getMonth(),_calView='cal',_editId=null;
 function _e(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}


### PR DESCRIPTION
Instead of redirecting to a separate page when clicking the Payroll tab (which broke back-navigation and caused loading issues), payroll is now embedded as an iframe within the admin page. The payroll code remains in its separate file but renders inline like other top-level tabs. When accessed directly, payroll still works as a standalone page.

Fixes #231

https://claude.ai/code/session_01VS66btgMcq36rUhvhPdUgh