### PR TITLE
Fix logbook.js self-init running on captain page causing 'user is not…

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -15,6 +15,7 @@
 <script src="../shared/certs.js"></script>
 <script src="../shared/mcm.js"></script>
 <script src="../shared/maintenance.js"></script>
+<script>window._logbookSkipInit = true;</script>
 <script src="../shared/logbook.js"></script>
 <style>
 /* ── Stats ── */
@@ -276,7 +277,6 @@ let _cqMembers = [], _cqCertDefs = [], _cqCertCategories = [];
 // Globals required by shared/logbook.js
 var allTrips = [], myTrips = [], allBoats = [];
 const _windUnit = getPref('windUnit', 'bft');
-var _confirmations = {incoming:[], outgoing:[]};
 // parseDateParts / bftLabel used by tripCard()
 function parseDateParts(d) {
   if (!d) return {day:'—',mon:'',yr:''};

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1268,6 +1268,7 @@ async function reload(){
 }
 
 (async function init(){
+  if (window._logbookSkipInit) return;
   applyStrings();
   buildHeader('member');
   try{


### PR DESCRIPTION
… defined'

logbook.js has an IIFE that auto-initializes (fetches data, calls buildHeader('member'), references user.kennitala) - this fails on the captain page where user is defined later in an inline script.

- Add _logbookSkipInit guard to logbook.js IIFE so host pages can opt out
- Set window._logbookSkipInit=true before loading logbook.js on captain page
- Remove conflicting var _confirmations (logbook.js declares it with let)

https://claude.ai/code/session_01S5ArwLUTupynWDBKxUcqUj