### PR TITLE
Fix add boat button by quoting category key parameter

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1470,7 +1470,7 @@ function renderBoats() {
         <div class="col-head" onclick="toggleSection(this)">
           <div class="col-title">${cat.emoji || boatEmoji(cat.key)} ${boatCatBadge(cat.key)}</div>
           <div style="display:flex;align-items:center;gap:6px" onclick="event.stopPropagation()">
-            <button class="row-edit" onclick="openBoatModalForCat(${cat.key})">+ Add boat</button>
+            <button class="row-edit" onclick="openBoatModalForCat('${cat.key}')">+ Add boat</button>
             <button class="row-edit" onclick="openBoatCatModal('${cat.key}')">Edit</button>
             <span class="col-toggle">▼</span>
           </div>


### PR DESCRIPTION
The onclick handler for the "Add boat" button passed cat.key unquoted, rendering as e.g. openBoatModalForCat(dinghy) which throws a ReferenceError. Added quotes so it renders as openBoatModalForCat('dinghy').

https://claude.ai/code/session_01DLp7AkQKXspBhfyv9TGikG