### PR TITLE
Add heatmap to member logbook page under stats

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="../shared/tripcard.css">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"></script>
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
 <script src="../shared/strings.js"></script>
@@ -71,6 +72,15 @@
 details#portDetails summary::-webkit-details-marker{display:none}
 details#portDetails[open] #portSummaryLabel::after{content:' ▴';font-size:8px}
 details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-size:8px}
+/* ── Member heatmap ── */
+.member-heatmap{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:12px;overflow:hidden}
+.member-heatmap-header{display:flex;align-items:center;justify-content:space-between;padding:10px 14px 0}
+.member-heatmap-title{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase}
+.heatmap-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden}
+.heatmap-toggle button{background:var(--surface);border:none;color:var(--muted);font-family:inherit;font-size:10px;padding:4px 10px;cursor:pointer;transition:background .15s,color .15s;border-right:1px solid var(--border)}
+.heatmap-toggle button:last-child{border-right:none}
+.heatmap-toggle button.active{background:var(--brass);color:#000;font-weight:500}
+#memberHeatmap{height:260px;border-radius:0 0 8px 8px}
 /* Logbook-only: detailed toggle */
 .trip-detailed{display:none;margin-top:6px}
 .trip-detailed.open{display:block}
@@ -161,6 +171,19 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
   <div class="cat-hours" id="catHours" style="display:none">
     <div class="cat-hours-title">Hours by category</div>
     <div id="catHoursList"></div>
+  </div>
+
+  <!-- Member heatmap -->
+  <div class="member-heatmap" id="memberHeatmapWrap" style="display:none">
+    <div class="member-heatmap-header">
+      <span class="member-heatmap-title">Heatmap</span>
+      <div class="heatmap-toggle">
+        <button class="active" data-mode="trips" onclick="setHeatMode('trips')">Trips</button>
+        <button data-mode="time" onclick="setHeatMode('time')">Time</button>
+        <button data-mode="tracks" onclick="setHeatMode('tracks')">GPS tracks</button>
+      </div>
+    </div>
+    <div id="memberHeatmap"></div>
   </div>
 
   <!-- Share logbook -->
@@ -557,6 +580,162 @@ async function renderCerts(){
   }
 }
 
+// ── Member heatmap ───────────────────────────────────────────────────────────
+let _hmMap = null, _hmHeatLayer = null, _hmMarkers = [], _hmTrackLines = [];
+let _hmMode = 'trips'; // 'trips' | 'time' | 'tracks'
+
+function buildLocStats() {
+  const stats = {}; // locationId → { count, hours }
+  myTrips.forEach(t => {
+    const lid = t.locationId || '';
+    if (!lid) return;
+    if (!stats[lid]) stats[lid] = { count: 0, hours: 0 };
+    stats[lid].count++;
+    stats[lid].hours += parseFloat(t.hoursDecimal) || 0;
+  });
+  const result = [];
+  Object.keys(stats).forEach(lid => {
+    const loc = allLocs.find(l => l.id === lid);
+    if (!loc || !loc.coordinates) return;
+    const parts = String(loc.coordinates).split(',');
+    if (parts.length < 2) return;
+    const lat = parseFloat(parts[0]), lng = parseFloat(parts[1]);
+    if (isNaN(lat) || isNaN(lng)) return;
+    result.push({ id: lid, name: loc.name || lid, lat, lng, tripCount: stats[lid].count, totalHours: Math.round(stats[lid].hours * 10) / 10 });
+  });
+  return result;
+}
+
+function getAllTrackPoints() {
+  const allPts = [];
+  myTrips.forEach(t => {
+    if (!t.trackSimplified) return;
+    try {
+      const pts = JSON.parse(t.trackSimplified);
+      if (Array.isArray(pts)) pts.forEach(p => {
+        if (typeof p.lat === 'number' && typeof p.lng === 'number') allPts.push(p);
+      });
+    } catch(e) {}
+  });
+  return allPts;
+}
+
+function getTrackLines() {
+  const lines = [];
+  myTrips.forEach(t => {
+    if (!t.trackSimplified) return;
+    try {
+      const pts = JSON.parse(t.trackSimplified);
+      if (Array.isArray(pts) && pts.length >= 2) {
+        lines.push(pts.filter(p => typeof p.lat === 'number' && typeof p.lng === 'number'));
+      }
+    } catch(e) {}
+  });
+  return lines;
+}
+
+function initMemberHeatmap() {
+  const locData = buildLocStats();
+  const trackPts = getAllTrackPoints();
+  if (!locData.length && !trackPts.length) return;
+
+  document.getElementById('memberHeatmapWrap').style.display = '';
+
+  if (_hmMap) { _hmMap.remove(); _hmMap = null; }
+  _hmMap = L.map('memberHeatmap', { zoomControl: true, attributionControl: true, scrollWheelZoom: false, zoomSnap: 0.25, zoomDelta: 0.25 });
+  addSeaLayers(_hmMap);
+
+  renderHeatMode();
+}
+
+function clearHeatLayers() {
+  if (_hmHeatLayer) { _hmMap.removeLayer(_hmHeatLayer); _hmHeatLayer = null; }
+  _hmMarkers.forEach(m => _hmMap.removeLayer(m));
+  _hmMarkers = [];
+  _hmTrackLines.forEach(l => _hmMap.removeLayer(l));
+  _hmTrackLines = [];
+}
+
+function renderHeatMode() {
+  if (!_hmMap) return;
+  clearHeatLayers();
+
+  if (_hmMode === 'tracks') {
+    renderTrackMode();
+  } else {
+    renderLocationMode();
+  }
+}
+
+function renderLocationMode() {
+  const locData = buildLocStats();
+  if (!locData.length) {
+    _hmMap.setView([64.148, -21.965], 11.25);
+    return;
+  }
+
+  const isTime = _hmMode === 'time';
+  const maxVal = locData.reduce((m, l) => Math.max(m, isTime ? l.totalHours : l.tripCount), 1);
+
+  const heatData = locData.map(l => [l.lat, l.lng, (isTime ? l.totalHours : l.tripCount) / maxVal]);
+  _hmHeatLayer = L.heatLayer(heatData, {
+    radius: 30, blur: 20, maxZoom: 14, max: 1.0,
+    gradient: { 0.2: '#1e3f6e', 0.4: '#2e86c1', 0.6: '#f1c40f', 0.8: '#e67e22', 1.0: '#e74c3c' }
+  }).addTo(_hmMap);
+
+  locData.forEach(l => {
+    const intensity = (isTime ? l.totalHours : l.tripCount) / maxVal;
+    const radius = Math.max(6, Math.min(20, 6 + intensity * 14));
+    const valLabel = isTime
+      ? l.totalHours + 'h'
+      : l.tripCount + (l.tripCount === 1 ? ' trip' : ' trips');
+    const marker = L.circleMarker([l.lat, l.lng], {
+      radius, color: '#d4af37', fillColor: '#d4af37', fillOpacity: 0.3, weight: 1,
+    }).bindTooltip(
+      '<strong>' + esc(l.name) + '</strong><br>' + valLabel + ' &middot; ' + l.totalHours + 'h',
+      { className: 'map-tooltip' }
+    ).addTo(_hmMap);
+    _hmMarkers.push(marker);
+  });
+
+  const bounds = L.latLngBounds(locData.map(l => [l.lat, l.lng]));
+  _hmMap.fitBounds(bounds.pad(0.15));
+}
+
+function renderTrackMode() {
+  const lines = getTrackLines();
+  if (!lines.length) {
+    _hmMap.setView([64.148, -21.965], 11.25);
+    return;
+  }
+
+  const allPts = [];
+  lines.forEach(pts => {
+    const latlngs = pts.map(p => [p.lat, p.lng]);
+    allPts.push(...latlngs);
+    const line = L.polyline(latlngs, { color: '#d4af37', weight: 2, opacity: 0.6 }).addTo(_hmMap);
+    _hmTrackLines.push(line);
+  });
+
+  // Add a subtle heat layer from track point density
+  if (allPts.length) {
+    _hmHeatLayer = L.heatLayer(allPts.map(p => [p[0], p[1], 0.5]), {
+      radius: 20, blur: 15, maxZoom: 14, max: 1.0,
+      gradient: { 0.2: '#1e3f6e', 0.4: '#2e86c1', 0.6: '#f1c40f', 0.8: '#e67e22', 1.0: '#e74c3c' }
+    }).addTo(_hmMap);
+  }
+
+  const bounds = L.latLngBounds(allPts);
+  _hmMap.fitBounds(bounds.pad(0.1));
+}
+
+function setHeatMode(mode) {
+  _hmMode = mode;
+  document.querySelectorAll('.heatmap-toggle button').forEach(b => {
+    b.classList.toggle('active', b.dataset.mode === mode);
+  });
+  renderHeatMode();
+}
 
 </script>
 <script src="../shared/logbook.js"></script>

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1289,6 +1289,7 @@ async function reload(){
     allMembers=(membersRes.members||[]).filter(m=>m.active!==false&&m.active!=='false');
     registerBoatCats(cfgRes.boatCategories||[]);
     renderStats();
+    if (typeof initMemberHeatmap === 'function') initMemberHeatmap();
     buildFilters();
     applyFilter();
     renderCerts();


### PR DESCRIPTION
Shows an interactive heatmap of the member's sailing activity below the stats section. Uses the same CartoDB/OpenSeaMap tiles and heat gradient as the public dashboard. Includes a three-way toggle for Trips (count), Time (hours), and GPS tracks view. The map auto-fits to the user's data on initial load.

https://claude.ai/code/session_01Wwkmmgg7iKxjsP37nwqZbE