### PR TITLE
Prefetch post-login data and warm backend during login

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -95,6 +95,9 @@ document.getElementById('ktInput').addEventListener('keydown', e => {
   if (e.key === 'Enter') doLogin();
 });
 
+// Warm the Apps Script container early so post-login API calls are fast
+apiGet('getConfig');
+
 async function doLogin() {
   const kt  = document.getElementById('ktInput').value.trim().replace(/\D/g, '');
   const btn = document.getElementById('loginBtn');
@@ -116,11 +119,20 @@ async function doLogin() {
     const user = data.member;
     setUser(user);
 
+    // Prefetch data the landing page will need while user is on role picker
+    // (or racing the redirect for regular members). Results land in
+    // sessionStorage via apiGet's cache, so the target page skips the call.
+    window._prefetchConfig = apiGet('getConfig');
     if (user.role === 'admin') {
+      window._prefetchMembers = apiGet('getMembers');
+      window._prefetchCheckouts = apiGet('getActiveCheckouts');
       showRolePicker(user, ['member', 'staff', 'admin']);
     } else if (user.role === 'staff') {
+      window._prefetchMembers = apiGet('getMembers');
+      window._prefetchCheckouts = apiGet('getActiveCheckouts');
       showRolePicker(user, ['member', 'staff']);
     } else {
+      window._prefetchCheckouts = apiGet('getActiveCheckouts');
       window.location.href = '../member/';
     }
   } catch(e) {


### PR DESCRIPTION
Fire getConfig on login page load to warm the Apps Script container before the user even authenticates. After successful login, prefetch getConfig, getActiveCheckouts, and getMembers (role-dependent) so sessionStorage cache is warm when the landing page loads.

https://claude.ai/code/session_015xvVqJyrVuWyPRkdrSeuWd