### PR TITLE
Remove redundant charter feature, rename reservations to "Assign Char…

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -712,31 +712,6 @@
       </div>
       <div id="bReservationActions"></div>
     </div>
-    <!-- Charter -->
-    <div id="bCharterSection">
-      <div style="font-size:9px;letter-spacing:1px;color:var(--muted);margin-bottom:6px" data-s="boat.charter">CHARTER</div>
-      <div id="bCharterInfo" style="font-size:12px;margin-bottom:6px"></div>
-      <div id="bCharterForm" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px">
-        <div class="field">
-          <label data-s="cq.resMember">Member</label>
-          <div style="position:relative">
-            <input type="text" id="bCharterMemberSearch" autocomplete="off" placeholder="" oninput="searchCharterMember(this.value)">
-            <div id="bCharterMemberSuggestions" class="suggest-drop" style="position:relative"></div>
-            <input type="hidden" id="bCharterMemberKt">
-            <div id="bCharterMemberName" style="font-size:10px;color:var(--muted);margin-top:3px"></div>
-          </div>
-        </div>
-        <div class="grid2">
-          <div class="field"><label data-s="cq.resStartDate">Start date</label><input type="date" id="bCharterStart"></div>
-          <div class="field"><label data-s="cq.resEndDate">End date</label><input type="date" id="bCharterEnd"></div>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-secondary" style="font-size:11px" onclick="cancelCharterForm()" data-s="btn.cancel"></button>
-          <button class="btn btn-primary" style="font-size:11px" onclick="saveCharterFromModal()" data-s="btn.save"></button>
-        </div>
-      </div>
-      <div id="bCharterActions"></div>
-    </div>
     <div class="check-row">
       <input type="checkbox" id="bOOS"> <label for="bOOS" data-s="admin.boatOos"></label>
     </div>
@@ -1117,8 +1092,6 @@ function _adminWireStrings() {
   if (search) search.placeholder = s('admin.searchMembers');
   const bOwnerSearch = document.getElementById('bOwnerSearch');
   if (bOwnerSearch) bOwnerSearch.placeholder = s('admin.searchMember');
-  const bCharterSearch = document.getElementById('bCharterMemberSearch');
-  if (bCharterSearch) bCharterSearch.placeholder = s('admin.searchMember');
   const mInitials = document.getElementById('mInitials');
   if (mInitials) mInitials.placeholder = s('admin.initialsPlaceholder');
 }
@@ -1533,14 +1506,6 @@ function openBoatModal(id) {
   document.getElementById("bResEnd").value = '';
   document.getElementById("bResNote").value = '';
   renderReservationList(b);
-  // Charter
-  document.getElementById("bCharterForm").classList.add("hidden");
-  document.getElementById("bCharterMemberKt").value = '';
-  document.getElementById("bCharterMemberSearch").value = '';
-  document.getElementById("bCharterMemberName").textContent = '';
-  document.getElementById("bCharterStart").value = '';
-  document.getElementById("bCharterEnd").value = '';
-  renderCharterInfo(b);
   updateOwnershipFields();
   updateBoatModalFields();
   applyStrings(document.getElementById("boatModal"));
@@ -1570,86 +1535,6 @@ function selectBoatOwner(kt, name) {
   document.getElementById("bOwnerName").textContent = name;
   document.getElementById("bOwnerSuggestions").innerHTML = '';
   document.getElementById("bOwnerSuggestions").style.display = 'none';
-}
-
-// ── Charter helpers ───────────────────────────────────────────────────────────
-function renderCharterInfo(boat) {
-  const infoEl = document.getElementById("bCharterInfo");
-  const actEl  = document.getElementById("bCharterActions");
-  if (!boat || boat.ownership === 'private') {
-    infoEl.textContent = '';
-    actEl.innerHTML = '';
-    return;
-  }
-  if (boat.charter && boat.charter.memberName) {
-    const ch = boat.charter;
-    infoEl.innerHTML = `${esc(s('fleet.charteredTo',{name:ch.memberName}))} ${esc(s('fleet.charteredUntil',{date:ch.endDate}))}`;
-    actEl.innerHTML = `<button class="btn btn-secondary" style="font-size:11px" onclick="showCharterForm()">${esc(s('boat.setCharter'))}</button> `
-                    + `<button class="btn btn-danger" style="font-size:11px" onclick="removeCharterFromModal()">${esc(s('boat.removeCharter'))}</button>`;
-  } else {
-    infoEl.textContent = '';
-    actEl.innerHTML = `<button class="btn btn-secondary" style="font-size:11px" onclick="showCharterForm()">${esc(s('boat.setCharter'))}</button>`;
-  }
-}
-
-function showCharterForm() {
-  document.getElementById("bCharterForm").classList.remove("hidden");
-}
-
-function cancelCharterForm() {
-  document.getElementById("bCharterForm").classList.add("hidden");
-}
-
-function searchCharterMember(q) {
-  const drop = document.getElementById("bCharterMemberSuggestions");
-  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
-  const ql = q.toLowerCase();
-  const hits = members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
-  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
-  drop.innerHTML = hits.map(m => `<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"
-    onclick="selectCharterMember('${esc(m.kennitala)}','${esc(m.name)}')">${esc(m.name)}</div>`).join('');
-  drop.style.display = 'block';
-}
-
-function selectCharterMember(kt, name) {
-  document.getElementById("bCharterMemberKt").value = kt;
-  document.getElementById("bCharterMemberSearch").value = '';
-  document.getElementById("bCharterMemberName").textContent = name;
-  document.getElementById("bCharterMemberSuggestions").innerHTML = '';
-  document.getElementById("bCharterMemberSuggestions").style.display = 'none';
-}
-
-async function saveCharterFromModal() {
-  const boatId = editingId;
-  if (!boatId) { toast(s("admin.saveBoatFirst"), "err"); return; }
-  const kt   = document.getElementById("bCharterMemberKt").value;
-  const name = document.getElementById("bCharterMemberName").textContent;
-  const start = document.getElementById("bCharterStart").value;
-  const end   = document.getElementById("bCharterEnd").value;
-  if (!kt || !name) { toast(s("admin.selectMember"), "err"); return; }
-  if (!start || !end) { toast(s("admin.setDatesRequired"), "err"); return; }
-  try {
-    await apiPost('saveCharter', { boatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end });
-    // Update local boat data
-    const b = _allBoats.find(x => x.id === boatId);
-    if (b) b.charter = { memberKennitala: kt, memberName: name, startDate: start, endDate: end };
-    cancelCharterForm();
-    renderCharterInfo(b);
-    toast(s('boat.charterSaved'));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function removeCharterFromModal() {
-  const boatId = editingId;
-  if (!boatId) return;
-  if (!await ymConfirm(s('boat.removeCharter') + '?')) return;
-  try {
-    await apiPost('removeCharter', { boatId });
-    const b = _allBoats.find(x => x.id === boatId);
-    if (b) delete b.charter;
-    renderCharterInfo(b);
-    toast(s('boat.charterRemoved'));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
 
 // ── Access control helpers ────────────────────────────────────────────────────
@@ -1778,7 +1663,7 @@ async function saveResFromModal() {
   try {
     var res = await apiPost('saveReservation', { boatId: boatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end, note: note });
     var b = _allBoats.find(function(x) { return x.id === boatId; });
-    if (b && res.boat) { b.reservations = res.boat.reservations; b.charter = res.boat.charter; }
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
     cancelResForm();
     renderReservationList(b);
     toast(s('boat.reservationSaved'));
@@ -1791,7 +1676,7 @@ async function removeResFromModal(resId) {
   try {
     var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
     var b = _allBoats.find(function(x) { return x.id === boatId; });
-    if (b && res.boat) { b.reservations = res.boat.reservations; b.charter = res.boat.charter; }
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
     renderReservationList(b);
     toast(s('boat.reservationRemoved'));
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
@@ -1831,9 +1716,8 @@ async function saveBoat() {
 
   const idx = _allBoats.findIndex(x => x.id === id);
   if (idx >= 0) {
-    // Preserve reservations and charter (managed via separate endpoints)
+    // Preserve reservations (managed via separate endpoints)
     payload.reservations = _allBoats[idx].reservations || [];
-    payload.charter = _allBoats[idx].charter || null;
     _allBoats[idx] = { ..._allBoats[idx], ...payload };
   } else {
     payload.reservations = [];

--- a/captain/index.html
+++ b/captain/index.html
@@ -611,8 +611,6 @@ function renderBoats() {
     if (b.accessMode === 'controlled' && b.accessGateCert === 'captain') return true;
     // Boat with active reservation for this captain
     if (b.reservations && b.reservations.some(r => String(r.memberKennitala) === String(user.kennitala))) return true;
-    // Legacy: chartered to this captain
-    if (b.charter && String(b.charter.memberKennitala) === String(user.kennitala)) return true;
     return false;
   });
 
@@ -756,7 +754,7 @@ async function saveCqReservation() {
   try {
     var res = await apiPost('saveReservation', { boatId: _resBoatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end, note: note });
     var b = _boats.find(x => x.id === _resBoatId);
-    if (b && res.boat) { b.reservations = res.boat.reservations; b.charter = res.boat.charter; }
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
     closeModal('resModal');
     renderBoats();
     showToast(s('boat.reservationSaved'), 'ok');
@@ -768,7 +766,7 @@ async function removeCqReservation(boatId, resId) {
   try {
     var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
     var b = _boats.find(x => x.id === boatId);
-    if (b && res.boat) { b.reservations = res.boat.reservations; b.charter = res.boat.charter; }
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
     renderBoats();
     showToast(s('boat.reservationRemoved'), 'ok');
   } catch (e) { showToast(e.message, 'err'); }

--- a/code.gs
+++ b/code.gs
@@ -391,8 +391,7 @@ function route_(action, b) {
     case 'saveGroupCheckout': return saveGroupCheckout_(b);
     case 'groupCheckIn': return groupCheckIn_(b);
     case 'linkGroupCheckoutToActivity': return linkGroupCheckoutToActivity_(b);
-    case 'saveCharter': return saveCharter_(b);
-    case 'removeCharter': return removeCharter_(b);
+    // charter endpoints removed — use saveReservation / removeReservation
     case 'saveBoatAccess': return saveBoatAccess_(b);
     case 'saveBoatOos': return saveBoatOos_(b);
     case 'saveReservation': return saveReservation_(b);
@@ -1215,22 +1214,9 @@ function getConfig_() {
   const certCategories = getCertCategoriesFromMap_(cfgMap);
   let boats = [], locations = [];
   try { var bRaw = getConfigValue_('boats', cfgMap); if (bRaw) boats = JSON.parse(bRaw); } catch (e) { }
-  // Lazy migration: charter → reservations
   var boatsMigrated = false;
   boats.forEach(function(bt) {
     if (!bt.accessMode) { bt.accessMode = 'free'; boatsMigrated = true; }
-    if (bt.charter && !bt.reservations) {
-      bt.reservations = [{
-        id: 'res_' + uid_(),
-        memberKennitala: bt.charter.memberKennitala || '',
-        memberName: bt.charter.memberName || '',
-        startDate: bt.charter.startDate || '',
-        endDate: bt.charter.endDate || '',
-        note: 'Migrated from charter',
-      }];
-      delete bt.charter;
-      boatsMigrated = true;
-    }
   });
   if (boatsMigrated) { try { setConfigSheetValue_('boats', JSON.stringify(boats)); } catch(e) {} }
   try { var lRaw = getConfigValue_('locations', cfgMap); if (lRaw) locations = JSON.parse(lRaw); } catch (e) { }
@@ -1746,41 +1732,6 @@ function deleteCheckout_(id) {
   cDel_('checkouts'); return okJ({ deleted });
 }
 
-// ── Charter management ───────────────────────────────────────────────────────
-
-function saveCharter_(b) {
-  if (!b.boatId) return failJ('boatId required');
-  if (!b.memberKennitala || !b.memberName) return failJ('member required');
-  if (!b.startDate || !b.endDate) return failJ('startDate and endDate required');
-  const cfgMap = getConfigMap_();
-  let boats = [];
-  try { boats = JSON.parse(getConfigValue_('boats', cfgMap) || '[]'); } catch (e) { return failJ('Failed to parse boats'); }
-  const idx = boats.findIndex(x => x.id === b.boatId);
-  if (idx < 0) return failJ('Boat not found');
-  boats[idx].charter = {
-    memberKennitala: b.memberKennitala,
-    memberName: b.memberName,
-    startDate: b.startDate,
-    endDate: b.endDate,
-  };
-  setConfigSheetValue_('boats', JSON.stringify(boats));
-  cDel_('config');
-  return okJ({ updated: true, boat: boats[idx] });
-}
-
-function removeCharter_(b) {
-  if (!b.boatId) return failJ('boatId required');
-  const cfgMap = getConfigMap_();
-  let boats = [];
-  try { boats = JSON.parse(getConfigValue_('boats', cfgMap) || '[]'); } catch (e) { return failJ('Failed to parse boats'); }
-  const idx = boats.findIndex(x => x.id === b.boatId);
-  if (idx < 0) return failJ('Boat not found');
-  delete boats[idx].charter;
-  setConfigSheetValue_('boats', JSON.stringify(boats));
-  cDel_('config');
-  return okJ({ updated: true, boat: boats[idx] });
-}
-
 // ── Boat OOS toggle ──────────────────────────────────────────────────────
 
 function saveBoatOos_(b) {
@@ -1836,8 +1787,6 @@ function saveReservation_(b) {
   };
   if (resIdx >= 0) boats[idx].reservations[resIdx] = res;
   else boats[idx].reservations.push(res);
-  // Also maintain legacy charter field for backward compat
-  boats[idx].charter = { memberKennitala: res.memberKennitala, memberName: res.memberName, startDate: res.startDate, endDate: res.endDate };
   setConfigSheetValue_('boats', JSON.stringify(boats));
   cDel_('config');
   return okJ({ updated: true, boat: boats[idx], reservation: res });
@@ -1853,8 +1802,6 @@ function removeReservation_(b) {
   if (idx < 0) return failJ('Boat not found');
   if (!boats[idx].reservations) boats[idx].reservations = [];
   boats[idx].reservations = boats[idx].reservations.filter(r => r.id !== b.reservationId);
-  // Clear legacy charter if no reservations remain
-  if (!boats[idx].reservations.length) delete boats[idx].charter;
   setConfigSheetValue_('boats', JSON.stringify(boats));
   cDel_('config');
   return okJ({ updated: true, boat: boats[idx] });

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -446,7 +446,7 @@ async function saveCxReservation() {
   try {
     var res = await apiPost('saveReservation', { boatId: _resBoatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end, note: note });
     var b = _boats.find(x => x.id === _resBoatId);
-    if (b && res.boat) { b.reservations = res.boat.reservations; b.charter = res.boat.charter; }
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
     closeModal('resModal');
     renderBoats();
     showToast(s('boat.reservationSaved'), 'ok');
@@ -458,7 +458,7 @@ async function removeCxReservation(boatId, resId) {
   try {
     var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
     var b = _boats.find(x => x.id === boatId);
-    if (b && res.boat) { b.reservations = res.boat.reservations; b.charter = res.boat.charter; }
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
     renderBoats();
     showToast(s('boat.reservationRemoved'), 'ok');
   } catch (e) { showToast(e.message, 'err'); }

--- a/member/index.html
+++ b/member/index.html
@@ -358,7 +358,7 @@ function openReturnModal(coId) {
 // Step 1 — boat picker
 function renderLaunchPicker(preselectedBoatId) {
   const active=checkouts.filter(c=>c.status==='out');
-  const avail=boats.filter(b=>!active.find(c=>c.boatId===b.id)&&!boolVal(b.oos)&&!isChartered(b));
+  const avail=boats.filter(b=>!active.find(c=>c.boatId===b.id)&&!boolVal(b.oos));
   if(!avail.length){
     document.getElementById('launchModalBody').innerHTML=
       '<div class="mb-12">'+

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -84,15 +84,6 @@ function boatEmoji(cat) {
 
 // ── Ownership / charter helpers ───────────────────────────────────────────────
 
-/** Returns true if the boat has an active charter (today falls within start–end). */
-function isChartered(boat) {
-  if (!boat || !boat.charter) return false;
-  const c = boat.charter;
-  if (!c.startDate || !c.endDate) return false;
-  const today = new Date().toISOString().slice(0, 10);
-  return today >= c.startDate && today <= c.endDate;
-}
-
 /** Returns true if the boat is privately owned. */
 function isPrivate(boat) {
   return boat && boat.ownership === 'private';
@@ -255,8 +246,7 @@ function renderBoatCard(boat, opts) {
   const locLine = (status==="avail" && boat.location)
     ? `<div style="font-size:11px;color:var(--muted);margin-top:2px">${_besc(boat.location)}</div>` : "";
 
-  // Ownership / charter / reservation info
-  const chartered = isChartered(boat);
+  // Ownership / charter info
   const priv      = isPrivate(boat);
   const activeRes = getActiveReservation(boat);
   const controlled = isControlledAccess(boat);
@@ -271,11 +261,6 @@ function renderBoatCard(boat, opts) {
     charterLine = `<div style="font-size:10px;color:var(--brass);margin-top:4px">`
                 + `${_besc(s("boat.reservedFor",{name:activeRes.memberName}))} ${_besc(s("boat.reservedUntil",{date:activeRes.endDate}))}`
                 + `</div>`;
-  } else if (chartered) {
-    const ch = boat.charter;
-    charterLine = `<div style="font-size:10px;color:var(--brass);margin-top:4px">`
-                + `${_besc(s("fleet.charteredTo",{name:ch.memberName}))} ${_besc(s("fleet.charteredUntil",{date:ch.endDate}))}`
-                + `</div>`;
   }
 
   // Use registry-based onclick to avoid JSON-in-attribute encoding problems
@@ -286,22 +271,20 @@ function renderBoatCard(boat, opts) {
     ? ` style="cursor:pointer" onclick="${opts.onClick}"`
     : "";
 
-  // Extra badge for access mode / chartered / private / reserved boats
+  // Extra badge for access mode / chartered / private boats
   let ownerBadge = "";
   if (controlled && !userCanAccess && !opts.staffView) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--red);border-color:var(--red)55;background:var(--red)11;margin-left:4px">${_besc(s("fleet.badgeRestricted"))}</span>`;
   } else if (activeRes) {
-    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeReserved"))}</span>`;
+    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeChartered"))}</span>`;
   } else if (controlled && userCanAccess && !opts.staffView) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111;margin-left:4px">${_besc(s("fleet.badgeAuthorized"))}</span>`;
-  } else if (chartered) {
-    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeChartered"))}</span>`;
   } else if (priv) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--muted);border-color:var(--border);background:var(--surface);margin-left:4px">${_besc(s("fleet.badgePrivate"))}</span>`;
   }
 
-  // Muted card style for restricted boats (controlled access without authorization, or chartered for non-staff)
-  const isMuted = (!opts.staffView && ((controlled && !userCanAccess) || (chartered && !activeRes)));
+  // Muted card style for restricted boats (controlled access without authorization)
+  const isMuted = (!opts.staffView && controlled && !userCanAccess);
   const charteredMuted = isMuted ? "opacity:.55;pointer-events:none;" : "";
 
   return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}">`
@@ -479,7 +462,7 @@ function renderFleetStatus(containerId, boats, active, opts) {
     const catBoats = boats.filter(b => (b.category||'').toLowerCase() === key);
     const isStaffV = !!opts.staffView;
     const fleetUser = opts.currentUser || null;
-    const avail    = catBoats.filter(b => !boolVal(b.oos) && !activeByBoat.has(b.id) && (isStaffV || (!isChartered(b) && canAccessBoat(b, fleetUser))));
+    const avail    = catBoats.filter(b => !boolVal(b.oos) && !activeByBoat.has(b.id) && (isStaffV || canAccessBoat(b, fleetUser)));
     const pct      = catBoats.length ? Math.round(avail.length / catBoats.length * 100) : 0;
     const catId    = containerId + '-fcat-' + encodeURIComponent(key);
 
@@ -493,7 +476,7 @@ function renderFleetStatus(containerId, boats, active, opts) {
       if (onClickAct) {
         // onClickAction receives the full boat object via registry — always clickable
         clickOpts = { onClickAction: onClickAct };
-      } else if (status === 'avail' && onAvail && (isStaffV || (!isChartered(b) && canAccessBoat(b, fleetUser)))) {
+      } else if (status === 'avail' && onAvail && (isStaffV || canAccessBoat(b, fleetUser))) {
         clickOpts = { onClick: onAvail + "('${b.id}')".replace('${b.id}', _besc(b.id)) };
       }
       return renderBoatCard(b, Object.assign({ status, checkoutData: co, staffView: isStaffV, currentUser: fleetUser }, clickOpts));

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -540,7 +540,7 @@ const STRINGS = {
   'admin.tabAlerts':       { EN:'Alerts',                  IS:'Viðvaranir' },
   'admin.tabPayroll':      { EN:'💰 Payroll',             IS:'💰 Launakerfi' },
   'admin.tabFlags':        { EN:'🚩 Flags',                IS:'🚩 Fánar' },
-  'admin.tabReservations': { EN:'📅 Reservations',         IS:'📅 Bókanir' },
+  'admin.tabReservations': { EN:'📅 Charters',              IS:'📅 Leigur' },
   'admin.importCsv':       { EN:'⇪ Import CSV',            IS:'⇪ Flytja inn CSV' },
   'admin.searchMembers':   { EN:'Search name or kennitala…', IS:'Leita að nafni eða kennitölu…' },
   'admin.noMembers':       { EN:'No members yet.',         IS:'Engir félagar ennþá.' },
@@ -887,11 +887,7 @@ const STRINGS = {
   'fleet.delete':            { EN:'Delete',                                IS:'Eyða' },
   'fleet.badgeChartered':    { EN:'CHARTERED',                             IS:'LEIGÐUR' },
   'fleet.badgePrivate':      { EN:'PRIVATE',                               IS:'EINKABÁTUR' },
-  'fleet.charteredTo':       { EN:'Chartered to {name}',                   IS:'Leigður til {name}' },
-  'fleet.charteredUntil':    { EN:'until {date}',                          IS:'til {date}' },
   'fleet.ownedBy':           { EN:'Owner: {name}',                         IS:'Eigandi: {name}' },
-  'fleet.charterOverride':   { EN:'This boat is chartered to {name} until {date}. Override and check out anyway?',
-                               IS:'Þessi bátur er leigður til {name} til {date}. Viltu taka hann út samt?' },
 
   // ── Fleet action popover (staff) ────────────────────────────────────────────
   'fleet.actionCheckout':    { EN:'Check Out',                              IS:'Útskrá' },
@@ -899,21 +895,13 @@ const STRINGS = {
   'fleet.actionMarkOos':     { EN:'Mark Unavailable',                       IS:'Merkja ótiltækan' },
   'fleet.actionMarkAvail':   { EN:'Mark Available',                         IS:'Merkja tiltækan' },
 
-  // ── Boat ownership & charter ──────────────────────────────────────────────
+  // ── Boat ownership ────────────────────────────────────────────────────────
   'boat.ownership':          { EN:'Ownership',                             IS:'Eignarhald' },
   'boat.ownershipClub':      { EN:'Club boat',                             IS:'Klúbbsbátur' },
   'boat.ownershipPrivate':   { EN:'Private boat',                          IS:'Einkabátur' },
   'boat.owner':              { EN:'Owner',                                 IS:'Eigandi' },
-  'boat.charter':            { EN:'Charter',                               IS:'Leiga' },
-  'boat.charterMember':      { EN:'Chartered to',                          IS:'Leigður til' },
-  'boat.charterStart':       { EN:'Start date',                            IS:'Upphafsdagur' },
-  'boat.charterEnd':         { EN:'End date',                              IS:'Lokadagur' },
-  'boat.setCharter':         { EN:'Set Charter',                           IS:'Skrá leigu' },
-  'boat.removeCharter':      { EN:'Remove Charter',                        IS:'Fjarlægja leigu' },
-  'boat.charterSaved':       { EN:'Charter saved',                         IS:'Leiga vistuð' },
-  'boat.charterRemoved':     { EN:'Charter removed',                       IS:'Leiga fjarlægð' },
 
-  // ── Boat access control & reservations ────────────────────────────────────
+  // ── Boat access control & charters ────────────────────────────────────────
   'boat.accessMode':         { EN:'Access Mode',                            IS:'Aðgangshamur' },
   'boat.accessFree':         { EN:'Free Access',                            IS:'Frjáls aðgangur' },
   'boat.accessControlled':   { EN:'Controlled Access',                      IS:'Stýrður aðgangur' },
@@ -921,12 +909,12 @@ const STRINGS = {
   'boat.gateCertNone':       { EN:'None (allowlist only)',                   IS:'Ekkert (aðeins listi)' },
   'boat.allowlist':          { EN:'Allowed Members',                        IS:'Leyfilegir meðlimir' },
   'boat.allowlistAdd':       { EN:'Add member…',                            IS:'Bæta við meðlim…' },
-  'boat.reservations':       { EN:'Reservations',                           IS:'Bókanir' },
-  'boat.addReservation':     { EN:'Add Reservation',                        IS:'Bæta við bókun' },
+  'boat.reservations':       { EN:'Assign Charter',                         IS:'Úthluta leigu' },
+  'boat.addReservation':     { EN:'Add Charter',                            IS:'Bæta við leigu' },
   'boat.removeReservation':  { EN:'Remove',                                 IS:'Fjarlægja' },
-  'boat.reservationSaved':   { EN:'Reservation saved',                      IS:'Bókun vistuð' },
-  'boat.reservationRemoved': { EN:'Reservation removed',                    IS:'Bókun fjarlægð' },
-  'boat.reservedFor':        { EN:'Reserved for {name}',                    IS:'Frátekið fyrir {name}' },
+  'boat.reservationSaved':   { EN:'Charter saved',                          IS:'Leiga vistuð' },
+  'boat.reservationRemoved': { EN:'Charter removed',                        IS:'Leiga fjarlægð' },
+  'boat.reservedFor':        { EN:'Chartered to {name}',                    IS:'Leigður til {name}' },
   'boat.reservedUntil':      { EN:'until {date}',                           IS:'til {date}' },
   'boat.reservationNote':    { EN:'Note',                                   IS:'Athugasemd' },
   'boat.accessDenied':       { EN:'You do not have access to this boat',    IS:'Þú hefur ekki aðgang að þessum bát' },
@@ -990,7 +978,7 @@ const STRINGS = {
   'slot.bulkPartial':        { EN:'{booked} booked, {skipped} already taken', IS:'{booked} bókaðir, {skipped} þegar teknir' },
 
   // ── Captain reservations ─────────────────────────────────────────────────
-  'cq.reservationsTitle':    { EN:'RESERVATIONS',                            IS:'BÓKANIR' },
+  'cq.reservationsTitle':    { EN:'CHARTERS',                                IS:'LEIGUR' },
 
   // ── Coxswain's Seat ───────────────────────────────────────────────────────
   'nav.coxswainSeat':        { EN:'🚣 Coxswain\'s Seat',                   IS:'🚣 Stýrimannssæti' },
@@ -1004,8 +992,8 @@ const STRINGS = {
   'cox.maintenance':         { EN:'MAINTENANCE',                            IS:'VIÐHALD' },
   'cox.readOnly':            { EN:'View only — contact a coxswain for changes', IS:'Aðeins skoðun — hafðu samband við stýrimann' },
   'cox.noMaint':             { EN:'No maintenance requests.',               IS:'Engar viðhaldsbeiðnir.' },
-  'cox.reservations':        { EN:'RESERVATIONS',                           IS:'BÓKANIR' },
-  'cox.addReservation':      { EN:'Add Reservation',                        IS:'Bæta við bókun' },
+  'cox.reservations':        { EN:'CHARTERS',                               IS:'LEIGUR' },
+  'cox.addReservation':      { EN:'Add Charter',                            IS:'Bæta við leigu' },
   'cox.resMember':           { EN:'Member',                                 IS:'Meðlimur' },
   'cox.resStartDate':        { EN:'Start date',                             IS:'Upphafsdagur' },
   'cox.resEndDate':          { EN:'End date',                               IS:'Lokadagur' },
@@ -1208,7 +1196,6 @@ const STRINGS = {
   'admin.ownerClub':         { EN:'Club boat',                           IS:'Klúbbsbátur' },
   'admin.ownerPrivate':      { EN:'Private boat',                        IS:'Einkabátur' },
   'admin.searchMember':      { EN:'Search member...',                    IS:'Leita að félaga...' },
-  'admin.saveCharter':       { EN:'Save Charter',                        IS:'Vista leigu' },
   'admin.oosReason':         { EN:'OOS reason',                          IS:'Ástæða' },
   'admin.openingChecklist':  { EN:'OPENING CHECKLIST',                   IS:'OPNUNARGÁTLISTI' },
   'admin.closingChecklist':  { EN:'CLOSING CHECKLIST',                   IS:'LOKUNARGÁTLISTI' },
@@ -1332,9 +1319,9 @@ const STRINGS = {
   'cq.makeAvailable':        { EN:'Mark available',                       IS:'Merkja tiltækan' },
   'cq.changePort':           { EN:'Change home port',                     IS:'Breyta heimahöfn' },
   'cq.viewPublicProfile':    { EN:'View public profile →',                IS:'Skoða opinbert prófíl →' },
-  'cq.reservations':         { EN:'RESERVATIONS',                          IS:'BÓKANIR' },
-  'cq.noReservations':       { EN:'No reservations.',                      IS:'Engar bókanir.' },
-  'cq.addReservation':       { EN:'Add Reservation',                       IS:'Bæta við bókun' },
+  'cq.reservations':         { EN:'CHARTERS',                              IS:'LEIGUR' },
+  'cq.noReservations':       { EN:'No charters.',                          IS:'Engar leigur.' },
+  'cq.addReservation':       { EN:'Add Charter',                           IS:'Bæta við leigu' },
   'cq.resStartDate':         { EN:'Start date',                            IS:'Upphafsdagur' },
   'cq.resEndDate':           { EN:'End date',                              IS:'Lokadagur' },
   'cq.resNote':              { EN:'Note (optional)',                        IS:'Athugasemd (valfrjálst)' },

--- a/staff/index.html
+++ b/staff/index.html
@@ -587,8 +587,8 @@ function populateSelects() {
   boats.filter(b => !active.find(c => c.boatId === b.id) && !boolVal(b.oos))
     .forEach(b => {
       const o = document.createElement('option'); o.value=b.id;
-      const chartered = isChartered(b);
-      o.textContent = b.name + (chartered ? ' [' + s('fleet.badgeChartered') + ']' : '');
+      const activeRes = getActiveReservation(b);
+      o.textContent = b.name + (activeRes ? ' [' + s('fleet.badgeChartered') + ']' : '');
       bSel.appendChild(o);
     });
   const lSel = document.getElementById('coLocation');
@@ -869,11 +869,6 @@ async function submitCheckout() {
   const boat     = boats.find(b => b.id === bid) || {};
   const location = locations.find(l => l.id === lid) || {};
   const member   = members.find(m => m.kennitala === kt) || {};
-  // Charter override warning for staff
-  if (isChartered(boat)) {
-    const ch = boat.charter;
-    if (!await ymConfirm(s('fleet.charterOverride', { name: ch.memberName, date: ch.endDate }))) return;
-  }
   const snap     = (typeof wxSnapshot === 'function') ? wxSnapshot(wxData) : null;
   try {
     const res = await apiPost('saveCheckout', {
@@ -1219,7 +1214,6 @@ function openGroupModal() {
     btn.dataset.id = b.id;
     if (boolVal(b.oos)) { btn.disabled = true; btn.style.opacity='.35'; btn.title = s('staff.oosTitle'); }
     else if (out) { btn.disabled = true; btn.style.opacity='.35'; btn.title = s('staff.alreadyOut'); }
-    else if (isChartered(b)) { btn.style.opacity='.55'; btn.title = s('fleet.charteredTo',{name:b.charter.memberName}); btn.addEventListener('click', async function() { if(await ymConfirm(s('fleet.charterOverride',{name:b.charter.memberName,date:b.charter.endDate}))) toggleGmBoat(this); }); }
     else btn.addEventListener('click', function() { toggleGmBoat(this); });
     grid.appendChild(btn);
   });


### PR DESCRIPTION
…ter"

The charter and reservation features had overlapping functionality for controlled-access boats. Reservations were the superior implementation (multiple per boat, notes, better access control integration), so:

- Remove standalone charter backend endpoints (saveCharter, removeCharter)
- Remove charter UI section and JS helpers from admin page
- Remove isChartered() helper and all charter override prompts
- Remove legacy charter→reservation migration path
- Remove backward-compat charter field syncing in save/removeReservation
- Rename all reservation UI labels to "Assign Charter" / "Charter" terminology

Closes #284

https://claude.ai/code/session_01CUE84BHAAy6rHnydzBYyhZ