### PR TITLE
Fix missing timeIn in crew confirmation requests

### DIFF
--- a/staff/index.html
+++ b/staff/index.html
@@ -901,6 +901,7 @@ async function submitCheckout() {
           locationId: lid, locationName: location.name||lid,
           date: new Date().toISOString().slice(0,10),
           timeOut: document.getElementById('coTimeOut').value,
+          timeIn: document.getElementById('coReturnBy').value,
           role: 'crew', wxSnapshot: snap,
         }); } catch(e2) { console.warn('crew confirmation failed for', _cn, e2.message); }
       }


### PR DESCRIPTION
When staff creates a checkout with named crew, the createConfirmation call was only passing timeOut (departure) but not timeIn (expected return from coReturnBy field). This caused crew trip records created from confirmations to have empty return times.

https://claude.ai/code/session_01E4eGPS5GTcB1WZ2nBFrABt