### PR TITLE
Optimize coxswain page response times

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1817,16 +1817,23 @@ function removeReservation_(b) {
 
 function getSlots_(b) {
   var all = readAll_('reservationSlots');
-  if (b.boatId) all = all.filter(function(s) { return s.boatId === b.boatId; });
+  var catBoatSet = null;
   if (b.category) {
     var cfgMap = getConfigMap_();
     var boats = JSON.parse(getConfigValue_('boats', cfgMap) || '[]');
-    var catBoatIds = boats.filter(function(bt) { return bt.category === b.category; }).map(function(bt) { return bt.id; });
-    all = all.filter(function(s) { return catBoatIds.indexOf(s.boatId) !== -1; });
+    catBoatSet = {};
+    boats.forEach(function(bt) { if (bt.category === b.category) catBoatSet[bt.id] = true; });
   }
-  if (b.fromDate) all = all.filter(function(s) { return s.date >= b.fromDate; });
-  if (b.toDate) all = all.filter(function(s) { return s.date <= b.toDate; });
-  return okJ({ slots: all });
+  var result = [];
+  for (var i = 0; i < all.length; i++) {
+    var s = all[i];
+    if (b.boatId && s.boatId !== b.boatId) continue;
+    if (catBoatSet && !catBoatSet[s.boatId]) continue;
+    if (b.fromDate && s.date < b.fromDate) continue;
+    if (b.toDate && s.date > b.toDate) continue;
+    result.push(s);
+  }
+  return okJ({ slots: result });
 }
 
 function saveSlot_(b) {
@@ -1965,19 +1972,17 @@ function unbookSlot_(b) {
 
 function getCrews_(b) {
   var all = readAll_('crews');
+  // Parse pairs JSON once upfront
+  all.forEach(function(c) {
+    c.pairs = typeof c.pairs === 'string' ? JSON.parse(c.pairs || '[]') : (c.pairs || []);
+  });
   if (b.kennitala) {
     var kt = String(b.kennitala);
     all = all.filter(function(c) {
       if (c.status === 'disbanded') return false;
-      var pairs = typeof c.pairs === 'string' ? JSON.parse(c.pairs) : (c.pairs || []);
-      return pairs.some(function(p) { return (p.members || []).some(function(m) { return String(m.kennitala) === kt; }); });
+      return c.pairs.some(function(p) { return (p.members || []).some(function(m) { return String(m.kennitala) === kt; }); });
     });
   }
-  // Parse pairs JSON for convenience
-  all = all.map(function(c) {
-    c.pairs = typeof c.pairs === 'string' ? JSON.parse(c.pairs || '[]') : (c.pairs || []);
-    return c;
-  });
   return okJ({ crews: all });
 }
 
@@ -2148,7 +2153,7 @@ function uploadHeadshot_(b) {
 function getTrips_(kennitala, limit, p) {
   p = p || {};
   const all = readAll_('trips');
-  const filtered = all.filter(t => (!kennitala || String(t.kennitala) === String(kennitala)) && (!p.date || (t.timeIn || t.date || '').slice(0, 10) === p.date) && (!p.linkedCheckoutId || String(t.linkedCheckoutId) === String(p.linkedCheckoutId)));
+  const filtered = all.filter(t => (!kennitala || String(t.kennitala) === String(kennitala)) && (!p.date || (t.timeIn || t.date || '').slice(0, 10) === p.date) && (!p.linkedCheckoutId || String(t.linkedCheckoutId) === String(p.linkedCheckoutId)) && (!p.category || (t.boatCategory || '').toLowerCase() === p.category.toLowerCase()));
   const sorted = filtered.sort((a, b) => (b.date || '') > (a.date || '') ? 1 : -1);
   return okJ({ trips: sorted.slice(0, limit || 100) });
 }

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -229,7 +229,7 @@ var _boats = [], _locations = [], _members = [], _allMaint = [], _allTrips = [];
     const [cfgRes, maintRes, tripsRes, membersRes, crewRes, invRes] = await Promise.all([
       apiGet('getConfig'),
       apiGet('getMaintenance'),
-      apiGet('getTrips', { limit: 500 }),
+      apiGet('getTrips', { limit: 500, category: 'rowing-shell' }),
       apiGet('getMembers'),
       apiGet('getCrews', { kennitala: user.kennitala }),
       apiGet('getCrewInvites', { kennitala: user.kennitala }),
@@ -238,15 +238,13 @@ var _boats = [], _locations = [], _members = [], _allMaint = [], _allTrips = [];
     _boats     = (cfgRes.boats     || []);
     _locations = (cfgRes.locations || []).filter(l => l.active !== false && l.active !== 'false');
     _members   = (membersRes.members || []).filter(m => m.active !== false && m.active !== 'false');
-    _allMaint  = maintRes.items || maintRes.maintenance || [];
+    _allMaint  = maintRes.requests || maintRes.items || maintRes.maintenance || [];
     _myCrews     = crewRes.crews || [];
     _crewInvites = invRes.invites || [];
 
     if (cfgRes.boatCategories) registerBoatCats(cfgRes.boatCategories);
 
-    // Filter trips to rowing-shell category
-    var allTripsRaw = tripsRes.trips || [];
-    _allTrips = allTripsRaw.filter(t => (t.boatCategory || '').toLowerCase() === 'rowing-shell');
+    _allTrips = tripsRes.trips || [];
 
     renderStats();
     renderBoats();
@@ -373,15 +371,22 @@ function openResModal(boatId) {
   openModal('resModal');
 }
 
+var _searchCxResTimer = null;
 function searchCxResMember(q) {
+  clearTimeout(_searchCxResTimer);
   var drop = document.getElementById('cxResMemberSuggestions');
   if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
-  var ql = q.toLowerCase();
-  var hits = _members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
-  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
-  drop.innerHTML = hits.map(m => '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-    + 'onclick="selectCxResMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>').join('');
-  drop.style.display = 'block';
+  _searchCxResTimer = setTimeout(function() {
+    var ql = q.toLowerCase();
+    var hits = [], count = 0;
+    for (var i = 0; i < _members.length && count < 8; i++) {
+      if (((_members[i].name||'').toLowerCase()).includes(ql)) { hits.push(_members[i]); count++; }
+    }
+    if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
+    drop.innerHTML = hits.map(m => '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
+      + 'onclick="selectCxResMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>').join('');
+    drop.style.display = 'block';
+  }, 150);
 }
 
 function selectCxResMember(kt, name) {
@@ -422,10 +427,13 @@ async function removeCxReservation(boatId, resId) {
 }
 
 // ══ MAINTENANCE ══════════════════════════════════════════════════════════════
+var _rowingBoatIdSet = null;
 function renderMaint() {
   var el = document.getElementById('maintList');
-  var rowingBoatIds = _boats.filter(b => (b.category || '').toLowerCase() === 'rowing-shell').map(b => b.id);
-  var items = _allMaint.filter(m => rowingBoatIds.indexOf(m.boatId) !== -1 && m.status !== 'resolved');
+  if (!_rowingBoatIdSet) {
+    _rowingBoatIdSet = new Set(_boats.filter(b => (b.category || '').toLowerCase() === 'rowing-shell').map(b => b.id));
+  }
+  var items = _allMaint.filter(m => _rowingBoatIdSet.has(m.boatId) && m.status !== 'resolved');
   if (!items.length) {
     el.innerHTML = '<div class="empty-note">' + s('cox.noMaint') + '</div>';
     return;
@@ -564,21 +572,25 @@ function openCrewInvModal(crewId) {
   openModal('crewInvModal');
 }
 
+var _searchCrewInvTimer = null;
 function searchCrewInvMember(q) {
+  clearTimeout(_searchCrewInvTimer);
   var drop = document.getElementById('ciMemberSuggestions');
   if (!q || q.length < 2) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
-  var ql = q.toLowerCase();
-  // Filter to rowers only
-  var hits = _members.filter(function(m) {
-    if (!(m.name || '').toLowerCase().includes(ql)) return false;
-    return hasRowingEndorsement(m);
-  }).slice(0, 8);
-  if (!hits.length) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
-  drop.innerHTML = hits.map(function(m) {
-    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-      + 'onclick="selectCrewInvMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>';
-  }).join('');
-  drop.style.display = 'block';
+  _searchCrewInvTimer = setTimeout(function() {
+    var ql = q.toLowerCase();
+    var hits = [], count = 0;
+    for (var i = 0; i < _members.length && count < 8; i++) {
+      var m = _members[i];
+      if ((m.name || '').toLowerCase().includes(ql) && hasRowingEndorsement(m)) { hits.push(m); count++; }
+    }
+    if (!hits.length) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
+    drop.innerHTML = hits.map(function(m) {
+      return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
+        + 'onclick="selectCrewInvMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>';
+    }).join('');
+    drop.style.display = 'block';
+  }, 150);
 }
 
 function selectCrewInvMember(kt, name) {
@@ -762,20 +774,42 @@ function renderCxSlots() {
 async function bookCxSlot(slotId) {
   var crewId = document.getElementById('cxSlotCrew').value;
   if (!crewId) { showToast(s('cox.selectCrew'), 'err'); return; }
+  var crew = _myCrews.find(function(c) { return c.id === crewId; });
+  var slot = _cxSlots.find(function(sl) { return sl.id === slotId; });
+  if (slot) {
+    slot.bookedByKennitala = user.kennitala;
+    slot.bookedByName = user.name;
+    slot.bookedByCrewId = crewId;
+    slot.bookedByCrewName = crew ? crew.name : '';
+    renderCxSlots();
+  }
   try {
     await apiPost('bookSlot', { slotId: slotId, crewId: crewId, kennitala: user.kennitala, memberName: user.name });
     showToast(s('slot.booked'), 'ok');
+  } catch(e) {
+    showToast(e.message || 'Error', 'err');
     loadCxSlots();
-  } catch(e) { showToast(e.message || 'Error', 'err'); }
+  }
 }
 
 async function unbookCxSlot(slotId) {
   if (!confirm(s('slot.confirmUnbook'))) return;
+  var slot = _cxSlots.find(function(sl) { return sl.id === slotId; });
+  var prevSlot = slot ? Object.assign({}, slot) : null;
+  if (slot) {
+    slot.bookedByKennitala = '';
+    slot.bookedByName = '';
+    slot.bookedByCrewId = '';
+    slot.bookedByCrewName = '';
+    renderCxSlots();
+  }
   try {
     await apiPost('unbookSlot', { slotId: slotId, kennitala: user.kennitala });
     showToast(s('slot.unbooked'), 'ok');
-    loadCxSlots();
-  } catch(e) { showToast(e.message || 'Error', 'err'); }
+  } catch(e) {
+    if (prevSlot && slot) { Object.assign(slot, prevSlot); renderCxSlots(); }
+    showToast(e.message || 'Error', 'err');
+  }
 }
 
 function shiftCxWeek(dir) {

--- a/shared/api.js
+++ b/shared/api.js
@@ -7,7 +7,7 @@ const BASE_URL   = "https://skarfur.github.io/ymir";
 async function apiGet(action, params) {
   params = params || {};
   // Cache getConfig in sessionStorage for 60s — called on every page load
-  var _CACHEABLE = { getConfig: 120000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000 };
+  var _CACHEABLE = { getConfig: 120000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewInvites: 30000 };
   if (_CACHEABLE[action] && !params._fresh) {
     try {
       var _ck = 'ymir_' + action + '_';
@@ -45,6 +45,14 @@ async function apiPost(action, payload) {
   if (action === 'saveMaintenance' || action === 'resolveMaintenance' ||
       action === 'deleteMaintenance' || action === 'addMaintenanceComment') {
     try { sessionStorage.removeItem('ymir_getMaintenance_'); } catch(e) {}
+  }
+  // Invalidate crew caches on crew mutations
+  if (action === 'createCrew' || action === 'disbandCrew' || action === 'inviteToCrew' ||
+      action === 'respondCrewInvite' || action === 'bookSlot' || action === 'unbookSlot') {
+    try {
+      sessionStorage.removeItem('ymir_getCrews_');
+      sessionStorage.removeItem('ymir_getCrewInvites_');
+    } catch(e) {}
   }
   return _call(action, payload);
 }


### PR DESCRIPTION
- Fix maintenance data bug: response key was 'requests' but frontend checked 'items'/'maintenance'
- Add server-side category filter for trips to reduce payload (was fetching all 500 then filtering client-side)
- Add sessionStorage caching for getCrews/getCrewInvites with proper invalidation on mutations
- Debounce member search inputs (150ms) with early termination when 8 results found
- Cache rowing boat ID set for maintenance filtering, use Set for O(1) lookups
- Optimistic UI updates for slot booking/unbooking (instant feedback, rollback on error)
- Optimize getSlots_ backend: single-pass filtering instead of 4 sequential .filter() calls
- Fix getCrews_ backend: parse pairs JSON once instead of twice (filter + map)

https://claude.ai/code/session_015gvnT5azFarWZjxePPW3jN