### PR TITLE
Fix ReferenceError when _STRINGS_FLAT is not loaded

### DIFF
--- a/shared/strings.js
+++ b/shared/strings.js
@@ -4,6 +4,10 @@
 
 window.s = function s(key, vars, lang) {
   // If a specific language is requested that differs from loaded, fall back to key
+  if (typeof _STRINGS_FLAT === 'undefined') {
+    console.warn('[strings] _STRINGS_FLAT not loaded; language file may be missing');
+    return key;
+  }
   var str = _STRINGS_FLAT[key];
   if (str === undefined) {
     console.warn('[strings] missing key:', key);


### PR DESCRIPTION
Add a guard in s() to check if _STRINGS_FLAT is defined before accessing it. If the language file (strings-en.js / strings-is.js) fails to load via document.write, the function now gracefully falls back to returning the key instead of throwing an uncaught ReferenceError.

https://claude.ai/code/session_014HNn6eaWbUBuNkn7vQ55Tf