### PR TITLE
Navigation audit: add back buttons to all subpages and make them more…

### DIFF
--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -147,13 +147,7 @@ var _boats = [], _locations = [], _members = [], _allMaint = [], _allTrips = [];
 // ══ INIT ═════════════════════════════════════════════════════════════════════
 (async function init() {
   applyTheme();
-  buildHeader(document.getElementById('ym-header'), {
-    title: s('cox.title'),
-    back: '../member/',
-    theme: true,
-    lang: true,
-    signOut: true,
-  });
+  buildHeader('coxswain');
   document.getElementById('cxTitle').textContent = s('cox.title');
   document.getElementById('cxSubtitle').textContent = user.name;
 

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -17,8 +17,6 @@
 <script src="../shared/boats.js"></script>
 <style>
 .page{max-width:640px;margin:0 auto;padding:20px 16px 60px}
-.back-nav{font-size:11px;color:var(--muted);text-decoration:none;display:inline-flex;align-items:center;gap:6px;margin-bottom:20px}
-.back-nav:hover{color:var(--text)}
 .stat-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:12px}
 .stat-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 12px;text-align:center}
 .stat-val{font-size:22px;font-weight:500;color:var(--text);line-height:1}
@@ -141,7 +139,6 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
   <div class="header-right"></div>
 </header>
 <div class="page">
-  <a class="back-nav" href="../member/">← Member Hub</a>
 
   <!-- Stats -->
   <div class="stat-strip">
@@ -406,6 +403,7 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 
 <script>
 requireAuth();
+buildHeader('logbook');
 const user = getUser();
 const IS   = getLang() === 'IS';
 const _windUnit = getPref('windUnit', 'bft');

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -227,7 +227,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   currentUserName = user.name || "";
   window._maintUser = user;
 
-  buildHeader('member');
+  buildHeader('saumaklubbur');
   applyStrings();
 
   try {

--- a/settings/index.html
+++ b/settings/index.html
@@ -12,8 +12,6 @@
 <script src="../shared/strings.js"></script>
 <style>
 .settings-page{max-width:560px;margin:0 auto;padding:20px 16px 60px}
-.back-nav{font-size:11px;color:var(--muted);text-decoration:none;display:inline-flex;align-items:center;gap:6px;margin-bottom:20px}
-.back-nav:hover{color:var(--text)}
 .settings-section{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:16px 18px;margin-bottom:12px}
 .settings-section-title{font-size:9px;color:var(--muted);letter-spacing:1.2px;text-transform:uppercase;margin-bottom:12px;font-weight:600}
 .settings-hint{font-size:11px;color:var(--muted);margin-top:4px}
@@ -45,7 +43,6 @@
 </header>
 
 <div class="settings-page">
-  <a class="back-nav" href="../member/">← Member Hub</a>
   <div class="fw-500 mb-16" style="font-size:16px" data-s="settings.title"></div>
 
   <!-- Initials -->

--- a/shared/style.css
+++ b/shared/style.css
@@ -143,6 +143,22 @@ main.wide { max-width: 1100px; }
 .hbtn:hover       { color: var(--brass); border-color: var(--brass); }
 .hbtn.active      { color: var(--brass); border-color: var(--brass); }
 
+.back-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 5px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  font-weight: 500;
+  transition: color .15s, border-color .15s;
+}
+.back-btn:hover { color: var(--brass); border-color: var(--brass); }
+
 /* ── CARDS ────────────────────────────────────────────────────────────────────── */
 
 .card {
@@ -737,6 +753,7 @@ textarea { min-height: 70px; }
   header { padding: 10px 12px; gap: 8px; }
   .logo { font-size: 15px; }
   .hbtn { padding: 6px 8px; font-size: 11px; }
+  .back-btn { padding: 6px 8px; font-size: 11px; }
   .header-left { gap: 8px; }
   .header-right { gap: 6px; }
   .page-title { font-size: 11px; padding-left: 8px; }
@@ -809,6 +826,7 @@ textarea { min-height: 70px; }
   .card { padding: 12px 10px; }
   header { padding: 8px 10px; }
   .hbtn { padding: 5px 6px; font-size: 10px; }
+  .back-btn { padding: 5px 6px; font-size: 10px; }
   main { padding: 12px 10px; }
   .page-content { padding: 10px 10px 80px; }
 }

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -11,15 +11,18 @@
 //
 // HEADER LAYOUT
 //
-// LEFT   = ÝMIR [⚓ Staff back-link if subpage]
+// LEFT   = ÝMIR [← Parent back-link if subpage]
 //          ⚓ Staff Hub  (shown to staff/admin when NOT on staff pages)
 //          ⛵ Members    (shown to staff/admin when NOT on member pages)
 //          ⚙ Admin       (shown to admin when NOT on admin page)
-// RIGHT  = ⛅ Weather · lang toggle · Sign out
+// RIGHT  = ⚙ Settings · ⛅ Weather · lang toggle · Sign out
 //
 // page values:
-//   hub pages   — 'staff' | 'admin' | 'member'
-//   subpages    — 'dailylog' | 'maintenance' | 'logbook-review' | 'incidents'
+//   hub pages      — 'staff' | 'admin' | 'member'
+//   staff subpages — 'dailylog' | 'maintenance' | 'logbook-review' | 'incidents'
+//   admin subpages — 'payroll'
+//   member subpages— 'settings' | 'logbook' | 'weather' | 'saumaklubbur'
+//                    'captain' | 'coxswain'
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // ── TOAST ─────────────────────────────────────────────────────────────────────
@@ -249,9 +252,11 @@ window.buildHeader = function (page) {
   // classify current page
   const STAFF_SUBPAGES  = ['dailylog', 'maintenance', 'logbook-review', 'incidents'];
   const ADMIN_SUBPAGES  = ['payroll'];
-  const isSubpage  = STAFF_SUBPAGES.includes(page);
-  const isAdminSub = ADMIN_SUBPAGES.includes(page);
-  const currentHub = isSubpage ? 'staff' : isAdminSub ? 'admin' : page;
+  const MEMBER_SUBPAGES = ['settings', 'logbook', 'weather', 'saumaklubbur', 'captain', 'coxswain'];
+  const isStaffSub  = STAFF_SUBPAGES.includes(page);
+  const isAdminSub  = ADMIN_SUBPAGES.includes(page);
+  const isMemberSub = MEMBER_SUBPAGES.includes(page);
+  const currentHub = isStaffSub ? 'staff' : isAdminSub ? 'admin' : isMemberSub ? 'member' : page;
   const depth = isAdminSub ? '../../' : '../';
   const isCaptainUser = typeof isCaptain === 'function' && user && isCaptain(user);
 
@@ -261,8 +266,9 @@ window.buildHeader = function (page) {
   left.appendChild(logo);
 
   // LEFT: back link on subpages
-  if (isSubpage)  left.appendChild(link('../staff/',   s('nav.staffHub'), 'hbtn'));
-  if (isAdminSub) left.appendChild(link('../../admin/', s('nav.admin'),   'hbtn'));
+  if (isStaffSub)  left.appendChild(link(depth + 'staff/',  '← ' + s('nav.staffHub'),  'back-btn'));
+  if (isAdminSub)  left.appendChild(link(depth + 'admin/',  '← ' + s('nav.admin'),     'back-btn'));
+  if (isMemberSub) left.appendChild(link(depth + 'member/', '← ' + s('nav.memberHub'), 'back-btn'));
 
   // LEFT: hub-switch buttons (staff/admin only)
   if (user) {
@@ -272,12 +278,12 @@ window.buildHeader = function (page) {
     if (canStaff && currentHub !== 'staff')  left.appendChild(link(depth + 'staff/',  s('nav.staffHub'),  'hbtn'));
     if (canStaff && currentHub !== 'member') left.appendChild(link(depth + 'member/', s('nav.memberHub'), 'hbtn'));
     if (canAdmin && currentHub !== 'admin')  left.appendChild(link(depth + 'admin/',  s('nav.admin'),     'hbtn'));
-    if (isCaptainUser && currentHub !== 'captain') left.appendChild(link(depth + 'captain/', s('nav.captainQuarters'), 'hbtn'));
+    if (isCaptainUser && page !== 'captain') left.appendChild(link(depth + 'captain/', s('nav.captainQuarters'), 'hbtn'));
   }
 
   // RIGHT: Settings · Weather · lang · sign out
-  if (user) right.appendChild(link(depth + 'settings/', s('nav.settings'), 'hbtn'));
-  right.appendChild(link(depth + 'weather/', s('nav.weather'), 'hbtn'));
+  if (user && page !== 'settings') right.appendChild(link(depth + 'settings/', s('nav.settings'), 'hbtn'));
+  if (page !== 'weather') right.appendChild(link(depth + 'weather/', s('nav.weather'), 'hbtn'));
   right.appendChild(btn(s('nav.langToggle'), () => { if (typeof toggleLang === 'function') toggleLang(); }));
   right.appendChild(btn(s('nav.signOut'),    () => { if (typeof signOut    === 'function') signOut();    }));
 };

--- a/weather/index.html
+++ b/weather/index.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/strings.js"></script>
+<script src="../shared/ui.js"></script>
 <script src="../shared/weather.js"></script>
 <script src="../shared/tides.js"></script>
 <style>
@@ -107,12 +108,15 @@ svg.chart { width:100%; overflow:visible; display:block; }
 </style>
 </head>
 <body>
+<header id="ym-header">
+  <div class="header-left"></div>
+  <div class="header-right"></div>
+</header>
 <div class="page">
 
   <!-- ══ TOP BAR ══ -->
   <div class="top-bar">
     <div class="top-bar-left">
-      <a href="../member/" class="text-md text-muted flex-center gap-4" style="text-decoration:none;display:inline-flex">← Member Hub</a>
       <div class="loc-row">
         <span class="loc-name" id="locName">Fossvogur</span>
         <span class="loc-coords" id="locCoords">64.1188°N 21.9376°W</span>
@@ -133,6 +137,8 @@ svg.chart { width:100%; overflow:visible; display:block; }
 </div><!-- /page -->
 
 <script>
+buildHeader('weather');
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // LOCATION SYSTEM
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
… prominent

Every authenticated subpage now gets a visible "← Parent Hub" back button in the header via buildHeader(). Added MEMBER_SUBPAGES list for settings, logbook, weather, saumaklubbur, captain, and coxswain pages. Introduced .back-btn CSS class with bolder styling (font-weight: 500, --text color). Removed duplicate inline back-nav links from settings, logbook, and weather. Fixed coxswain to use standard buildHeader API. Added header to weather page.

Closes #230

https://claude.ai/code/session_01WWQobioMwisoonHJHF3Gfh