### PR TITLE
Extract shared trip card CSS into shared/tripcard.css

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -7,6 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../shared/style.css">
+<link rel="stylesheet" href="../shared/tripcard.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
 <script src="../shared/strings.js"></script>
@@ -61,62 +62,6 @@
 .sev-high     { background:var(--orange); }
 .sev-critical { background:var(--red); }
 
-/* ── Trip cards (logbook-style) ── */
-.trip-card { background:var(--surface); border:1px solid var(--border); border-radius:8px;
-  margin-bottom:8px; overflow:hidden; cursor:pointer; transition:border-color .15s; }
-.trip-card:hover { border-color:var(--brass); }
-.trip-card-main { display:grid; grid-template-columns:52px 1fr auto; align-items:stretch; }
-.trip-date-col { background:var(--card); border-right:1px solid var(--border);
-  display:flex; flex-direction:column; align-items:center; justify-content:center; padding:10px 6px; text-align:center; }
-.trip-date-day { font-size:16px; font-weight:500; color:var(--text); line-height:1; }
-.trip-date-mon { font-size:14px; font-weight:500; color:var(--text); text-transform:uppercase; margin-top:2px; }
-.trip-date-yr { font-size:9px; color:var(--muted); }
-.trip-body { padding:10px 12px; min-width:0; }
-.trip-boat { font-size:14px; font-weight:500; color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; margin-bottom:4px; }
-.trip-meta { display:flex; gap:10px; flex-wrap:wrap; font-size:11px; color:var(--muted); align-items:center; }
-.trip-badge { font-size:9px; letter-spacing:.6px; padding:2px 6px; border-radius:8px; border:1px solid; text-transform:uppercase; flex-shrink:0; }
-.badge-skipper { color:var(--brass); border-color:var(--brass)55; background:var(--brass)11; }
-.badge-crew { color:var(--muted); border-color:var(--border); background:var(--surface); }
-.badge-verified { color:#2ecc71; border-color:#2ecc7155; background:#2ecc7111; }
-.trip-arrow { padding:10px 10px 10px 0; display:flex; align-items:center; color:var(--muted); font-size:11px; transition:transform .2s; flex-shrink:0; }
-.trip-card.open .trip-arrow { transform:rotate(180deg); }
-.trip-expand { display:none; padding:0 12px 0; }
-.trip-card.open .trip-expand { display:block; }
-.trip-expand-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:4px 12px; font-size:11px;
-  border-top:1px solid var(--border); padding-top:10px; margin-top:2px; }
-.trip-exp-row { display:flex; flex-direction:column; gap:1px; padding:4px 0; }
-.trip-exp-lbl { font-size:9px; color:var(--muted); letter-spacing:.6px; text-transform:uppercase; }
-.trip-exp-val { color:var(--text); }
-.cq-trip-captain { font-size:10px; color:var(--muted); font-weight:400; margin-left:4px; }
-
-/* ── Expandable sections ── */
-.exp-section { margin:0 -12px; padding:6px 12px 10px; border-top:1px solid var(--border); }
-.exp-section:first-child { padding-top:10px; }
-.exp-section .trip-expand-grid { border-top:none; padding-top:2px; margin-top:0; }
-.exp-boat { background:var(--card); }
-.exp-logistics { background:var(--card); }
-.exp-weather { background:rgba(41,128,185,.08); }
-.exp-weather .trip-expand-grid { padding-top:4px; }
-.exp-notes { background:rgba(255,255,255,.02); }
-.exp-section-hdr { font-size:9px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; margin-bottom:4px; font-weight:500; }
-.exp-section-hdr.expandable { cursor:pointer; display:flex; align-items:center; gap:4px; }
-.exp-section-hdr.expandable:hover { color:var(--brass); }
-.exp-section-hdr .exp-chevron { font-size:10px; transition:transform .2s; transform:rotate(0deg); }
-.exp-section-hdr.expanded .exp-chevron { transform:rotate(180deg); }
-.exp-section-detail { display:none; margin-top:4px; }
-.exp-section-detail.open { display:block; }
-
-/* ── Trip action buttons ── */
-.trip-actions { display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; padding-top:8px; border-top:1px solid var(--border); }
-.trip-action-btn { background:var(--surface); border:1px solid var(--border); color:var(--muted); border-radius:6px;
-  padding:4px 10px; font-size:10px; font-family:inherit; cursor:pointer; display:inline-flex; align-items:center; gap:4px;
-  transition:color .15s,border-color .15s; }
-.trip-action-btn:hover { color:var(--brass); border-color:var(--brass); }
-.trip-action-btn.primary { color:var(--brass); border-color:var(--brass)55; }
-.trip-more-btn { background:none; border:1px solid var(--border); color:var(--muted); border-radius:5px;
-  padding:3px 10px; font-size:10px; font-family:inherit; cursor:pointer; margin-top:4px;
-  transition:color .15s,border-color .15s; }
-.trip-more-btn:hover { color:var(--brass); border-color:var(--brass); }
 
 /* ── Show-more button ── */
 .cq-show-more { width:100%; background:var(--surface); border:1px solid var(--border); border-radius:8px;
@@ -146,15 +91,9 @@
 @media(max-width:600px){
   .cq-stats { grid-template-columns:1fr 1fr; }
   .cq-stat .sn { font-size:20px; }
-  .trip-card-main { grid-template-columns:44px 1fr auto; }
-  .trip-date-col { padding:8px 4px; }
-  .trip-date-day { font-size:14px; }
-  .trip-date-mon { font-size:12px; }
-  .trip-expand-grid { grid-template-columns:1fr 1fr; }
   .cq-filter-bar { grid-template-columns:repeat(auto-fill,minmax(90px,1fr)); }
 }
 @media(max-width:400px){
-  .trip-expand-grid { grid-template-columns:1fr; }
   .cq-filter-bar { grid-template-columns:1fr 1fr; gap:4px; }
   .cq-filter-bar select, .cq-filter-bar input[type="text"] { font-size:9px; padding:3px 6px; }
 }

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -7,6 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../shared/style.css">
+<link rel="stylesheet" href="../shared/tripcard.css">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="../shared/api.js"></script>
@@ -36,27 +37,6 @@
 .filter-bar .filter-search-row{grid-column:1/-1;display:flex;gap:6px;align-items:center}
 .filter-bar .filter-search-row input{flex:1;min-width:0}
 .filter-count{font-size:10px;color:var(--muted);white-space:nowrap}
-.trip-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:8px;overflow:hidden;cursor:pointer;transition:border-color .15s}
-.trip-card:hover{border-color:var(--brass)}
-.trip-card-main{display:grid;grid-template-columns:52px 1fr auto;align-items:stretch}
-.trip-date-col{background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}
-.trip-date-day{font-size:16px;font-weight:500;color:var(--text);line-height:1}
-.trip-date-mon{font-size:14px;font-weight:500;color:var(--text);text-transform:uppercase;margin-top:2px}
-.trip-date-yr{font-size:9px;color:var(--muted)}
-.trip-body{padding:10px 12px;min-width:0}
-.trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:4px}
-.trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center}
-.trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
-.badge-skipper{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
-.badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}
-.badge-verified{color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111}
-.badge-helm{color:var(--text);border-color:var(--border);background:var(--surface)}
-.trip-expand-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:4px 12px;font-size:11px;border-top:1px solid var(--border);padding-top:10px;margin-top:2px}
-.trip-exp-row{display:flex;flex-direction:column;gap:1px;padding:4px 0}
-.trip-exp-lbl{font-size:9px;color:var(--muted);letter-spacing:.6px;text-transform:uppercase}
-.trip-exp-val{color:var(--text)}
-.trip-arrow{padding:10px 10px 10px 0;display:flex;align-items:center;color:var(--muted);font-size:11px;transition:transform .2s;flex-shrink:0}
-.trip-card.open .trip-arrow{transform:rotate(180deg)}
 .empty-note{font-size:12px;color:var(--muted);padding:20px;text-align:center}
 .load-more{width:100%;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px;font-size:11px;color:var(--muted);cursor:pointer;font-family:inherit;margin-top:4px}
 .load-more:hover{border-color:var(--brass);color:var(--text)}
@@ -90,40 +70,12 @@
 .manual-crew-row input[type="text"]{flex:1;min-width:0}
 .manual-crew-row .helm-toggle{display:flex;align-items:center;gap:4px;font-size:10px;color:var(--muted);white-space:nowrap}
 .manual-crew-row .helm-toggle input{width:auto;accent-color:var(--brass)}
-.photo-thumb{width:60px;height:60px;object-fit:cover;border-radius:6px;border:1px solid var(--border);cursor:pointer}
-.photo-thumb-link{display:block;width:60px;height:60px}
-.trip-photos{display:flex;gap:6px;flex-wrap:wrap;margin-top:4px}
 details#portDetails summary::-webkit-details-marker{display:none}
 details#portDetails[open] #portSummaryLabel::after{content:' ▴';font-size:8px}
 details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-size:8px}
-/* Expanded card sections */
-.trip-expand{display:none;padding:0 12px 0}
-.trip-card.open .trip-expand{display:block}
-.exp-section{margin:0 -12px;padding:6px 12px 10px;border-top:1px solid var(--border)}
-.exp-section:first-child{padding-top:10px}
-.exp-section .trip-expand-grid{border-top:none;padding-top:2px;margin-top:0}
-.exp-boat{background:var(--card)}
-.exp-logistics{background:var(--card)}
-.exp-weather{background:rgba(41,128,185,.08)}
-.exp-weather .trip-expand-grid{padding-top:4px}
-
-.exp-notes{background:rgba(255,255,255,.02)}
-.trip-more-btn{background:none;border:1px solid var(--border);color:var(--muted);border-radius:5px;padding:3px 10px;font-size:10px;font-family:inherit;cursor:pointer;margin-top:4px;transition:color .15s,border-color .15s}
-.trip-more-btn:hover{color:var(--brass);border-color:var(--brass)}
+/* Logbook-only: detailed toggle */
 .trip-detailed{display:none;margin-top:6px}
 .trip-detailed.open{display:block}
-.exp-section-hdr{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px;font-weight:500}
-.exp-section-hdr.expandable{cursor:pointer;display:flex;align-items:center;gap:4px}
-.exp-section-hdr.expandable:hover{color:var(--brass)}
-.exp-section-hdr .exp-chevron{font-size:10px;transition:transform .2s;transform:rotate(0deg)}
-.exp-section-hdr.expanded .exp-chevron{transform:rotate(180deg)}
-.exp-section-detail{display:none;margin-top:4px}
-.exp-section-detail.open{display:block}
-
-/* Track map thumbnail */
-.track-map-thumb{width:100%;height:140px;border-radius:6px;border:1px solid var(--border);overflow:hidden;cursor:pointer;margin-top:4px;position:relative}
-.track-map-thumb .leaflet-control-zoom,.track-map-thumb .leaflet-control-attribution{display:none}
-.track-map-expand-hint{position:absolute;bottom:6px;right:6px;background:rgba(0,0,0,.6);color:#fff;font-size:9px;padding:3px 8px;border-radius:4px;z-index:500;pointer-events:none;letter-spacing:.4px}
 
 /* Full-screen map modal */
 .map-modal-overlay{position:fixed;inset:0;background:#000e;z-index:600;display:flex;flex-direction:column}
@@ -142,13 +94,6 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .lightbox-nav.prev{left:12px}
 .lightbox-nav.next{right:12px}
 
-/* Upload thumbnails with delete */
-.upload-thumb-wrap{position:relative;display:inline-block;width:72px;height:72px;flex-shrink:0}
-.upload-thumb-wrap .photo-thumb{width:72px;height:72px}
-.upload-delete-btn{position:absolute;top:-4px;right:-4px;width:20px;height:20px;border-radius:50%;background:var(--red);border:2px solid var(--bg);color:#fff;font-size:12px;line-height:16px;text-align:center;cursor:pointer;z-index:2;display:flex;align-items:center;justify-content:center;padding:0}
-.upload-delete-btn:hover{background:#c0392b}
-.track-delete-btn{background:none;border:none;color:var(--red);font-size:11px;cursor:pointer;padding:0;margin-left:8px;opacity:.7}
-.track-delete-btn:hover{opacity:1;text-decoration:underline}
 /* ── Confirmations ── */
 .conf-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:8px 12px;margin-bottom:6px}
 .conf-card .conf-line{font-size:11px;color:var(--text);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
@@ -167,44 +112,25 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .conf-status.confirmed{background:var(--green)22;color:var(--green)}
 .conf-status.rejected{background:var(--red)22;color:var(--red)}
 .conf-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;border-radius:9px;background:var(--red);color:#fff;font-size:10px;font-weight:600;margin-left:6px;padding:0 5px;vertical-align:middle;line-height:1}
-/* ── Inline trip actions ── */
-.trip-actions{display:flex;gap:6px;flex-wrap:wrap;margin-top:8px;padding-top:8px;border-top:1px solid var(--border)}
-.trip-action-btn{background:var(--surface);border:1px solid var(--border);color:var(--muted);border-radius:6px;padding:4px 10px;font-size:10px;font-family:inherit;cursor:pointer;display:inline-flex;align-items:center;gap:4px;transition:color .15s,border-color .15s}
-.trip-action-btn:hover{color:var(--brass);border-color:var(--brass)}
-.trip-action-btn.primary{color:var(--brass);border-color:var(--brass)55}
 /* ── Photo meta toggles ── */
 .photo-meta-row{display:flex;align-items:center;gap:10px;font-size:10px;color:var(--muted);margin-top:4px}
 .photo-meta-row label{display:flex;align-items:center;gap:4px;cursor:pointer}
 .photo-meta-row input[type="checkbox"]{width:14px;height:14px;accent-color:var(--brass)}
-.photo-sharing-badge{font-size:8px;letter-spacing:.4px;padding:1px 5px;border-radius:4px;text-transform:uppercase;margin-left:4px}
-.photo-sharing-badge.shared{color:var(--green);border:1px solid var(--green)55;background:var(--green)11}
-.photo-sharing-badge.private{color:var(--muted);border:1px solid var(--border);background:var(--surface)}
-.photo-sharing-badge.club{color:var(--brass);border:1px solid var(--brass)55;background:var(--brass)11}
-
 /* ── Responsive ── */
 @media(max-width:600px){
   .page{padding:16px 12px 60px}
   .stat-strip{grid-template-columns:repeat(2,1fr)}
   .filter-bar{grid-template-columns:1fr 1fr}
-  .trip-expand-grid{grid-template-columns:1fr 1fr}
   .form-row{grid-template-columns:1fr}
   .wx-row{grid-template-columns:1fr 1fr}
   .modal-sheet{border-radius:14px 14px 0 0;padding:16px 14px 32px;max-height:95vh}
-  .upload-thumb-wrap,.upload-thumb-wrap .photo-thumb{width:56px;height:56px}
-  .photo-thumb{width:48px;height:48px}
-  .photo-thumb-link{width:48px;height:48px}
   .gm-row{grid-template-columns:1fr}
-  .trip-card-main{grid-template-columns:44px 1fr auto}
-  .trip-date-col{padding:8px 4px}
-  .trip-date-day{font-size:14px}
-  .trip-date-mon{font-size:12px}
   .trip-body{padding:8px 10px}
   .lightbox-nav{padding:6px 10px;font-size:20px}
 }
 @media(max-width:400px){
   .stat-strip{grid-template-columns:1fr 1fr}
   .filter-bar{grid-template-columns:1fr}
-  .trip-expand-grid{grid-template-columns:1fr}
   .wx-row{grid-template-columns:1fr}
 }
 </style>

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -1,0 +1,89 @@
+/* ── Trip card (shared between logbook & captain) ── */
+.trip-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:8px;overflow:hidden;cursor:pointer;transition:border-color .15s}
+.trip-card:hover{border-color:var(--brass)}
+.trip-card-main{display:grid;grid-template-columns:52px 1fr auto;align-items:stretch}
+.trip-date-col{background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}
+.trip-date-day{font-size:16px;font-weight:500;color:var(--text);line-height:1}
+.trip-date-mon{font-size:14px;font-weight:500;color:var(--text);text-transform:uppercase;margin-top:2px}
+.trip-date-yr{font-size:9px;color:var(--muted)}
+.trip-body{padding:10px 12px;min-width:0}
+.trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:4px}
+.trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center}
+.trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
+.badge-skipper{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
+.badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}
+.badge-verified{color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111}
+.badge-helm{color:var(--text);border-color:var(--border);background:var(--surface)}
+.trip-arrow{padding:10px 10px 10px 0;display:flex;align-items:center;color:var(--muted);font-size:11px;transition:transform .2s;flex-shrink:0}
+.trip-card.open .trip-arrow{transform:rotate(180deg)}
+
+/* ── Expanded card ── */
+.trip-expand{display:none;padding:0 12px 0}
+.trip-card.open .trip-expand{display:block}
+.trip-expand-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:4px 12px;font-size:11px;border-top:1px solid var(--border);padding-top:10px;margin-top:2px}
+.trip-exp-row{display:flex;flex-direction:column;gap:1px;padding:4px 0}
+.trip-exp-lbl{font-size:9px;color:var(--muted);letter-spacing:.6px;text-transform:uppercase}
+.trip-exp-val{color:var(--text)}
+
+/* ── Expandable sections ── */
+.exp-section{margin:0 -12px;padding:6px 12px 10px;border-top:1px solid var(--border)}
+.exp-section:first-child{padding-top:10px}
+.exp-section .trip-expand-grid{border-top:none;padding-top:2px;margin-top:0}
+.exp-boat{background:var(--card)}
+.exp-logistics{background:var(--card)}
+.exp-weather{background:rgba(41,128,185,.08)}
+.exp-weather .trip-expand-grid{padding-top:4px}
+.exp-notes{background:rgba(255,255,255,.02)}
+.exp-section-hdr{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px;font-weight:500}
+.exp-section-hdr.expandable{cursor:pointer;display:flex;align-items:center;gap:4px}
+.exp-section-hdr.expandable:hover{color:var(--brass)}
+.exp-section-hdr .exp-chevron{font-size:10px;transition:transform .2s;transform:rotate(0deg)}
+.exp-section-hdr.expanded .exp-chevron{transform:rotate(180deg)}
+.exp-section-detail{display:none;margin-top:4px}
+.exp-section-detail.open{display:block}
+
+/* ── Trip action buttons ── */
+.trip-actions{display:flex;gap:6px;flex-wrap:wrap;margin-top:8px;padding-top:8px;border-top:1px solid var(--border)}
+.trip-action-btn{background:var(--surface);border:1px solid var(--border);color:var(--muted);border-radius:6px;padding:4px 10px;font-size:10px;font-family:inherit;cursor:pointer;display:inline-flex;align-items:center;gap:4px;transition:color .15s,border-color .15s}
+.trip-action-btn:hover{color:var(--brass);border-color:var(--brass)}
+.trip-action-btn.primary{color:var(--brass);border-color:var(--brass)55}
+.trip-more-btn{background:none;border:1px solid var(--border);color:var(--muted);border-radius:5px;padding:3px 10px;font-size:10px;font-family:inherit;cursor:pointer;margin-top:4px;transition:color .15s,border-color .15s}
+.trip-more-btn:hover{color:var(--brass);border-color:var(--brass)}
+
+/* ── Photos ── */
+.photo-thumb{width:60px;height:60px;object-fit:cover;border-radius:6px;border:1px solid var(--border);cursor:pointer}
+.photo-thumb-link{display:block;width:60px;height:60px}
+.trip-photos{display:flex;gap:6px;flex-wrap:wrap;margin-top:4px}
+.upload-thumb-wrap{position:relative;display:inline-block;width:72px;height:72px;flex-shrink:0}
+.upload-thumb-wrap .photo-thumb{width:72px;height:72px}
+.upload-delete-btn{position:absolute;top:-4px;right:-4px;width:20px;height:20px;border-radius:50%;background:var(--red);border:2px solid var(--bg);color:#fff;font-size:12px;line-height:16px;text-align:center;cursor:pointer;z-index:2;display:flex;align-items:center;justify-content:center;padding:0}
+.upload-delete-btn:hover{background:#c0392b}
+.photo-sharing-badge{font-size:8px;letter-spacing:.4px;padding:1px 5px;border-radius:4px;text-transform:uppercase;margin-left:4px}
+.photo-sharing-badge.shared{color:var(--green);border:1px solid var(--green)55;background:var(--green)11}
+.photo-sharing-badge.private{color:var(--muted);border:1px solid var(--border);background:var(--surface)}
+.photo-sharing-badge.club{color:var(--brass);border:1px solid var(--brass)55;background:var(--brass)11}
+
+/* ── Track map ── */
+.track-map-thumb{width:100%;height:140px;border-radius:6px;border:1px solid var(--border);overflow:hidden;cursor:pointer;margin-top:4px;position:relative}
+.track-map-thumb .leaflet-control-zoom,.track-map-thumb .leaflet-control-attribution{display:none}
+.track-map-expand-hint{position:absolute;bottom:6px;right:6px;background:rgba(0,0,0,.6);color:#fff;font-size:9px;padding:3px 8px;border-radius:4px;z-index:500;pointer-events:none;letter-spacing:.4px}
+.track-delete-btn{background:none;border:none;color:var(--red);font-size:11px;cursor:pointer;padding:0;margin-left:8px;opacity:.7}
+.track-delete-btn:hover{opacity:1;text-decoration:underline}
+
+/* ── Captain tag (captain view only) ── */
+.cq-trip-captain{font-size:10px;color:var(--muted);font-weight:400;margin-left:4px}
+
+/* ── Responsive ── */
+@media(max-width:600px){
+  .trip-card-main{grid-template-columns:44px 1fr auto}
+  .trip-date-col{padding:8px 4px}
+  .trip-date-day{font-size:14px}
+  .trip-date-mon{font-size:12px}
+  .trip-expand-grid{grid-template-columns:1fr 1fr}
+  .upload-thumb-wrap,.upload-thumb-wrap .photo-thumb{width:56px;height:56px}
+  .photo-thumb{width:48px;height:48px}
+  .photo-thumb-link{width:48px;height:48px}
+}
+@media(max-width:400px){
+  .trip-expand-grid{grid-template-columns:1fr}
+}


### PR DESCRIPTION
Move duplicated trip card styles (card layout, badges, expandable sections, photos, track maps, action buttons) from captain and logbook into a single shared stylesheet. Both pages now link to shared/tripcard.css instead.

https://claude.ai/code/session_015eqD8wm3Rm4ScNYT8Bumtu