### PR TITLE
Optimize page performance: eliminate round trips and add optimistic UI

### DIFF
--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -1081,7 +1081,7 @@ async function prLoadConfig(){
   if(u)u.value=cfg.personuafslattrUnit||68681;
   // Load allowBreaks from config
   try {
-    var cfgRes = await apiGet('getConfig', { _fresh: true });
+    var cfgRes = await apiGet('getConfig');
     var cb = document.getElementById('cfgAllowBreaks');
     if (cb) cb.checked = !!(cfgRes && cfgRes.allowBreaks);
     var lbl = document.getElementById('cfgAllowBreaksLbl');

--- a/captain/index.html
+++ b/captain/index.html
@@ -465,12 +465,18 @@ function renderValidation() {
 }
 
 async function respondValidation(id, status) {
+  // Optimistic UI — remove card immediately
+  var prev = _verificationRequests.slice();
+  _verificationRequests = _verificationRequests.filter(r => r.id !== id);
+  renderValidation();
   try {
     await apiPost('respondConfirmation', { id, status, responderName: user.name });
-    _verificationRequests = _verificationRequests.filter(r => r.id !== id);
-    renderValidation();
     showToast(s('toast.saved'), 'ok');
-  } catch (e) { showToast(e.message, 'err'); }
+  } catch (e) {
+    _verificationRequests = prev;
+    renderValidation();
+    showToast(e.message, 'err');
+  }
 }
 
 // ══ CREW APPROVALS ═══════════════════════════════════════════════════════════
@@ -497,12 +503,18 @@ function renderCrew() {
 }
 
 async function respondCrew(id, status) {
+  // Optimistic UI — update card immediately
+  var prev = _crewConfirmations.slice();
+  _crewConfirmations = _crewConfirmations.map(c => c.id === id ? Object.assign({}, c, { status }) : c);
+  renderCrew();
   try {
     await apiPost('respondConfirmation', { id, status, responderName: user.name });
-    _crewConfirmations = _crewConfirmations.map(c => c.id === id ? Object.assign({}, c, { status }) : c);
-    renderCrew();
     showToast(s('toast.saved'), 'ok');
-  } catch (e) { showToast(e.message, 'err'); }
+  } catch (e) {
+    _crewConfirmations = prev;
+    renderCrew();
+    showToast(e.message, 'err');
+  }
 }
 
 
@@ -624,35 +636,36 @@ function openPortModal(boatId) {
 async function savePort() {
   if (!_portBoatId) return;
   var portId = document.getElementById('portSelect').value;
+  var idx = _boats.findIndex(b => b.id === _portBoatId);
+  if (idx < 0) return;
+  var prev = _boats[idx].defaultPortId;
+  _boats[idx].defaultPortId = portId || '';
+  renderBoats();
+  closeModal('portModal');
   try {
-    // Update boat config
-    var cfgRes = await apiGet('getConfig', { _fresh: true });
-    var boats = cfgRes.boats || [];
-    var idx = boats.findIndex(b => b.id === _portBoatId);
-    if (idx >= 0) {
-      boats[idx].defaultPortId = portId || '';
-      await apiPost('saveConfig', { boats: boats });
-      _boats = boats;
-      renderBoats();
-      closeModal('portModal');
-      showToast(s('toast.saved'), 'ok');
-    }
-  } catch (e) { showToast(e.message, 'err'); }
+    await apiPost('saveConfig', { boats: _boats });
+    showToast(s('toast.saved'), 'ok');
+  } catch (e) {
+    _boats[idx].defaultPortId = prev;
+    renderBoats();
+    showToast(e.message, 'err');
+  }
 }
 
 async function toggleBoatOos(boatId, oos) {
+  var idx = _boats.findIndex(b => b.id === boatId);
+  if (idx < 0) return;
+  var prev = _boats[idx].oos;
+  _boats[idx].oos = oos;
+  renderBoats();
   try {
-    var cfgRes = await apiGet('getConfig', { _fresh: true });
-    var boats = cfgRes.boats || [];
-    var idx = boats.findIndex(b => b.id === boatId);
-    if (idx >= 0) {
-      boats[idx].oos = oos;
-      await apiPost('saveConfig', { boats: boats });
-      _boats = boats;
-      renderBoats();
-      showToast(s('toast.saved'), 'ok');
-    }
-  } catch (e) { showToast(e.message, 'err'); }
+    await apiPost('saveConfig', { boats: _boats });
+    showToast(s('toast.saved'), 'ok');
+  } catch (e) {
+    _boats[idx].oos = prev;
+    renderBoats();
+    showToast(e.message, 'err');
+  }
 }
 
 // ══ RESERVATION MANAGEMENT ═══════════════════════════════════════════════════

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -226,17 +226,21 @@ var _boats = [], _locations = [], _members = [], _allMaint = [], _allTrips = [];
   }
 
   try {
-    const [cfgRes, maintRes, tripsRes, membersRes] = await Promise.all([
+    const [cfgRes, maintRes, tripsRes, membersRes, crewRes, invRes] = await Promise.all([
       apiGet('getConfig'),
       apiGet('getMaintenance'),
       apiGet('getTrips', { limit: 500 }),
       apiGet('getMembers'),
+      apiGet('getCrews', { kennitala: user.kennitala }),
+      apiGet('getCrewInvites', { kennitala: user.kennitala }),
     ]);
 
     _boats     = (cfgRes.boats     || []);
     _locations = (cfgRes.locations || []).filter(l => l.active !== false && l.active !== 'false');
     _members   = (membersRes.members || []).filter(m => m.active !== false && m.active !== 'false');
     _allMaint  = maintRes.items || maintRes.maintenance || [];
+    _myCrews     = crewRes.crews || [];
+    _crewInvites = invRes.invites || [];
 
     if (cfgRes.boatCategories) registerBoatCats(cfgRes.boatCategories);
 
@@ -247,7 +251,8 @@ var _boats = [], _locations = [], _members = [], _allMaint = [], _allTrips = [];
     renderStats();
     renderBoats();
     renderMaint();
-    await loadCrews();
+    renderCrews();
+    renderCrewInvites();
     initCxSlots();
 
     applyStrings();
@@ -337,18 +342,20 @@ function renderBoats() {
 }
 
 async function toggleBoatOos(boatId, oos) {
+  var idx = _boats.findIndex(b => b.id === boatId);
+  if (idx < 0) return;
+  // Optimistic UI update
+  var prev = _boats[idx].oos;
+  _boats[idx].oos = oos;
+  renderBoats();
   try {
-    var cfgRes = await apiGet('getConfig', { _fresh: true });
-    var boats = cfgRes.boats || [];
-    var idx = boats.findIndex(b => b.id === boatId);
-    if (idx >= 0) {
-      boats[idx].oos = oos;
-      await apiPost('saveConfig', { boats: boats });
-      _boats = boats;
-      renderBoats();
-      showToast(s('toast.saved'), 'ok');
-    }
-  } catch (e) { showToast(e.message, 'err'); }
+    await apiPost('saveConfig', { boats: _boats });
+    showToast(s('toast.saved'), 'ok');
+  } catch (e) {
+    _boats[idx].oos = prev;
+    renderBoats();
+    showToast(e.message, 'err');
+  }
 }
 
 // ══ RESERVATION MANAGEMENT ═══════════════════════════════════════════════════
@@ -602,21 +609,37 @@ async function sendCrewInvite() {
 }
 
 async function respondInvite(inviteId, response) {
+  // Optimistic UI — remove invite card immediately
+  var prevInvites = _crewInvites.slice();
+  _crewInvites = _crewInvites.filter(function(inv) { return inv.id !== inviteId; });
+  renderCrewInvites();
   try {
     await apiPost('respondCrewInvite', { inviteId: inviteId, response: response });
     showToast(response === 'accepted' ? s('cox.inviteAccepted') : s('cox.inviteRejected'), 'ok');
     await loadCrews();
     initCxSlots(); // refresh slot view if crew is now active
-  } catch(e) { showToast(e.message, 'err'); }
+  } catch(e) {
+    _crewInvites = prevInvites;
+    renderCrewInvites();
+    showToast(e.message, 'err');
+  }
 }
 
 async function disbandCrewConfirm(crewId) {
   if (!confirm(s('cox.confirmDisband'))) return;
+  // Optimistic UI — remove crew card immediately
+  var prevCrews = _myCrews.slice();
+  _myCrews = _myCrews.filter(function(c) { return c.id !== crewId; });
+  renderCrews();
   try {
     await apiPost('disbandCrew', { crewId: crewId });
     showToast(s('cox.crewDisbanded'), 'ok');
     await loadCrews();
-  } catch(e) { showToast(e.message, 'err'); }
+  } catch(e) {
+    _myCrews = prevCrews;
+    renderCrews();
+    showToast(e.message, 'err');
+  }
 }
 
 

--- a/shared/api.js
+++ b/shared/api.js
@@ -7,7 +7,7 @@ const BASE_URL   = "https://skarfur.github.io/ymir";
 async function apiGet(action, params) {
   params = params || {};
   // Cache getConfig in sessionStorage for 60s — called on every page load
-  var _CACHEABLE = { getConfig: 120000, getMembers: 30000 };
+  var _CACHEABLE = { getConfig: 120000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000 };
   if (_CACHEABLE[action] && !params._fresh) {
     try {
       var _ck = 'ymir_' + action + '_';
@@ -36,6 +36,15 @@ async function apiPost(action, payload) {
       sessionStorage.removeItem('ymir_getConfig_');
       sessionStorage.removeItem('ymir_getMembers_');
     } catch(e) {}
+  }
+  // Invalidate trips cache on trip mutations
+  if (action === 'saveTrip' || action === 'deleteTrip' || action === 'setHelm') {
+    try { sessionStorage.removeItem('ymir_getTrips_'); } catch(e) {}
+  }
+  // Invalidate maintenance cache on maintenance mutations
+  if (action === 'saveMaintenance' || action === 'resolveMaintenance' ||
+      action === 'deleteMaintenance' || action === 'addMaintenanceComment') {
+    try { sessionStorage.removeItem('ymir_getMaintenance_'); } catch(e) {}
   }
   return _call(action, payload);
 }


### PR DESCRIPTION
- Coxswain: move crew/invite loading into initial parallel batch (6 calls in parallel instead of 4 + 2 sequential)
- Coxswain/Captain: remove read-modify-write pattern from toggleBoatOos and savePort — use local state instead of re-fetching config (saves 1 round trip per action)
- Captain: add optimistic UI for validation and crew approval responses
- Coxswain: add optimistic UI for crew invite responses and disband
- API: cache getTrips and getMaintenance (30s) with proper invalidation
- Admin/payroll: remove unnecessary _fresh config re-fetch

https://claude.ai/code/session_011zrCv6m5pb1yrcyUGWaXKW