### PR TITLE
Fix SyntaxError: add missing async to onMcmCategoryChange

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2547,7 +2547,7 @@ function populateMcmCategories() {
   sel.appendChild(addOpt);
 }
 
-function onMcmCategoryChange() {
+async function onMcmCategoryChange() {
   const sel = document.getElementById("mcmCategory");
   if (sel.value === "__add__") {
     const name = await ymPrompt("Enter new category name:");


### PR DESCRIPTION
The function uses `await ymPrompt(...)` but was not declared as async, causing "await is only valid in async functions" and preventing the admin page from loading.

Fixes #231

https://claude.ai/code/session_01VS66btgMcq36rUhvhPdUgh