### PR TITLE
Fix public page map to keep initial center and zoom

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -463,13 +463,11 @@ function initMap(locations) {
     return typeof loc.lat === 'number' && typeof loc.lng === 'number' && !isNaN(loc.lat) && !isNaN(loc.lng);
   });
 
+  _map.setView([64.148, -21.965], 11.25);
+
   if (!valid.length) {
-    _map.setView([64.148, -21.965], 11.25);
     return;
   }
-
-  var bounds = L.latLngBounds(valid.map(function(loc) { return [loc.lat, loc.lng]; }));
-  _map.fitBounds(bounds.pad(0.3));
 
   var maxTrips = 1;
   valid.forEach(function(loc) { if (loc.tripCount > maxTrips) maxTrips = loc.tripCount; });


### PR DESCRIPTION
Remove fitBounds call that was repositioning the map based on heat map data. The map now always starts at the default center/zoom and only moves when the user interacts with it.

https://claude.ai/code/session_0186VE8Uk8q2oGAg7rZwVXmP