### PR TITLE
Add optional time filter to bulk slot booking

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -260,6 +260,10 @@
       </div>
     </div>
     <div class="grid2">
+      <div class="field"><label data-s="slot.startTime">Start time</label><input type="time" id="cqBbStartTime"></div>
+      <div class="field"><label data-s="slot.endTime">End time</label><input type="time" id="cqBbEndTime"></div>
+    </div>
+    <div class="grid2">
       <div class="field"><label data-s="slot.fromDate">From date</label><input type="date" id="cqBbFromDate"></div>
       <div class="field"><label data-s="slot.toDate">To date</label><input type="date" id="cqBbToDate"></div>
     </div>
@@ -999,6 +1003,8 @@ async function unbookCqSlot(slotId) {
 function openCqBulkBookModal() {
   document.querySelectorAll('#cqBbDays input').forEach(function(cb) { cb.checked = false; });
   var today = new Date().toISOString().slice(0, 10);
+  document.getElementById('cqBbStartTime').value = '';
+  document.getElementById('cqBbEndTime').value = '';
   document.getElementById('cqBbFromDate').value = today;
   var endD = new Date(); endD.setMonth(endD.getMonth() + 1);
   document.getElementById('cqBbToDate').value = endD.toISOString().slice(0, 10);
@@ -1014,6 +1020,8 @@ async function previewCqBulkBook() {
   var toDate = document.getElementById('cqBbToDate').value;
   if (!days.length || !fromDate || !toDate) { document.getElementById('cqBbPreview').textContent = s('slot.selectDays'); return; }
   var boatId = document.getElementById('cqResBoat').value;
+  var filterStart = document.getElementById('cqBbStartTime').value || '';
+  var filterEnd = document.getElementById('cqBbEndTime').value || '';
   try {
     var res = await apiGet('getSlots', { boatId: boatId, fromDate: fromDate, toDate: toDate });
     var slots = res.slots || [];
@@ -1021,6 +1029,8 @@ async function previewCqBulkBook() {
     slots.forEach(function(sl) {
       var d = new Date(sl.date + 'T00:00:00');
       if (days.indexOf(d.getDay()) === -1) return;
+      if (filterStart && sl.startTime < filterStart) return;
+      if (filterEnd && sl.endTime > filterEnd) return;
       total++;
       if (!sl.bookedByKennitala) open++;
     });
@@ -1035,11 +1045,14 @@ async function submitCqBulkBook() {
   var fromDate = document.getElementById('cqBbFromDate').value;
   var toDate = document.getElementById('cqBbToDate').value;
   var boatId = document.getElementById('cqResBoat').value;
+  var startTime = document.getElementById('cqBbStartTime').value || '';
+  var endTime = document.getElementById('cqBbEndTime').value || '';
   if (!days.length || !fromDate || !toDate || !boatId) { toast(s('slot.missingFields'), 'err'); return; }
   try {
     var res = await apiPost('bulkBookSlots', {
       boatId: boatId, kennitala: user.kennitala, memberName: user.name,
       fromDate: fromDate, toDate: toDate, daysOfWeek: days,
+      startTime: startTime, endTime: endTime,
     });
     closeModal('cqBulkBookModal');
     if (res.skipped > 0) { toast(s('slot.bulkPartial', { booked: res.booked, skipped: res.skipped })); }

--- a/code.gs
+++ b/code.gs
@@ -2006,6 +2006,8 @@ function bulkBookSlots_(b) {
 
   // Fetch all slots for this boat in the date range
   var days = b.daysOfWeek.map(Number);
+  var filterStart = b.startTime || '';
+  var filterEnd = b.endTime || '';
   var all = readAll_('reservationSlots');
   var booked = 0;
   var skipped = 0;
@@ -2015,6 +2017,8 @@ function bulkBookSlots_(b) {
     if (sl.date < b.fromDate || sl.date > b.toDate) continue;
     var slDate = new Date(sl.date + 'T00:00:00');
     if (days.indexOf(slDate.getDay()) === -1) continue;
+    if (filterStart && sl.startTime < filterStart) continue;
+    if (filterEnd && sl.endTime > filterEnd) continue;
     if (sl.bookedByKennitala) { skipped++; continue; }
     updateRow_('reservationSlots', 'id', sl.id, updates);
     booked++;

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -139,6 +139,10 @@
       </div>
     </div>
     <div class="grid2">
+      <div class="field"><label data-s="slot.startTime">Start time</label><input type="time" id="cxBbStartTime"></div>
+      <div class="field"><label data-s="slot.endTime">End time</label><input type="time" id="cxBbEndTime"></div>
+    </div>
+    <div class="grid2">
       <div class="field"><label data-s="slot.fromDate">From date</label><input type="date" id="cxBbFromDate"></div>
       <div class="field"><label data-s="slot.toDate">To date</label><input type="date" id="cxBbToDate"></div>
     </div>
@@ -851,6 +855,8 @@ function openCxBulkBookModal() {
   if (!crewId) { showToast(s('cox.selectCrew'), 'err'); return; }
   document.querySelectorAll('#cxBbDays input').forEach(function(cb) { cb.checked = false; });
   var today = new Date().toISOString().slice(0, 10);
+  document.getElementById('cxBbStartTime').value = '';
+  document.getElementById('cxBbEndTime').value = '';
   document.getElementById('cxBbFromDate').value = today;
   var endD = new Date(); endD.setMonth(endD.getMonth() + 1);
   document.getElementById('cxBbToDate').value = endD.toISOString().slice(0, 10);
@@ -866,6 +872,8 @@ async function previewCxBulkBook() {
   var toDate = document.getElementById('cxBbToDate').value;
   if (!days.length || !fromDate || !toDate) { document.getElementById('cxBbPreview').textContent = s('slot.selectDays'); return; }
   var boatId = document.getElementById('cxSlotBoat').value;
+  var filterStart = document.getElementById('cxBbStartTime').value || '';
+  var filterEnd = document.getElementById('cxBbEndTime').value || '';
   try {
     var res = await apiGet('getSlots', { boatId: boatId, fromDate: fromDate, toDate: toDate });
     var slots = res.slots || [];
@@ -873,6 +881,8 @@ async function previewCxBulkBook() {
     slots.forEach(function(sl) {
       var d = new Date(sl.date + 'T00:00:00');
       if (days.indexOf(d.getDay()) === -1) return;
+      if (filterStart && sl.startTime < filterStart) return;
+      if (filterEnd && sl.endTime > filterEnd) return;
       total++;
       if (!sl.bookedByKennitala) open++;
     });
@@ -889,11 +899,14 @@ async function submitCxBulkBook() {
   var fromDate = document.getElementById('cxBbFromDate').value;
   var toDate = document.getElementById('cxBbToDate').value;
   var boatId = document.getElementById('cxSlotBoat').value;
+  var startTime = document.getElementById('cxBbStartTime').value || '';
+  var endTime = document.getElementById('cxBbEndTime').value || '';
   if (!days.length || !fromDate || !toDate || !boatId) { showToast(s('slot.missingFields'), 'err'); return; }
   try {
     var res = await apiPost('bulkBookSlots', {
       boatId: boatId, crewId: crewId, kennitala: user.kennitala, memberName: user.name,
       fromDate: fromDate, toDate: toDate, daysOfWeek: days,
+      startTime: startTime, endTime: endTime,
     });
     closeModal('cxBulkBookModal');
     if (res.skipped > 0) { showToast(s('slot.bulkPartial', { booked: res.booked, skipped: res.skipped }), 'ok'); }


### PR DESCRIPTION
The bulk book modal now includes optional start/end time fields so users can narrow which slots are booked when multiple slots exist on the same day.

https://claude.ai/code/session_01AEJVJKqGpNHyKvDZbSMMZ8