### PR TITLE
Fix time input rounding bug where :00 minutes displayed as :16

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -211,13 +211,13 @@ function getSheet_(tabKey) {
   return s;
 }
 
-const TIME_COLS_ = new Set(['checkedOutAt', 'checkedInAt', 'expectedReturn', 'timeOut', 'timeIn', 'returnBy']);
+const TIME_COLS_ = new Set(['checkedOutAt', 'checkedInAt', 'expectedReturn', 'timeOut', 'timeIn', 'returnBy', 'startTime', 'endTime']);
 
 function sanitizeCell_(col, val) {
   if (!(val instanceof Date)) return val;
   const iso = val.toISOString();
   if (iso.startsWith('1899-12-3') || iso.startsWith('1899-12-2')) {
-    return String(val.getHours()).padStart(2, '0') + ':' + String(val.getMinutes()).padStart(2, '0');
+    return iso.slice(11, 16);
   }
   return TIME_COLS_.has(col) ? iso.slice(11, 16) : iso.slice(0, 10);
 }


### PR DESCRIPTION
Google Sheets stores time-only values as Date objects anchored to Dec 30, 1899. The sanitizeCell_ function used getHours()/getMinutes() to extract the time, but these methods apply the historical timezone offset for 1899 (Iceland's pre-1908 LMT), causing minutes to shift.

Fix by using iso.slice(11,16) from the UTC ISO string instead, which matches how the Date was constructed from the modern UTC+0 offset. Also add startTime/endTime to TIME_COLS_ as a safety net.

https://claude.ai/code/session_01VPEXKWc5jKAyCYv4wQc6ry