### PR TITLE
Fix wxFetch undefined error by removing defer from script tags

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -11,8 +11,8 @@
 <script src="../shared/ui.js"></script>
 <script>document.write('<script src="../shared/strings-'+(localStorage.getItem('ymirLang')||'EN').toLowerCase()+'.js"><\/script>');</script>
 <script src="../shared/strings.js"></script>
-<script src="../shared/weather.js" defer></script>
-<script src="../shared/tides.js" defer></script>
+<script src="../shared/weather.js"></script>
+<script src="../shared/tides.js"></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/maintenance.js" defer></script>
 <style>

--- a/weather/index.html
+++ b/weather/index.html
@@ -11,8 +11,8 @@
 <script>document.write('<script src="../shared/strings-'+(localStorage.getItem('ymirLang')||'EN').toLowerCase()+'.js"><\/script>');</script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/ui.js"></script>
-<script src="../shared/weather.js" defer></script>
-<script src="../shared/tides.js" defer></script>
+<script src="../shared/weather.js"></script>
+<script src="../shared/tides.js"></script>
 <style>
 .page { max-width:700px; margin:0 auto; padding:20px 16px 56px; }
 


### PR DESCRIPTION
The weather.js and tides.js scripts were loaded with `defer`, but inline scripts that call wxFetch() execute before deferred scripts. Removing `defer` ensures the functions are available when the inline code runs.

https://claude.ai/code/session_01NsA3YCEvogjDcVLrbBWYgX