### PR TITLE
Skip issuing authority requirement for club endorsements

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2659,9 +2659,9 @@ async function assignMemberCert() {
     : (def?.name || certId);
   if (!title) { toast(s('admin.certTitleRequired'), "err"); return; }
 
-  // Issuing authority (mandatory)
+  // Issuing authority (mandatory for non-endorsements)
   const issuingAuthority = document.getElementById("mcmIssuingAuthority").value.trim();
-  if (!issuingAuthority) { toast(s('admin.certAuthorityReq'), "err"); return; }
+  if (!issuingAuthority && !def?.clubEndorsement) { toast(s('admin.certAuthorityReq'), "err"); return; }
 
   // Expiry
   const expires   = document.getElementById("mcmExpires").checked;

--- a/captain/index.html
+++ b/captain/index.html
@@ -1277,7 +1277,7 @@ async function assignMemberCert() {
   if (!title) { toast(s('admin.certTitleRequired'), 'err'); return; }
 
   const issuingAuthority = document.getElementById('mcmIssuingAuthority').value.trim();
-  if (!issuingAuthority) { toast(s('admin.certAuthorityReq'), 'err'); return; }
+  if (!issuingAuthority && !def?.clubEndorsement) { toast(s('admin.certAuthorityReq'), 'err'); return; }
 
   const expires   = document.getElementById('mcmExpires').checked;
   const expiresAt = expires ? document.getElementById('mcmExpiresAt').value : '';


### PR DESCRIPTION
Club endorsements do not need an issuing authority, so the validation is now bypassed when the credential type has clubEndorsement set.

https://claude.ai/code/session_01TYfAtueMuUVWeMy46Tk9i4