### PR TITLE
Extract cert validation into shared buildMemberCertFromForm()

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2642,51 +2642,12 @@ async function assignMemberCert() {
   const m      = members.find(x => String(x.id) === String(mcmMemberId));
   if (!m) return;
 
-  const category = document.getElementById("mcmCategory").value;
-  const certId   = document.getElementById("mcmCertType").value;
-  const isCustom = certId === "__custom__";
+  const newCert = buildMemberCertFromForm(certDefs, getUser()?.name || 'Staff');
+  if (!newCert) return;
 
-  if (!certId) { toast(s('cert.typeRequired'), "err"); return; }
-  if (!category || category === "__add__") { toast(s('admin.certCategoryReq'), "err"); return; }
-
-  const def = isCustom ? null : certDefs.find(d => d.id === certId);
-  const sub = def?.subcats?.length ? document.getElementById("mcmSubcat").value : null;
-  if (def?.subcats?.length && !sub) { toast(s('cert.levelRequired'), "err"); return; }
-
-  // Title
-  const title = isCustom
-    ? document.getElementById("mcmCustomTitle").value.trim()
-    : (def?.name || certId);
-  if (!title) { toast(s('admin.certTitleRequired'), "err"); return; }
-
-  // Issuing authority (mandatory for non-endorsements)
-  const issuingAuthority = document.getElementById("mcmIssuingAuthority").value.trim();
-  if (!issuingAuthority && !def?.clubEndorsement) { toast(s('admin.certAuthorityReq'), "err"); return; }
-
-  // Expiry
-  const expires   = document.getElementById("mcmExpires").checked;
-  const expiresAt = expires ? document.getElementById("mcmExpiresAt").value : '';
-  if (expires && !expiresAt) { toast(s('admin.certExpiryReq'), "err"); return; }
-
-  const userName = getUser()?.name || "Staff";
-  const now      = todayISO();
-
-  const newCert = {
-    certId:           isCustom ? null : certId,
-    sub:              sub || null,
-    category,
-    title,
-    idNumber:         document.getElementById("mcmIdNumber").value.trim() || '',
-    issuingAuthority,
-    issueDate:        document.getElementById("mcmIssueDate").value || '',
-    expires,
-    expiresAt:        expiresAt || '',
-    description:      document.getElementById("mcmDescription").value.trim() || '',
-    assignedBy:       userName,
-    assignedAt:       now,
-    verifiedBy:       userName,
-    verifiedAt:       now,
-  };
+  const certId   = newCert.certId;
+  const sub      = newCert.sub;
+  const isCustom = !certId;
 
   let existing = parseJson(m.certifications, []);
   if (!isCustom) {

--- a/captain/index.html
+++ b/captain/index.html
@@ -1260,48 +1260,12 @@ async function assignMemberCert() {
   const m = _mcmMembers().find(x => String(x.id) === String(mcmMemberId));
   if (!m) return;
 
-  const category = document.getElementById('mcmCategory').value;
-  const certId   = document.getElementById('mcmCertType').value;
-  const isCustom = certId === '__custom__';
+  const newCert = buildMemberCertFromForm(_mcmCertDefs(), getUser()?.name || 'Captain');
+  if (!newCert) return;
 
-  if (!certId) { toast(s('cert.typeRequired'), 'err'); return; }
-  if (!category || category === '__add__') { toast(s('admin.certCategoryReq'), 'err'); return; }
-
-  const def = isCustom ? null : _mcmCertDefs().find(d => d.id === certId);
-  const sub = def?.subcats?.length ? document.getElementById('mcmSubcat').value : null;
-  if (def?.subcats?.length && !sub) { toast(s('cert.levelRequired'), 'err'); return; }
-
-  const title = isCustom
-    ? document.getElementById('mcmCustomTitle').value.trim()
-    : (def?.name || certId);
-  if (!title) { toast(s('admin.certTitleRequired'), 'err'); return; }
-
-  const issuingAuthority = document.getElementById('mcmIssuingAuthority').value.trim();
-  if (!issuingAuthority && !def?.clubEndorsement) { toast(s('admin.certAuthorityReq'), 'err'); return; }
-
-  const expires   = document.getElementById('mcmExpires').checked;
-  const expiresAt = expires ? document.getElementById('mcmExpiresAt').value : '';
-  if (expires && !expiresAt) { toast(s('admin.certExpiryReq'), 'err'); return; }
-
-  const userName = getUser()?.name || 'Captain';
-  const now      = todayISO();
-
-  const newCert = {
-    certId:           isCustom ? null : certId,
-    sub:              sub || null,
-    category,
-    title,
-    idNumber:         document.getElementById('mcmIdNumber').value.trim() || '',
-    issuingAuthority,
-    issueDate:        document.getElementById('mcmIssueDate').value || '',
-    expires,
-    expiresAt:        expiresAt || '',
-    description:      document.getElementById('mcmDescription').value.trim() || '',
-    assignedBy:       userName,
-    assignedAt:       now,
-    verifiedBy:       userName,
-    verifiedAt:       now,
-  };
+  const certId   = newCert.certId;
+  const sub      = newCert.sub;
+  const isCustom = !certId;
 
   let existing = parseJson(m.certifications, []);
   if (!isCustom) {

--- a/shared/certs.js
+++ b/shared/certs.js
@@ -152,6 +152,55 @@ function certCardHTML(enriched) {
   </div>`;
 }
 
+/**
+ * Validate the member-cert modal form and build a cert object.
+ * @param {Array} certDefs – the active cert definitions list
+ * @param {string} userName – name to stamp as assignedBy / verifiedBy
+ * @returns {Object|null} the cert object, or null if validation failed (toast already shown)
+ */
+function buildMemberCertFromForm(certDefs, userName) {
+  const category = document.getElementById('mcmCategory').value;
+  const certId   = document.getElementById('mcmCertType').value;
+  const isCustom = certId === '__custom__';
+
+  if (!certId) { toast(s('cert.typeRequired'), 'err'); return null; }
+  if (!category || category === '__add__') { toast(s('admin.certCategoryReq'), 'err'); return null; }
+
+  const def = isCustom ? null : certDefs.find(d => d.id === certId);
+  const sub = def?.subcats?.length ? document.getElementById('mcmSubcat').value : null;
+  if (def?.subcats?.length && !sub) { toast(s('cert.levelRequired'), 'err'); return null; }
+
+  const title = isCustom
+    ? document.getElementById('mcmCustomTitle').value.trim()
+    : (def?.name || certId);
+  if (!title) { toast(s('admin.certTitleRequired'), 'err'); return null; }
+
+  const issuingAuthority = document.getElementById('mcmIssuingAuthority').value.trim();
+  if (!issuingAuthority && !def?.clubEndorsement) { toast(s('admin.certAuthorityReq'), 'err'); return null; }
+
+  const expires   = document.getElementById('mcmExpires').checked;
+  const expiresAt = expires ? document.getElementById('mcmExpiresAt').value : '';
+  if (expires && !expiresAt) { toast(s('admin.certExpiryReq'), 'err'); return null; }
+
+  const now = todayISO();
+  return {
+    certId:           isCustom ? null : certId,
+    sub:              sub || null,
+    category,
+    title,
+    idNumber:         document.getElementById('mcmIdNumber').value.trim() || '',
+    issuingAuthority,
+    issueDate:        document.getElementById('mcmIssueDate').value || '',
+    expires,
+    expiresAt:        expiresAt || '',
+    description:      document.getElementById('mcmDescription').value.trim() || '',
+    assignedBy:       userName,
+    assignedAt:       now,
+    verifiedBy:       userName,
+    verifiedAt:       now,
+  };
+}
+
 window.certCardToggle = function(id) {
   const el = document.getElementById(id);
   if (el) el.classList.toggle('ccard-open');


### PR DESCRIPTION
The duplicate validation + cert-building logic in captain and admin assignMemberCert() is now a single function in shared/certs.js. The club endorsement issuing-authority exemption lives in one place.

https://claude.ai/code/session_01TYfAtueMuUVWeMy46Tk9i4