### PR TITLE
Apply tripcard CSS classes to trip cards in logbook and captain's qua…

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -649,10 +649,10 @@ function _cqTripCard(t, showCaptain) {
   var arrow = _dirArrow(cardDir);
   var windBit = '';
   if (arrow || cardWs || cardDir) {
-    windBit = '<span style="display:inline-flex;align-items:center;gap:3px">'
-      + (arrow ? '<span style="font-size:16px;line-height:1">'+arrow+'</span>' : '')
+    windBit = '<span class="trip-wind">'
+      + (arrow ? '<span class="trip-wind-arrow">'+arrow+'</span>' : '')
       + (cardWs ? '<span>'+esc(cardWs)+'</span>' : '')
-      + (cardDir ? '<span style="opacity:.7">'+esc(cardDir)+'</span>' : '')
+      + (cardDir ? '<span class="trip-wind-dir">'+esc(cardDir)+'</span>' : '')
       + '</span>';
   }
 
@@ -681,7 +681,7 @@ function _cqTripCard(t, showCaptain) {
   var crewNames = [];
   try { if (t.crewNames) crewNames = typeof t.crewNames === 'string' ? JSON.parse(t.crewNames) : t.crewNames; } catch(e){}
   var crewDisplay = crewNames.length ? crewNames.map(function(c) { return esc(typeof c === 'string' ? c : c.name||''); }).filter(Boolean).join(', ') : esc(t.crew||1);
-  var crewNamesRow = '<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">Crew</span><span class="trip-exp-val">'+crewDisplay+'</span></div>';
+  var crewNamesRow = '<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">Crew</span><span class="trip-exp-val">'+crewDisplay+'</span></div>';
 
   var toplineTrip = (t.timeOut ? '<div class="trip-exp-row"><span class="trip-exp-lbl">Departed</span><span class="trip-exp-val">'+esc(t.timeOut)+'</span></div>' : '')
     + (t.timeIn ? '<div class="trip-exp-row"><span class="trip-exp-lbl">Returned</span><span class="trip-exp-val">'+esc(t.timeIn)+'</span></div>' : '')
@@ -713,24 +713,24 @@ function _cqTripCard(t, showCaptain) {
   var canEditSkipperNote = isSki && isOwner;
   var canEditNote = isOwner;
   var skipperNoteRow = (t.skipperNote || canEditSkipperNote) ?
-    '<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl" style="color:var(--brass)">Skipper note <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">'+(isSki?'visible to crew':'from skipper')+'</span></span><span class="trip-exp-val">'+(t.skipperNote?esc(t.skipperNote):'<span style="color:var(--muted);font-style:italic">No note yet</span>')+(canEditSkipperNote?' <button class="trip-more-btn" onclick="event.stopPropagation();_cqEditNote(\''+esc(t.id)+'\',\'skipperNote\')">Edit</button>':'')+'</span></div>' : '';
+    '<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl" style="color:var(--brass)">Skipper note <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">'+(isSki?'visible to crew':'from skipper')+'</span></span><span class="trip-exp-val">'+(t.skipperNote?esc(t.skipperNote):'<span style="color:var(--muted);font-style:italic">No note yet</span>')+(canEditSkipperNote?' <button class="trip-more-btn" onclick="event.stopPropagation();_cqEditNote(\''+esc(t.id)+'\',\'skipperNote\')">Edit</button>':'')+'</span></div>' : '';
   var notesRow = (t.notes || canEditNote) ?
-    '<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">Private note <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">only you</span></span><span class="trip-exp-val">'+(t.notes?esc(t.notes):'<span style="color:var(--muted);font-style:italic">No note yet</span>')+(canEditNote?' <button class="trip-more-btn" onclick="event.stopPropagation();_cqEditNote(\''+esc(t.id)+'\',\'notes\')">Edit</button>':'')+'</span></div>' : '';
+    '<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">Private note <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">only you</span></span><span class="trip-exp-val">'+(t.notes?esc(t.notes):'<span style="color:var(--muted);font-style:italic">No note yet</span>')+(canEditNote?' <button class="trip-more-btn" onclick="event.stopPropagation();_cqEditNote(\''+esc(t.id)+'\',\'notes\')">Edit</button>':'')+'</span></div>' : '';
 
   // Photos display
   var photosRow = '';
   try {
     var urls = t.photoUrls ? JSON.parse(t.photoUrls) : [];
     if (urls.length) {
-      var thumbs = urls.slice(0,6).map(function(u) { return '<img src="'+esc(u)+'" style="width:48px;height:48px;object-fit:cover;border-radius:6px;border:1px solid var(--border)" loading="lazy" onerror="this.style.display=\'none\'">'; }).join('');
-      if (urls.length > 6) thumbs += '<span style="font-size:10px;color:var(--muted);align-self:center">+' + (urls.length-6) + ' more</span>';
-      photosRow = '<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">Photos</span><span class="trip-exp-val"><div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:4px">'+thumbs+'</div></span></div>';
+      var thumbs = urls.slice(0,6).map(function(u) { return '<img src="'+esc(u)+'" class="photo-thumb" loading="lazy" onerror="this.style.display=\'none\'">'; }).join('');
+      if (urls.length > 6) thumbs += '<span class="text-xs text-muted" style="align-self:center">+' + (urls.length-6) + ' more</span>';
+      photosRow = '<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">Photos</span><span class="trip-exp-val"><div class="trip-photos">'+thumbs+'</div></span></div>';
     }
   } catch(e){}
 
   // Action buttons
   var canEditTrip = isSki && isOwner;
-  var actionsRow = isOwner ? '<div class="trip-actions" style="grid-column:1/-1">'
+  var actionsRow = isOwner ? '<div class="trip-actions trip-exp-full">'
     + (canEditTrip ? '<button class="trip-action-btn primary" onclick="event.stopPropagation();window.open(\'../logbook/#trip-'+esc(t.id)+'\',\'_blank\')">✏️ Edit trip</button>' : '')
     + '<button class="trip-action-btn" onclick="event.stopPropagation();_cqUploadTrack(\''+esc(t.id)+'\')">📍 Add GPS</button>'
     + '<button class="trip-action-btn" onclick="event.stopPropagation();_cqUploadPhotos(\''+esc(t.id)+'\')">📷 Add photos</button>'

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -581,9 +581,9 @@ function tripCard(t){
   const cardWs  = formatWindValue(wx?.ws, t.beaufort, _windUnit);
   const cardDir = wx?.dir || t.windDir || '';
   const cardArrow = dirArrow(cardDir);
-  const windLine = [cardArrow && `<span style="font-size:16px;line-height:1">${cardArrow}</span>`,
+  const windLine = [cardArrow && `<span class="trip-wind-arrow">${cardArrow}</span>`,
                     cardWs   && `<span>${esc(cardWs)}</span>`,
-                    cardDir  && `<span style="opacity:.7">${esc(cardDir)}</span>`
+                    cardDir  && `<span class="trip-wind-dir">${esc(cardDir)}</span>`
                    ].filter(Boolean).join('');
 
   // Port display (shown on card face for keelboats)
@@ -720,7 +720,7 @@ function tripCard(t){
   const skipperNameRow = linkedSkipper ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Skipstjóri':'Skipper'}</span><span class="trip-exp-val">${esc(linkedSkipper.memberName||'?')}${skipperGuestTag}</span></div>` : '';
   const crewCountRow = `<div class="trip-exp-row"><span class="trip-exp-lbl">${IS?'Áhöfn um borð':'Crew aboard'}</span><span class="trip-exp-val">${esc(t.crew||1)}</span></div>`;
   const crewNamesRow = (linkedCrew.length || pendingCrewNames.length)
-    ? `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Áhöfn':'Crew'}</span><span class="trip-exp-val">${allCrewDisplay.join(', ')}</span></div>`
+    ? `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${IS?'Áhöfn':'Crew'}</span><span class="trip-exp-val">${allCrewDisplay.join(', ')}</span></div>`
     : '';
 
   // Helm assignment row — read-only display showing who was at the helm
@@ -745,7 +745,7 @@ function tripCard(t){
         `<span class="text-sm flex-center gap-4" style="display:inline-flex;color:var(--yellow);border:1px solid var(--yellow)55;border-radius:12px;padding:2px 8px;background:var(--yellow)08"><span class="text-xs">⎈</span> ${n} <span style="font-size:9px;opacity:.8">${IS?'í bið':'pending'}</span></span>`
       );
       const allPills = confirmedPills.concat(pendingPills).join(' ');
-      helmRow = `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Við stýri':'At the helm'}</span><span class="trip-exp-val"><div class="flex-center flex-wrap gap-4">${allPills}</div></span></div>`;
+      helmRow = `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${IS?'Við stýri':'At the helm'}</span><span class="trip-exp-val"><div class="flex-center flex-wrap gap-4">${allPills}</div></span></div>`;
     }
   }
 
@@ -763,22 +763,22 @@ function tripCard(t){
   const trackDeleteBtn = isOwner && t.trackFileUrl ? `<button class="track-delete-btn" onclick="event.stopPropagation();deleteTripTrack('${esc(t.id)}')">${IS?'Eyða leið':'Delete track'}</button>` : '';
   let trackRow = '';
   if (trackPoints.length >= 2) {
-    trackRow = `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'GPS-leið':'GPS Track'}${t.trackSource?' · '+esc(t.trackSource):''}${trackDeleteBtn}</span><span class="trip-exp-val">
+    trackRow = `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${IS?'GPS-leið':'GPS Track'}${t.trackSource?' · '+esc(t.trackSource):''}${trackDeleteBtn}</span><span class="trip-exp-val">
       <div class="track-map-thumb" id="tmap-${esc(t.id)}" onclick="event.stopPropagation();openMapModal('${esc(t.id)}')" data-track="${JSON.stringify(trackPoints).replace(/&/g,'&amp;').replace(/"/g,'&quot;')}">
         <div class="track-map-expand-hint">${IS?'Smelltu til að stækka':'Click to expand'}</div>
       </div>
       ${t.trackFileUrl?`<a href="${esc(t.trackFileUrl)}" target="_blank" class="text-xs text-brass" style="margin-top:4px;display:inline-block" onclick="event.stopPropagation()">⬇ ${IS?'Sækja skrá':'Download file'}</a>`:''}
     </span></div>`;
   } else if (t.trackFileUrl) {
-    trackRow = `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'GPS-leið':'GPS Track'}</span><span class="trip-exp-val"><a href="${esc(t.trackFileUrl)}" target="_blank" class="text-brass" onclick="event.stopPropagation()">📍 ${IS?'Skoða leið':'View track'}</a>${t.trackSource?' · '+esc(t.trackSource):''}${trackDeleteBtn}</span></div>`;
+    trackRow = `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${IS?'GPS-leið':'GPS Track'}</span><span class="trip-exp-val"><a href="${esc(t.trackFileUrl)}" target="_blank" class="text-brass" onclick="event.stopPropagation()">📍 ${IS?'Skoða leið':'View track'}</a>${t.trackSource?' · '+esc(t.trackSource):''}${trackDeleteBtn}</span></div>`;
   }
 
   // Skipper note (visible to crew) — always show for skipper with edit, show for crew if present
   const canEditSkipperNote = isSki && isOwner;
-  const skipperNoteRow = (t.skipperNote || canEditSkipperNote) ? `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl text-brass">${IS?'Skipstjóraskýring':'Skipper note'} <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">${isSki?(IS?'sýnilegt áhöfn':'visible to crew'):(IS?'frá skipstjóra':'from skipper')}</span></span><span class="trip-exp-val" id="skipperNote-${esc(t.id)}">${t.skipperNote?esc(t.skipperNote):`<span class="text-muted" style="font-style:italic">${IS?'Engin skýring':'No note yet'}</span>`}${canEditSkipperNote?` <button class="trip-more-btn" onclick="event.stopPropagation();editNote('${esc(t.id)}','skipperNote')" style="margin-left:6px">${IS?'Breyta':'Edit'}</button>`:''}</span></div>` : '';
+  const skipperNoteRow = (t.skipperNote || canEditSkipperNote) ? `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl text-brass">${IS?'Skipstjóraskýring':'Skipper note'} <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">${isSki?(IS?'sýnilegt áhöfn':'visible to crew'):(IS?'frá skipstjóra':'from skipper')}</span></span><span class="trip-exp-val" id="skipperNote-${esc(t.id)}">${t.skipperNote?esc(t.skipperNote):`<span class="text-muted" style="font-style:italic">${IS?'Engin skýring':'No note yet'}</span>`}${canEditSkipperNote?` <button class="trip-more-btn" onclick="event.stopPropagation();editNote('${esc(t.id)}','skipperNote')" style="margin-left:6px">${IS?'Breyta':'Edit'}</button>`:''}</span></div>` : '';
   // Private note (only visible to owner) — always show for owner with edit
   const canEditNote = isOwner;
-  const notesRow = (t.notes || canEditNote) ? `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Athugasemd':'Private note'} <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">${IS?'aðeins þú sérð':'only you'}</span></span><span class="trip-exp-val" id="privateNote-${esc(t.id)}">${t.notes?esc(t.notes):`<span class="text-muted" style="font-style:italic">${IS?'Engin athugasemd':'No note yet'}</span>`}${canEditNote?` <button class="trip-more-btn" onclick="event.stopPropagation();editNote('${esc(t.id)}','notes')" style="margin-left:6px">${IS?'Breyta':'Edit'}</button>`:''}</span></div>` : '';
+  const notesRow = (t.notes || canEditNote) ? `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${IS?'Athugasemd':'Private note'} <span style="font-weight:400;opacity:.6;font-size:8px;text-transform:none">${IS?'aðeins þú sérð':'only you'}</span></span><span class="trip-exp-val" id="privateNote-${esc(t.id)}">${t.notes?esc(t.notes):`<span class="text-muted" style="font-style:italic">${IS?'Engin athugasemd':'No note yet'}</span>`}${canEditNote?` <button class="trip-more-btn" onclick="event.stopPropagation();editNote('${esc(t.id)}','notes')" style="margin-left:6px">${IS?'Breyta':'Edit'}</button>`:''}</span></div>` : '';
   const photosRow = (()=>{
     let urls=[]; try{if(t.photoUrls)urls=JSON.parse(t.photoUrls);}catch(e){}
     let meta={}; try{if(t.photoMeta)meta=JSON.parse(t.photoMeta);}catch(e){}
@@ -807,11 +807,11 @@ function tripCard(t){
         ${badges?`<div style="margin-top:2px">${badges}</div>`:''}
       </div>`;
     }).join('');
-    return `<div class="trip-exp-row" style="grid-column:1/-1"><span class="trip-exp-lbl">${IS?'Myndir':'Photos'}</span><span class="trip-exp-val"><div class="trip-photos">${thumbs}</div></span></div>`;
+    return `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${IS?'Myndir':'Photos'}</span><span class="trip-exp-val"><div class="trip-photos">${thumbs}</div></span></div>`;
   })();
   // Action buttons: edit (skipper+owner only), add GPS/photos (owner)
   const canEditTrip = isSki && isOwner;
-  const actionsRow = isOwner ? `<div class="trip-actions" style="grid-column:1/-1">
+  const actionsRow = isOwner ? `<div class="trip-actions trip-exp-full">
     ${canEditTrip ? `<button class="trip-action-btn primary" onclick="event.stopPropagation();openEditTrip('${esc(t.id)}')">${IS?'✏️ Breyta ferð':'✏️ Edit trip'}</button>` : ''}
     ${!t.trackFileUrl ? `<button class="trip-action-btn" onclick="event.stopPropagation();inlineUploadTrack('${esc(t.id)}')">${IS?'📍 Bæta við GPS':'📍 Add GPS'}</button>` : ''}
     <button class="trip-action-btn" onclick="event.stopPropagation();inlineUploadPhotos('${esc(t.id)}')">${IS?'📷 Bæta við myndum':'📷 Add photos'}</button>
@@ -838,7 +838,7 @@ function tripCard(t){
           ${(t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ '+(IS?'Staðfesting í bið':'Verification pending')+'</span>' : ''}
           <span>${esc(dur)}</span>
           ${t.distanceNm?`<span>${esc(t.distanceNm)} nm</span>`:''}
-          ${windLine?'<span class="flex-center" style="gap:3px">'+windLine+'</span>':''}
+          ${windLine?'<span class="trip-wind">'+windLine+'</span>':''}
           ${isKeelboat&&portLine?portLine:''}
         </div>
       </div>

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -70,6 +70,14 @@
 .track-delete-btn{background:none;border:none;color:var(--red);font-size:11px;cursor:pointer;padding:0;margin-left:8px;opacity:.7}
 .track-delete-btn:hover{opacity:1;text-decoration:underline}
 
+/* ── Full-width row ── */
+.trip-exp-full{grid-column:1/-1}
+
+/* ── Wind display on card face ── */
+.trip-wind{display:inline-flex;align-items:center;gap:3px}
+.trip-wind-arrow{font-size:16px;line-height:1}
+.trip-wind-dir{opacity:.7}
+
 /* ── Captain tag (captain view only) ── */
 .cq-trip-captain{font-size:10px;color:var(--muted);font-weight:400;margin-left:4px}
 


### PR DESCRIPTION
…rters

Replace inline styles with shared CSS classes from tripcard.css:
- Add .trip-exp-full class for full-width grid rows (replaces grid-column:1/-1)
- Add .trip-wind, .trip-wind-arrow, .trip-wind-dir classes for wind display
- Use .photo-thumb and .trip-photos classes in captain's page (was inline)
- Replace all grid-column inline styles in both pages with .trip-exp-full

Closes #238

https://claude.ai/code/session_01Rt2BwwRMKcCcHWd28wixkH