### PR TITLE
Fix endorsement subcategories, issuing authority, and custom types

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -929,8 +929,8 @@
         <input type="text" id="mcmIdNumber" placeholder="e.g. IS-12345">
       </div>
 
-      <!-- Issuing authority -->
-      <div class="field">
+      <!-- Issuing authority (hidden for club endorsements) -->
+      <div class="field" id="mcmIssuingAuthorityField">
         <label data-s="admin.certIssuingAuth"></label>
         <input type="text" id="mcmIssuingAuthority" placeholder="e.g. World Sailing">
       </div>
@@ -2565,10 +2565,12 @@ function updateMcmCertTypes() {
     o.value = d.id; o.textContent = d.name;
     typeSel.appendChild(o);
   });
-  // Add custom option
-  const customOpt = document.createElement("option");
-  customOpt.value = "__custom__"; customOpt.textContent = s('admin.certCustomType');
-  typeSel.appendChild(customOpt);
+  // Add custom option (not for club endorsements — those are admin-defined only)
+  if (category !== 'Club Endorsement') {
+    const customOpt = document.createElement("option");
+    customOpt.value = "__custom__"; customOpt.textContent = s('admin.certCustomType');
+    typeSel.appendChild(customOpt);
+  }
   typeSel.value = "";
   document.getElementById("mcmSubcatField").style.display = "none";
   document.getElementById("mcmCustomTitleField").style.display = "none";
@@ -2627,9 +2629,16 @@ function updateMCMSubcats() {
   } else {
     sf.style.display = "none";
   }
-  // Pre-fill issuing authority from cert def if set
-  if (def?.issuingAuthority && !document.getElementById("mcmIssuingAuthority").value) {
-    document.getElementById("mcmIssuingAuthority").value = def.issuingAuthority;
+  // Hide issuing authority for club endorsements; pre-fill from def otherwise
+  const iaField = document.getElementById("mcmIssuingAuthorityField");
+  if (def?.clubEndorsement) {
+    iaField.style.display = "none";
+    document.getElementById("mcmIssuingAuthority").value = "";
+  } else {
+    iaField.style.display = "";
+    if (def?.issuingAuthority && !document.getElementById("mcmIssuingAuthority").value) {
+      document.getElementById("mcmIssuingAuthority").value = def.issuingAuthority;
+    }
   }
   // Pre-check expiry toggle from cert def (date is member-specific)
   if (def?.expires) {

--- a/captain/index.html
+++ b/captain/index.html
@@ -250,8 +250,8 @@
         <input type="text" id="mcmIdNumber" placeholder="e.g. IS-12345">
       </div>
 
-      <!-- Issuing authority -->
-      <div class="field">
+      <!-- Issuing authority (hidden for club endorsements) -->
+      <div class="field" id="mcmIssuingAuthorityField">
         <label data-s="admin.certIssuingAuth"></label>
         <input type="text" id="mcmIssuingAuthority" placeholder="e.g. World Sailing">
       </div>
@@ -1215,9 +1215,12 @@ function updateMcmCertTypes() {
     o.value = d.id; o.textContent = d.name;
     typeSel.appendChild(o);
   });
-  const customOpt = document.createElement('option');
-  customOpt.value = '__custom__'; customOpt.textContent = s('admin.certCustomType');
-  typeSel.appendChild(customOpt);
+  // Add custom option (not for club endorsements — those are admin-defined only)
+  if (category !== 'Club Endorsement') {
+    const customOpt = document.createElement('option');
+    customOpt.value = '__custom__'; customOpt.textContent = s('admin.certCustomType');
+    typeSel.appendChild(customOpt);
+  }
   typeSel.value = '';
   document.getElementById('mcmSubcatField').style.display = 'none';
   document.getElementById('mcmCustomTitleField').style.display = 'none';
@@ -1241,8 +1244,16 @@ function updateMCMSubcats() {
   } else {
     sf.style.display = 'none';
   }
-  if (def?.issuingAuthority && !document.getElementById('mcmIssuingAuthority').value) {
-    document.getElementById('mcmIssuingAuthority').value = def.issuingAuthority;
+  // Hide issuing authority for club endorsements; pre-fill from def otherwise
+  const iaField = document.getElementById('mcmIssuingAuthorityField');
+  if (def?.clubEndorsement) {
+    iaField.style.display = 'none';
+    document.getElementById('mcmIssuingAuthority').value = '';
+  } else {
+    iaField.style.display = '';
+    if (def?.issuingAuthority && !document.getElementById('mcmIssuingAuthority').value) {
+      document.getElementById('mcmIssuingAuthority').value = def.issuingAuthority;
+    }
   }
   if (def?.expires) {
     document.getElementById('mcmExpires').checked = true;

--- a/shared/certs.js
+++ b/shared/certs.js
@@ -59,10 +59,12 @@ function enrichMemberCerts(memberCerts, certDefs) {
       subcat,
       expired: expiresAt ? expiresAt < today : false,
       hasIdNumber: !!def?.hasIdNumber,
-      // Resolve display title: explicit title > def name + subcat > certId
-      displayTitle: c.title || (subcat
-        ? `${def?.name || c.certId} — ${subcat.label}`
-        : (def?.name || c.certId || 'Unknown')),
+      // Resolve display title: for predefined types use def name + subcat; for custom use title
+      displayTitle: c.certId
+        ? (subcat
+          ? `${def?.name || c.certId} — ${subcat.label}`
+          : (def?.name || c.certId || 'Unknown'))
+        : (c.title || 'Unknown'),
       // Resolve category: explicit > def category
       displayCategory: c.category || def?.category || '',
     };
@@ -172,8 +174,8 @@ function buildMemberCertFromForm(certDefs, userName) {
 
   const title = isCustom
     ? document.getElementById('mcmCustomTitle').value.trim()
-    : (def?.name || certId);
-  if (!title) { toast(s('admin.certTitleRequired'), 'err'); return null; }
+    : '';
+  if (isCustom && !title) { toast(s('admin.certTitleRequired'), 'err'); return null; }
 
   const issuingAuthority = document.getElementById('mcmIssuingAuthority').value.trim();
   if (!issuingAuthority && !def?.clubEndorsement) { toast(s('admin.certAuthorityReq'), 'err'); return null; }


### PR DESCRIPTION
- Fix subcategory display: enrichMemberCerts was using c.title (always set to def name) before checking subcategory, so subcategory labels like "Coxswain" or "Released Rower" never appeared in credential cards/badges. Now predefined types use def name + subcat label; only custom types use title.
- Stop setting title field for predefined cert types in buildMemberCertFromForm so stored data is cleaner and display logic works correctly.
- Hide issuing authority field in member cert modal when a club endorsement type is selected (both admin and captain pages).
- Remove custom type option from cert type dropdown when Club Endorsement category is selected, ensuring only admin-defined endorsement types can be assigned.

https://claude.ai/code/session_01Bry4p74yw47D2Ku8GmMBin