### PR TITLE
Fix captain page log search defaulting to all categories instead of k…

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -793,7 +793,8 @@ function buildFilters() {
   var cSel = document.getElementById('fCat');
   cSel.innerHTML = '<option value="">' + s('cq.allCategories') + '</option>';
   cats.forEach(function(c) { var o = document.createElement('option'); o.value = c; o.textContent = boatEmoji(c.toLowerCase()) + ' ' + c; cSel.appendChild(o); });
-  if (cats.map(function(c) { return c.toLowerCase(); }).includes('keelboat')) cSel.value = 'Keelboat';
+  var keelboatCat = cats.find(function(c) { return c.toLowerCase() === 'keelboat'; });
+  if (keelboatCat) cSel.value = keelboatCat;
 
   // Boat name filter (keelboats only)
   var keelboatNames = [...new Set(myTrips


### PR DESCRIPTION
…eelboats

The category filter default was set using a hardcoded 'Keelboat' (capital K) but option values use the raw data which stores 'keelboat' (lowercase). HTML select value matching is case-sensitive, so the default silently failed. Now finds the actual category value case-insensitively.

Fixes #289

https://claude.ai/code/session_01XzhhsNCAXZtVkFAYYJr9AR