### PR TITLE
Fix lag when launching a boat from member page

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1568,7 +1568,6 @@ function getActiveCheckouts_() {
       guardianPhone: c.guardianPhone || m.guardianPhone || '',
     };
   });
-  cDel_('checkouts');
   return okJ({ checkouts: enriched });
 }
 

--- a/member/index.html
+++ b/member/index.html
@@ -693,12 +693,16 @@ async function submitLaunch() {
       checkedOutAt:tout, expectedReturn:ret, status:'out',
       nonClub:isNC,
     });
+    // Update UI immediately — don't block on crew confirmations
+    window._launchFormValues=null;
+    closeModal('launchModal'); renderActiveCheckouts(); renderFleetByCat();
+    showToast(s('staff.coForm.checkedOut'));
+    // Fire crew confirmations in the background (non-blocking)
     if(crewNames.length){
       var _coId=res?.checkoutId||res?.id||'';
-      // Only create confirmations for non-guest crew (guests are stored in crewNames only)
       var _confCrew=crewNames.filter(function(cn){return cn.kennitala&&!cn.guest;});
       if(_confCrew.length){
-        await Promise.all(_confCrew.map(function(cn){
+        Promise.all(_confCrew.map(function(cn){
           return apiPost('createConfirmation',{
             type:'crew_assigned',
             fromKennitala:user.kennitala, fromName:user.name,
@@ -709,12 +713,9 @@ async function submitLaunch() {
             date:new Date().toISOString().slice(0,10), timeOut:tout,
             role:'crew', wxSnapshot:snap,
           }).catch(function(e2){console.warn('crew confirmation:',cn,e2.message);});
-        }));
+        })).catch(function(e3){console.warn('crew confirmations failed:',e3.message);});
       }
     }
-    window._launchFormValues=null;
-    closeModal('launchModal'); renderActiveCheckouts(); renderFleetByCat();
-    showToast(s('staff.coForm.checkedOut'));
   } catch(e){
     var errEl=document.getElementById('launchCheckErr');
     if(errEl){errEl.textContent=s('toast.error')+': '+e.message;errEl.style.display='block';}


### PR DESCRIPTION
Two changes to reduce latency after pressing "Launch":

1. Backend: Remove unnecessary cDel_('checkouts') from getActiveCheckouts_(). This was clearing the cache on every read, forcing subsequent reads to hit the full Google Sheet. The cache is already properly invalidated on writes (saveCheckout_, saveCheckin_).

2. Frontend: Move UI update (close modal, render, toast) before crew confirmations. Crew confirmation API calls now fire in the background without blocking the UI, so the user sees immediate feedback.

Fixes #286

https://claude.ai/code/session_01CvYu4Hac3tWdxpyojbxDj2