### PR TITLE
Fix boat category display showing raw keys instead of titles

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -407,7 +407,7 @@ var _boatCategories   = null;
 
 function _fmtCatLabel(cat) {
   var c=_boatCategories&&_boatCategories.find(x=>x.key===cat);
-  var lbl=c?(getLang()==='IS'&&c.labelIS?c.labelIS:c.labelEN):cat;
+  var lbl=c?(getLang()==='IS'&&c.labelIS?c.labelIS:c.labelEN):cat.replace(/[-_]/g,' ').replace(/\b\w/g,function(l){return l.toUpperCase();});
   var ico=(c&&c.emoji)?c.emoji:boatEmoji(cat);
   return ico+' '+esc(lbl.toUpperCase());
 }

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -49,7 +49,7 @@ function registerBoatCats(cats) {
 
 function _boatCatLabel(key) {
   const c = _boatCatRegistry.find(x => x.key === key);
-  if (!c) return key;
+  if (!c) return key.replace(/[-_]/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
   const lang = typeof getLang === 'function' ? getLang() : 'EN';
   return (lang === 'IS' && c.labelIS) ? c.labelIS : (c.labelEN || key);
 }


### PR DESCRIPTION
When a boat category isn't found in the registry (e.g. custom categories like "support-boat"), the fallback now formats the key into a proper title ("Support Boat") instead of displaying the raw hyphenated key.

https://claude.ai/code/session_01Nx5YSFG1kL13g4EgPVBvp3