### PR TITLE
Fix user settings not syncing between server and pages

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -119,6 +119,14 @@ async function doLogin() {
     const user = data.member;
     setUser(user);
 
+    // Sync server preferences → localStorage so all pages see saved settings
+    var serverPrefs = parseJson(user.preferences, {});
+    if (Object.keys(serverPrefs).length) {
+      setPrefs(serverPrefs);
+      if (serverPrefs.theme) setTheme(serverPrefs.theme);
+    }
+    if (user.lang) setLang(user.lang);
+
     // Prefetch data the landing page will need while user is on role picker
     // (or racing the redirect for regular members). Results land in
     // sessionStorage via apiGet's cache, so the target page skips the call.

--- a/settings/index.html
+++ b/settings/index.html
@@ -198,14 +198,13 @@ document.addEventListener('DOMContentLoaded', async function() {
     setToggle('langToggle', btn.dataset.val);
   });
 
-  // Also fetch from server to sync any saved prefs
+  // Always fetch from server to keep local prefs in sync
   try {
     var mRes = await apiGet('getMembers');
     var me = (mRes.members || []).find(function(m) { return String(m.kennitala) === String(user.kennitala); });
     if (me) {
       var serverPrefs = parseJson(me.preferences, {});
-      // If local has no prefs yet, populate from server
-      if (!localStorage.getItem('ymirPrefs') && Object.keys(serverPrefs).length) {
+      if (Object.keys(serverPrefs).length) {
         setPrefs(serverPrefs);
         if (serverPrefs.windUnit) document.getElementById('sWindUnit').value = serverPrefs.windUnit;
         if (serverPrefs.theme) { setToggle('themeToggle', serverPrefs.theme); setTheme(serverPrefs.theme); }


### PR DESCRIPTION
Two issues caused settings to become unlinked:

1. Login never applied server preferences to localStorage — validateMember returns saved preferences but they were only stored in the user object (sessionStorage), not in localStorage where getPrefs() reads from. Now login syncs preferences, theme, and language to localStorage.

2. Settings page only synced from server when localStorage was completely empty, so cross-device or stale prefs were never updated. Removed the empty-localStorage guard so server prefs always take precedence.

https://claude.ai/code/session_01FwvySi4PXk7jcz4hFotmpn