### PR TITLE
Remove pending kanban column and add editable materials list

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -355,6 +355,8 @@ function route_(action, b) {
     case 'approveSaumaklubbur':     return approveSaumaklubbur_(b);
     case 'holdSaumaklubbur':        return holdSaumaklubbur_(b);
     case 'toggleMaterial':          return toggleMaterial_(b);
+    case 'addMaterial':             return addMaterial_(b);
+    case 'removeMaterial':          return removeMaterial_(b);
     // ── PAYROLL ────────────────────────────────────────────────────────────────────
     case 'clockIn':             return clockIn_(b);
     case 'clockOut':            return clockOut_(b);
@@ -1113,6 +1115,36 @@ function toggleMaterial_(b) {
   updateRow_('maintenance', 'id', b.id, { materials: JSON.stringify(materials) });
   cDel_('maintenance');
   return okJ({ toggled: true, materials });
+}
+
+function addMaterial_(b) {
+  if (!b.id) return failJ('id required');
+  if (!b.name) return failJ('name required');
+  const ex = findOne_('maintenance', 'id', b.id);
+  if (!ex) return failJ('Request not found', 404);
+  let materials = [];
+  try { materials = JSON.parse(ex.materials || '[]'); } catch(e) { materials = []; }
+  materials.push({ name: b.name, purchased: false });
+  addColIfMissing_('maintenance', 'materials');
+  updateRow_('maintenance', 'id', b.id, { materials: JSON.stringify(materials) });
+  cDel_('maintenance');
+  return okJ({ added: true, materials });
+}
+
+function removeMaterial_(b) {
+  if (!b.id) return failJ('id required');
+  if (b.index === undefined) return failJ('index required');
+  const ex = findOne_('maintenance', 'id', b.id);
+  if (!ex) return failJ('Request not found', 404);
+  let materials = [];
+  try { materials = JSON.parse(ex.materials || '[]'); } catch(e) { materials = []; }
+  const idx = parseInt(b.index);
+  if (idx < 0 || idx >= materials.length) return failJ('Invalid index');
+  materials.splice(idx, 1);
+  addColIfMissing_('maintenance', 'materials');
+  updateRow_('maintenance', 'id', b.id, { materials: JSON.stringify(materials) });
+  cDel_('maintenance');
+  return okJ({ removed: true, materials });
 }
 
 function approveSaumaklubbur_(b) {

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -437,7 +437,6 @@ function viewPhoto(url) {
 
 function getProjectColumn(r) {
   if (boolVal(r.resolved))                        return 'done';
-  if (!boolVal(r.approved))                        return 'pending';
   if (boolVal(r.onHold))                           return 'onhold';
   if (r.verkstjori)                                return 'inprogress';
   return 'todo';
@@ -448,7 +447,6 @@ function renderBoard() {
   const projects = myOnly ? allProjects.filter(isMyProject) : allProjects;
 
   const columns = {
-    pending:    { key: 'sauma.colPending',    items: [] },
     todo:       { key: 'sauma.colTodo',       items: [] },
     inprogress: { key: 'sauma.colInProgress', items: [] },
     onhold:     { key: 'sauma.colOnHold',     items: [] },

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -149,14 +149,19 @@ function maintOpenDetail(r, currentUser) {
       </div>`).join('');
 
     // Materials list for saumaklúbbur projects
-    const materialsHtml = isSauma && materials.length ? `
+    const materialsHtml = isSauma ? `
       <div style="margin-bottom:14px">
         <div style="font-size:10px;color:var(--brass);letter-spacing:1px;margin-bottom:6px">${s('maint.materials')}</div>
         ${materials.map((m,i)=>`
-          <div class="mat-row" data-midx="${i}" style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:12px;border-bottom:1px solid var(--border)33;cursor:pointer">
+          <div class="mat-row" data-midx="${i}" style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:12px;border-bottom:1px solid var(--border)33">
             <input type="checkbox" ${m.purchased?'checked':''} style="width:15px;height:15px;accent-color:var(--green);cursor:pointer" data-matidx="${i}">
-            <span style="${m.purchased?'text-decoration:line-through;color:var(--muted)':''}">${esc(m.name)}</span>
+            <span style="flex:1;${m.purchased?'text-decoration:line-through;color:var(--muted)':''}">${esc(m.name)}</span>
+            ${!resolved ? `<button data-matdelete="${i}" style="background:none;border:none;cursor:pointer;font-size:14px;color:var(--muted);padding:0 2px;line-height:1" title="${s('maint.removeMaterial')}">&times;</button>` : ''}
           </div>`).join('')}
+        ${!resolved ? `<div style="display:flex;gap:6px;align-items:center;margin-top:8px">
+          <input id="mdMaterialInput" type="text" placeholder="${s('maint.addMaterialPh')}" style="flex:1">
+          <button id="mdAddMaterialBtn" class="btn btn-secondary" style="font-size:11px;padding:4px 12px">${s('maint.addMaterialBtn')}</button>
+        </div>` : ''}
       </div>` : '';
 
     document.getElementById('maintDetailBody').innerHTML = `
@@ -263,7 +268,39 @@ function maintOpenDetail(r, currentUser) {
           const res = await apiPost('toggleMaterial',{id:r.id,index:idx});
           if (res.materials) r.materials = JSON.stringify(res.materials);
           renderAndWire();
+          if(typeof renderList==='function') renderList();
         } catch(e) { cb.disabled = false; }
+      });
+    });
+
+    // Add material
+    const addMat = async () => {
+      const input = document.getElementById('mdMaterialInput');
+      const name = (input?.value||'').trim();
+      if (!name) return;
+      const btn = document.getElementById('mdAddMaterialBtn');
+      if(btn) btn.disabled = true;
+      try {
+        const res = await apiPost('addMaterial',{id:r.id,name});
+        if (res.materials) r.materials = JSON.stringify(res.materials);
+        renderAndWire();
+        if(typeof renderList==='function') renderList();
+      } catch(e) { if(btn) btn.disabled = false; }
+    };
+    document.getElementById('mdAddMaterialBtn')?.addEventListener('click', addMat);
+    document.getElementById('mdMaterialInput')?.addEventListener('keydown', e => { if(e.key==='Enter') addMat(); });
+
+    // Delete material
+    document.querySelectorAll('#maintDetailBody [data-matdelete]').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const idx = parseInt(btn.dataset.matdelete);
+        doConfirm(s('maint.removeMaterialConfirm'), async () => {
+          const res = await apiPost('removeMaterial',{id:r.id,index:idx});
+          if (res.materials) r.materials = JSON.stringify(res.materials);
+          renderAndWire();
+          if(typeof renderList==='function') renderList();
+        });
       });
     });
 

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -1442,6 +1442,10 @@ const STRINGS = {
   'maint.markOosConfirm':    { EN:'Mark as Out of Service without resolving?',     IS:'Merkja utan þjónustu án þess að leysa?' },
   'maint.maxFileSize':       { EN:'Max 5 MB',                                      IS:'Hámark 5 MB' },
   'maint.materials':         { EN:'MATERIALS',                                     IS:'EFNI' },
+  'maint.addMaterialPh':     { EN:'e.g. Sandpaper 120-grit…',                     IS:'t.d. Sandpappír 120…' },
+  'maint.addMaterialBtn':    { EN:'+ Add',                                        IS:'+ Bæta við' },
+  'maint.removeMaterial':    { EN:'Remove material',                              IS:'Fjarlægja efni' },
+  'maint.removeMaterialConfirm': { EN:'Remove this material?',                   IS:'Fjarlægja þetta efni?' },
 
   // ── Alerts — inline strings ────────────────────────────────────────────────
   'alert.overdueTitle':      { EN:'OVERDUE BOATS',                                 IS:'BÁTAR YFIRTÍMA' },


### PR DESCRIPTION
- Remove the "pending" column from the saumaklúbbur kanban board; unapproved items now appear in the "todo" column instead
- Make materials lists editable in the project detail modal: users can add new materials and delete unwanted ones
- Purchased materials display with strikethrough styling (two-state system: needed vs purchased, with deletion as a separate action)
- Add backend endpoints addMaterial and removeMaterial in code.gs
- Add localization strings for material add/remove UI

Closes #283

https://claude.ai/code/session_01JnQ8x5XmenB43hfbeTHXmp