### PR TITLE
Cap heatmap initial zoom to max level 11

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -733,7 +733,7 @@ function renderLocationMode() {
   });
 
   const bounds = L.latLngBounds(locData.map(l => [l.lat, l.lng]));
-  _hmMap.fitBounds(bounds.pad(0.15));
+  _hmMap.fitBounds(bounds.pad(0.15), { maxZoom: 11 });
 }
 
 function renderTrackMode() {
@@ -760,7 +760,7 @@ function renderTrackMode() {
   }
 
   const bounds = L.latLngBounds(allPts);
-  _hmMap.fitBounds(bounds.pad(0.1));
+  _hmMap.fitBounds(bounds.pad(0.1), { maxZoom: 11 });
 }
 
 function setHeatMode(mode) {


### PR DESCRIPTION
Prevents the member logbook heatmap from zooming in too far when fitBounds is called, keeping the view contextual for both location and track modes.

https://claude.ai/code/session_018a9ofzimFsV7u3kLFnSN2D