### PR TITLE
Remove legacy/migration backward-compat code for fresh site launch

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1064,9 +1064,8 @@ async function loadAll() {
 
   // ── Assign data ───────────────────────────────────────────────────────────
   actTypes       = cfgRes.activityTypes || [];
-  // Support both old phase values (am/pm) and new (opening/closing) for back-compat
-  clItems        = [ ...(cfgRes.dailyChecklist?.opening || cfgRes.dailyChecklist?.am || []),
-                     ...(cfgRes.dailyChecklist?.closing  || cfgRes.dailyChecklist?.pm || []) ];
+  clItems        = [ ...(cfgRes.dailyChecklist?.opening || []),
+                     ...(cfgRes.dailyChecklist?.closing  || []) ];
   certDefs       = certDefsFromConfig(cfgRes.certDefs || []);
   certCategories = certCategoriesFromConfig(cfgRes.certCategories || []);
   _allBoats      = cfgRes.boats      || [];
@@ -1839,7 +1838,6 @@ async function deleteLocation(id) {
 // ══ OPENING / CLOSING CHECKLISTS ═════════════════════════════════════════════
 // Items stored in dailyChecklist.opening[] and dailyChecklist.closing[] in config.
 // Phase field on each item is "opening" or "closing".
-// Back-compat: legacy "am"/"pm" values are normalised on load in loadAll().
 
 function renderChecklists() {
   renderCLPhase("openingCLCard", "opening");
@@ -1848,10 +1846,8 @@ function renderChecklists() {
 
 function renderCLPhase(cardId, phase) {
   const card  = document.getElementById(cardId);
-  // Normalise legacy am→opening, pm→closing for display
-  const norm  = p => (p === 'am' ? 'opening' : p === 'pm' ? 'closing' : p);
   const items = clItems
-    .filter(i => norm(String(i.phase).toLowerCase()) === phase && bool(i.active))
+    .filter(i => String(i.phase).toLowerCase() === phase && bool(i.active))
     .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
   if (!items.length) { card.innerHTML = `<div class="empty-state">${s('admin.noItems')}</div>`; return; }
   card.innerHTML = items.map(i => `
@@ -1867,9 +1863,8 @@ function renderCLPhase(cardId, phase) {
 function openCLModal(id) {
   editingId    = id || null;
   const item   = id ? clItems.find(x => x.id === id) : null;
-  const norm   = p => (p === 'am' ? 'opening' : p === 'pm' ? 'closing' : (p || 'opening'));
   document.getElementById("clModalTitle").textContent = item ? s('admin.clModal.edit') : s('admin.clModal.add');
-  document.getElementById("clPhase").value    = item ? norm(item.phase) : "opening";
+  document.getElementById("clPhase").value    = item ? (item.phase || 'opening') : "opening";
   document.getElementById("clTextEN").value   = item ? (item.textEN  || "") : "";
   document.getElementById("clTextIS").value   = item ? (item.textIS  || "") : "";
   document.getElementById("clSort").value     = item ? (item.sortOrder || 99) : 99;

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -394,19 +394,11 @@ function prRenderCalLabel(){
   var d=new Date(_calYear,_calMonth,1);
   document.getElementById('prCalLabel').textContent=String(d.getMonth()+1).padStart(2,'0')+'-'+d.getFullYear();
 }
-// Pair separate type='in'/type='out' rows into single session entries,
-// and preserve legacy single-row entries (originalTimestamp format).
+// Pair separate type='in'/type='out' rows into single session entries.
 function _pairTimeEntries(rows) {
   var ins   = rows.filter(function(r){ return r.type==='in'; });
   var outs  = rows.filter(function(r){ return r.type==='out'; });
-  var other = rows.filter(function(r){ return r.type!=='in'&&r.type!=='out'&&r.type!=='break_start'&&r.type!=='break_end'; });
   var paired = [];
-  // Legacy single-row entries
-  other.forEach(function(r){
-    var e=Object.assign({},r);
-    if(!e.clockIn&&e.originalTimestamp)e.clockIn=e.originalTimestamp;
-    paired.push(e);
-  });
   // Pair out rows with their matching in rows
   var usedInIds=new Set();
   outs.slice().sort(function(a,b){return a.timestamp>b.timestamp?1:-1;}).forEach(function(out){
@@ -692,8 +684,8 @@ function prPayslipCard(emp,calc,ytd,regularMins){
   h+='</div><div class="psc-hrs">';
   h+='<label class="hrs-label" data-s="payroll.regularHours"></label>';
   h+='<input class="hrs-inp" id="pHrs_'+eid+'" type="number" min="0" step="0.25" value="'+(regularMins/60).toFixed(2)+'" onchange="prRecalc(\''+eid+'\')">';
-  var _otTiers=typeof _legacyOtRulesToArray==='function'
-    ?_legacyOtRulesToArray((window.PAYROLL_CONFIG||{}).otRules||[])
+  var _otTiers=typeof _otRulesToArray==='function'
+    ?_otRulesToArray((window.PAYROLL_CONFIG||{}).otRules||[])
     :((window.PAYROLL_CONFIG||{}).otRules||[]);
   _otTiers.forEach(function(tier){
     var hrs=((calc.otLines||[]).find(function(l){return l.tierId===tier.id;})||{hrs:0}).hrs||0;
@@ -794,8 +786,8 @@ function prGetLines(empId){
 function prRecalc(empId){
   var d=(_previewData.employees||{})[empId];if(!d)return;
   var hrs=+(document.getElementById('pHrs_'+empId)||{value:0}).value||0;
-  var otTiers=typeof _legacyOtRulesToArray==='function'
-    ?_legacyOtRulesToArray((window.PAYROLL_CONFIG||{}).otRules||[])
+  var otTiers=typeof _otRulesToArray==='function'
+    ?_otRulesToArray((window.PAYROLL_CONFIG||{}).otRules||[])
     :((window.PAYROLL_CONFIG||{}).otRules||[]);
   var otMins={};
   otTiers.forEach(function(tier){
@@ -1109,7 +1101,7 @@ async function cfgSaveAllowBreaks(){
 }
 function cfgRenderOT(){
   var cfg=window.PAYROLL_CONFIG||{};
-  var tiers=typeof _legacyOtRulesToArray==='function'?_legacyOtRulesToArray(cfg.otRules||[]):(cfg.otRules||[]);
+  var tiers=typeof _otRulesToArray==='function'?_otRulesToArray(cfg.otRules||[]):(cfg.otRules||[]);
   cfg.otRules=tiers;
   var div=document.getElementById('cfgOTPanel');if(!div)return;
   var html='';
@@ -1138,7 +1130,7 @@ function cfgRenderOT(){
 }
 function cfgAddOTTier(){
   var cfg=window.PAYROLL_CONFIG||{};
-  var tiers=typeof _legacyOtRulesToArray==='function'?_legacyOtRulesToArray(cfg.otRules||[]):(cfg.otRules||[]);
+  var tiers=typeof _otRulesToArray==='function'?_otRulesToArray(cfg.otRules||[]):(cfg.otRules||[]);
   var n=tiers.length+1;
   tiers.push({id:'ot'+n,label:'Eftirvinna '+n,labelEN:'Overtime '+n,multiplier:1.33,periods:[]});
   cfg.otRules=tiers;window.PAYROLL_CONFIG=cfg;cfgRenderOT();

--- a/code.gs
+++ b/code.gs
@@ -1223,15 +1223,9 @@ function getConfig_() {
   const c = cGet_('config'); if (c) return okJ(c);
   // Read the config sheet ONCE and look up all keys from the in-memory map
   const cfgMap = getConfigMap_();
-  let activityTypes = [], dailyChecklist = { am: [], pm: [] };
+  let activityTypes = [], dailyChecklist = { opening: [], closing: [] };
   try {
     activityTypes = JSON.parse(getConfigValue_('activity_types', cfgMap) || '[]');
-    // Ensure each type has a subtypes array (for backwards compat)
-    activityTypes = activityTypes.map(function(t) {
-      if (!t.subtypes) t.subtypes = [];
-      else if (typeof t.subtypes === 'string') { try { t.subtypes = JSON.parse(t.subtypes); } catch(e) { t.subtypes = []; } }
-      return t;
-    });
   } catch (e) { }
   try {
     readAll_('dailyCL').filter(r => bool_(r.active)).forEach(r => {
@@ -2542,9 +2536,6 @@ function requestVerification_(b) {
   if (!trip) return failJ('Trip not found', 404);
   if (trip.verified && trip.verified !== 'false') return failJ('Already verified');
 
-  // Mark the trip as validation-requested (backward compat)
-  updateRow_('trips', 'id', b.tripId, { validationRequested: true });
-
   ensureConfirmationCols_();
   var ts = now_(), id = uid_();
   insertRow_('tripConfirmations', {
@@ -3321,40 +3312,6 @@ function sendSmsAlert_(alert, cfg) {
   cfg.staffSmsList.forEach(to => {
     Logger.log('[SMS] to=' + to + ' | ' + message);
   });
-}
-
-// ── One-time migration — run from Apps Script editor ───────────────────────
-function migrateTripColumns() {
-  var ss    = SpreadsheetApp.openById(SHEET_ID_);
-  var sheet = ss.getSheetByName("trips");
-  if (!sheet) { Logger.log("trips sheet not found"); return; }
-  var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-  Logger.log("Current headers: " + headers.join(", "));
-
-  // Columns to remove
-  var toRemove = ["windMs","seaState","precip","waveHeight","launchBeaufort","launchWindDir","launchWaveHeight"];
-
-  // Add wxSnapshot if missing
-  if (headers.indexOf("wxSnapshot") === -1) {
-    sheet.getRange(1, headers.length + 1).setValue("wxSnapshot");
-    headers.push("wxSnapshot");
-    Logger.log("Added wxSnapshot column");
-  }
-
-  // Remove redundant columns (work right-to-left so indices stay valid)
-  var removeIndices = [];
-  toRemove.forEach(function(name) {
-    var idx = headers.indexOf(name);
-    if (idx !== -1) removeIndices.push(idx + 1);  // 1-based
-  });
-  removeIndices.sort(function(a,b){return b-a;});
-  removeIndices.forEach(function(col) {
-    sheet.deleteColumn(col);
-    Logger.log("Deleted column " + col);
-  });
-
-  Logger.log("Migration complete. New headers: " + 
-    sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0].join(", "));
 }
 
 // ── resolveAlert: called by the email relay page ────────────────────────────

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -688,7 +688,7 @@ document.addEventListener('DOMContentLoaded', () => {
       var nowISO  = new Date().toISOString().slice(0,13);
       var nowIdx  = Math.max(0, (hr.time||[]).findIndex(function(tt) { return tt.slice(0,13) === nowISO; }));
       var presObj = wxPressureTrend(hr.surface_pressure, nowIdx);
-      var assessed = wxAssessFlag(ws, wDir, waveH || 0);
+      var assessed = wxScoreFlag(ws, wDir, waveH || 0, null, null, null, 'good');
       wxData = { ws:ws, wd:wd, wg:wg, bft:bft, wDir:wDir, waveH:waveH,
                  waveDir:waveDir, sst:sst, flagKey:assessed.flagKey,
                  airT:c.temperature_2m, apparentT:c.apparent_temperature,
@@ -999,8 +999,8 @@ async function loadIncidentsForDate(date) {
 
 function applyLogData(log, cfgRes) {
   const cfg = cfgRes || {};
-  amItems       = cfg.dailyChecklist?.opening || cfg.dailyChecklist?.am  || DEFAULT_AM;
-  pmItems       = cfg.dailyChecklist?.closing  || cfg.dailyChecklist?.pm  || DEFAULT_PM;
+  amItems       = cfg.dailyChecklist?.opening || DEFAULT_AM;
+  pmItems       = cfg.dailyChecklist?.closing  || DEFAULT_PM;
   activityTypes = cfg.activityTypes       || DEFAULT_TYPES;
   // Always auto-fill tides from harmonic prediction for the viewed date
   _autoFillTide();

--- a/member/index.html
+++ b/member/index.html
@@ -411,9 +411,7 @@ function _fmtCatLabel(cat) {
   var ico=(c&&c.emoji)?c.emoji:boatEmoji(cat);
   return ico+' '+esc(lbl.toUpperCase());
 }
-// Handles both config objects {text, textIS, sort} and legacy plain strings.
 function _clItemLabel(it) {
-  if(typeof it==='string') return it;
   return (getLang()==='IS'&&it.textIS)?it.textIS:(it.text||'');
 }
 

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -248,8 +248,8 @@ function tripCard(t){
     // Filter: show own photos + photos shared with crew
     const visibleUrls = urls.filter((u) => {
       const pm = meta[u];
-      if (!pm) return true; // legacy photos: visible to all
       if (isOwner) return true; // owner always sees own photos
+      if (!pm) return false;
       return pm.shared; // crew only sees shared photos
     });
     if (!visibleUrls.length) return '';
@@ -1126,8 +1126,6 @@ document.addEventListener('click', function(e) {
     document.querySelectorAll('.trip-card.open').forEach(c => c.classList.remove('open'));
   }
 });
-// Keep old name for backwards compat with any external callers
-function toggleTripCard(card) { openTripCard(card); }
 function toggleTripDetail(btn) {
   const detail = btn.parentElement.querySelector('.trip-detailed');
   if (!detail) return;

--- a/shared/payroll.js
+++ b/shared/payroll.js
@@ -63,21 +63,12 @@ window.fmtDurationMins = function(mins) {
 };
 
 /* PP OT SPLITTER ═════════════════════════════════════════════════════════════
-   otRules is now an ordered array of tier objects {id, label, labelEN, multiplier, periods}.
-   Higher index = higher priority (checked first). Returns {regularMins, otMins, ot1Mins, ot2Mins}.
-   Backward-compat aliases ot1Mins/ot2Mins map to tiers[0]/tiers[1] by position.
+   otRules is an ordered array of tier objects {id, label, labelEN, multiplier, periods}.
+   Higher index = higher priority (checked first). Returns {regularMins, otMins}.
 ══════════════════════════════════════════════════════════════════════════════ */
-function _legacyOtRulesToArray(rules) {
+function _otRulesToArray(rules) {
   if (!rules) return [];
-  if (Array.isArray(rules)) return rules;
-  // Legacy object {ot1:{...}, ot2:{...}} → ordered array
-  var arr = [];
-  if (rules.ot1) arr.push(Object.assign({ id:'ot1' }, rules.ot1));
-  if (rules.ot2) arr.push(Object.assign({ id:'ot2' }, rules.ot2));
-  Object.keys(rules).forEach(function(k) {
-    if (k !== 'ot1' && k !== 'ot2') arr.push(Object.assign({ id:k }, rules[k]));
-  });
-  return arr;
+  return Array.isArray(rules) ? rules : [];
 }
 
 function _inPeriods(day, hour, periods) {
@@ -105,7 +96,7 @@ function _runLengthDynamic(start, maxMins, cls, tiersArr) {
 }
 
 window.splitOTMinutes = function(entries, otRules) {
-  var tiersArr = _legacyOtRulesToArray(otRules || (window.PAYROLL_CONFIG || {}).otRules);
+  var tiersArr = _otRulesToArray(otRules || (window.PAYROLL_CONFIG || {}).otRules);
   var regularMins = 0;
   var otMins = {};
   tiersArr.forEach(function(t) { otMins[t.id] = 0; });
@@ -129,40 +120,21 @@ window.splitOTMinutes = function(entries, otRules) {
 
   var result = { regularMins: Math.round(regularMins), otMins: {} };
   tiersArr.forEach(function(t) { result.otMins[t.id] = Math.round(otMins[t.id] || 0); });
-  // Backward-compat aliases
-  result.ot1Mins = result.otMins[tiersArr[0] && tiersArr[0].id] || 0;
-  result.ot2Mins = result.otMins[tiersArr[1] && tiersArr[1].id] || 0;
   return result;
 };
 
 /* PP CALCULATE PAYSLIP ════════════════════════════════════════════════════════
-   New signature: calculatePayslip(emp, regularMinutes, otMinutes, manualLines, cfg)
-     otMinutes: object {[tierId]: minutes}  — OR —
-   Legacy:     calculatePayslip(emp, regularMinutes, ot1Min, ot2Min, manualLines, cfg)
-     (detected when 3rd arg is a number)
-   Returns full breakdown; includes otLines[] array + backward-compat ot1/ot2 aliases.
+   calculatePayslip(emp, regularMinutes, otMinutes, manualLines, cfg)
+     otMinutes: object {[tierId]: minutes}
+   Returns full breakdown including otLines[] array.
 ══════════════════════════════════════════════════════════════════════════════ */
-window.calculatePayslip = function(emp, regularMinutes, otMinutesOrOt1, manualLinesOrOt2, cfgOrManual, cfgLegacy) {
-  var otMins, manualLines, cfg;
-  if (typeof otMinutesOrOt1 === 'object' && !Array.isArray(otMinutesOrOt1) && otMinutesOrOt1 !== null) {
-    // New call: (emp, regular, {ot1:x,...}, manual, cfg)
-    otMins      = otMinutesOrOt1 || {};
-    manualLines = manualLinesOrOt2 || [];
-    cfg         = cfgOrManual;
-  } else {
-    // Legacy call: (emp, regular, ot1, ot2, manual, cfg)
-    var _tiers = _legacyOtRulesToArray((window.PAYROLL_CONFIG || {}).otRules);
-    otMins = {};
-    if (_tiers[0]) otMins[_tiers[0].id] = +otMinutesOrOt1  || 0;
-    if (_tiers[1]) otMins[_tiers[1].id] = +manualLinesOrOt2 || 0;
-    manualLines = cfgOrManual || [];
-    cfg         = cfgLegacy;
-  }
+window.calculatePayslip = function(emp, regularMinutes, otMinutes, manualLines, cfg) {
+  var otMins      = otMinutes || {};
   cfg            = Object.assign({}, window.PAYROLL_CONFIG, cfg || {});
   regularMinutes = +regularMinutes || 0;
   manualLines    = manualLines || [];
 
-  var tiersArr = _legacyOtRulesToArray(cfg.otRules);
+  var tiersArr = _otRulesToArray(cfg.otRules);
   var baseRate  = +(emp.baseRateKr) || 0;
   var regularHrs = regularMinutes / 60;
   var dagvinna   = Math.round(regularHrs * baseRate);

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -59,9 +59,7 @@
     _tid = setTimeout(() => { el.style.opacity = '0'; _tid = null; }, ms);
   };
 
-  // backward-compat aliases
-  window.toast   = (msg, type) => showToast(msg, type);
-  window.showMsg = (msg, type) => showToast(msg, type);
+  window.toast = (msg, type) => showToast(msg, type);
 })();
 
 // ── HTML ESCAPE ────────────────────────────────────────────────────────────────

--- a/shared/weather.js
+++ b/shared/weather.js
@@ -6,7 +6,7 @@
 //
 // FLAG SYSTEM
 // -----------
-// All flag thresholds live in FLAG_CONFIG (below). Admin can edit these via
+// All flag thresholds live in SCORE_CONFIG (below). Admin can edit these via
 // admin/index.html → Flags tab; changes are saved to the backend and fetched
 // on load via wxLoadFlagConfig(). No magic numbers anywhere else.
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -33,7 +33,6 @@ let WX_LABEL = WX_DEFAULT.label;
 // SCORE_CONFIG  —  single source of truth for all flag/scoring logic.
 // Admin-editable via admin → Flags tab. wxLoadFlagConfig() merges saved values.
 // wxScoreFlag()  computes total score → flag + full breakdown.
-// wxAssessFlag() is a backwards-compatible wrapper for legacy call sites.
 // ═══════════════════════════════════════════════════════════════════════════════
 const SCORE_CONFIG = {
   thresholds: { yellow: 25, orange: 45, red: 65, black: 80 },
@@ -120,13 +119,6 @@ function wxLoadFlagConfig(saved) {
   }
 }
 
-// Backwards-compat shim
-const FLAG_CONFIG = {
-  get flags()        { return SCORE_CONFIG.flags; },
-  get easterlyDirs() { return SCORE_CONFIG.easterlyDirs; },
-  get wind()  { return { yellow: SCORE_CONFIG.thresholds.yellow, orange: SCORE_CONFIG.thresholds.orange, red: SCORE_CONFIG.thresholds.red }; },
-  get wave()  { const w = SCORE_CONFIG.waves; return { yellow:(w[1]||{}).maxM||0.5, orange:(w[2]||{}).maxM||1.0, red:(w[3]||{}).maxM||1.5 }; },
-};
 
 // ── Unit helpers ───────────────────────────────────────────────────────────────────────────────
 function wxMsToBft(ms) {
@@ -235,10 +227,6 @@ function wxScoreFlag(ws, wDir, waveH, airT, sst, wg, visKey) {
     reasons: breakdown.map(b => ({ f: flagKey, t: b.label })) };
 }
 
-// Backwards-compat wrapper
-function wxAssessFlag(ws, wDir, waveH) {
-  return wxScoreFlag(ws, wDir, waveH, null, null, null, 'good');
-}
 
 // ── Staff status badge HTML ─────────────────────────────────────────────────────────────────────
 function wxStaffStatusHtml(status, lang) {

--- a/weather/index.html
+++ b/weather/index.html
@@ -190,7 +190,7 @@ function render(wx, marine, staffStatus) {
   const nowIdx = Math.max(0, (hr.time||[]).findIndex(t => t.slice(0,13) === nowISO));
   const { trend: presTrend, diff: presDiff } = wxPressureTrend(hr.surface_pressure, nowIdx);
 
-  // Use wxAssessFlag from shared/weather.js (reads FLAG_CONFIG, admin-editable)
+  // Use wxScoreFlag from shared/weather.js (reads SCORE_CONFIG, admin-editable)
   const _fr = { flagKey:null };
   const { flagKey, flag, score, breakdown, reasons } = wxScoreFlag(ws, wDir, waveH ?? 0, c.temperature_2m, sst, wg, 'good');
   const presClass = presTrend === 'rising' ? 'rising' : presTrend === 'falling' ? 'falling' : '';
@@ -228,7 +228,7 @@ function render(wx, marine, staffStatus) {
   <div class="flex-1">
     <div class="flag-label">${flag.label}</div>
     <div class="flag-advice">${flag.advice}</div>
-    ${reasons.length ? `<div class="flag-reasons">${reasons.map(r=>`<span class="flag-chip" style="color:${FLAG_CONFIG.flags[r.f].color};border-color:${FLAG_CONFIG.flags[r.f].border}">${esc(r.t)}</span>`).join('')}</div>` : ''}
+    ${reasons.length ? `<div class="flag-reasons">${reasons.map(r=>`<span class="flag-chip" style="color:${SCORE_CONFIG.flags[r.f].color};border-color:${SCORE_CONFIG.flags[r.f].border}">${esc(r.t)}</span>`).join('')}</div>` : ''}
   </div>
 </div>
 ${staffStatus ? wxStaffStatusHtml(staffStatus, null) : ''}
@@ -358,7 +358,7 @@ ${staffStatus ? wxStaffStatusHtml(staffStatus, null) : ''}
 function renderHourStrip(pts) {
   const FLAG_COLORS = { green:'#27ae60', yellow:'#f1c40f', orange:'#e67e22', red:'#e74c3c' };
   document.getElementById('hourStrip').innerHTML = pts.map(p => {
-    const { flagKey } = wxAssessFlag(p.ws, wxDirLabel(p.wd), p.mWH ?? 0);
+    const { flagKey } = wxScoreFlag(p.ws, wxDirLabel(p.wd), p.mWH ?? 0, null, null, null, 'good');
     return `<div class="h-slot${p.isNow?' now':p.isPast?' past':''}">
       <div class="h-time">${p.isNow ? 'NOW' : p.t}</div>
       <div class="h-main">


### PR DESCRIPTION
Clean up accumulated backward-compatibility shims, one-time migration functions, and legacy data-format handling no longer needed for a brand-new site deployment.

Removed:
- migrateTripColumns() one-time migration function (code.gs)
- FLAG_CONFIG shim & wxAssessFlag() wrapper (weather.js) — callers updated to use SCORE_CONFIG / wxScoreFlag() directly
- Legacy OT rules object→array conversion (_legacyOtRulesToArray → simplified _otRulesToArray that only accepts arrays)
- Legacy calculatePayslip dual-signature (old positional ot1/ot2 args)
- splitOTMinutes ot1Mins/ot2Mins backward-compat aliases
- Checklist am/pm → opening/closing normalization (admin, dailylog, backend now uses opening/closing keys natively)
- Legacy single-row originalTimestamp payroll time entries
- Legacy plain-string checklist item handling (member page)
- Subtypes string→array backward-compat parsing (code.gs)
- Redundant validationRequested write in requestVerification_
- Unused toggleTripCard() alias (logbook.js)
- Unused window.showMsg alias (ui.js)
- Legacy photos-without-meta default-visible behavior (logbook.js)

Closes #295

https://claude.ai/code/session_014euc9VvV3wDKb6qLwWWr97