### PR TITLE
Fix helm data disappearing after confirmation handshake

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -2454,9 +2454,20 @@ function respondConfirmation_(b) {
       }
     }
     if (type === 'helm') {
-      // Set helm on the specified trip
+      // Set helm on the crew member's trip (by tripId or kennitala+checkout)
       if (row.tripId) {
         updateRow_('trips', 'id', row.tripId, { helm: true, updatedAt: ts });
+      } else {
+        var helmKt = row.toKennitala;
+        var helmCoId = row.linkedCheckoutId;
+        if (helmKt && helmCoId) {
+          var helmTrips = readAll_('trips').filter(function(t) {
+            return String(t.kennitala) === String(helmKt) && String(t.linkedCheckoutId) === String(helmCoId);
+          });
+          helmTrips.forEach(function(t) {
+            updateRow_('trips', 'id', t.id, { helm: true, updatedAt: ts });
+          });
+        }
       }
     }
     if (type === 'student') {

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -86,6 +86,13 @@ function tripCard(t){
     c.status==='pending' && c.type==='helm' &&
     (c.tripId===t.id || (t.linkedCheckoutId && c.linkedCheckoutId===t.linkedCheckoutId))
   );
+  const confirmedHelmConfs = _confirmations.outgoing.filter(c =>
+    c.status==='confirmed' && c.type==='helm' &&
+    (c.tripId===t.id || (t.linkedCheckoutId && c.linkedCheckoutId===t.linkedCheckoutId))
+  ).concat(_confirmations.incoming.filter(c =>
+    c.status==='confirmed' && c.type==='helm' &&
+    (c.tripId===t.id || (t.linkedCheckoutId && c.linkedCheckoutId===t.linkedCheckoutId))
+  ));
   // Also check incoming pending (requests sent TO this user)
   const pendingCrewIn = _confirmations.incoming.filter(c =>
     c.status==='pending' && (c.type==='crew_assigned'||c.type==='crew_join') &&
@@ -171,7 +178,7 @@ function tripCard(t){
   // 1. Trip owner (the person whose card this is)
   const _ownerCn = _crewNameEntry(t.kennitala);
   const ownerIsStudent = (t.student && t.student!=='false') || !!(_ownerCn?.student) || studentConfs.some(c=>String(c.toKennitala)===String(t.kennitala)) || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)));
-  const ownerIsHelm = isHelm || !!(_ownerCn?.helm);
+  const ownerIsHelm = isHelm || !!(_ownerCn?.helm) || confirmedHelmConfs.some(c=>String(c.toKennitala)===String(t.kennitala));
   const ownerEntry = esc(t.memberName||'?') + _personBadges({
     skipper: isSki,
     helm: ownerIsHelm,
@@ -191,7 +198,7 @@ function tripCard(t){
   // 3. Linked crew (confirmed via handshake — use crewNames as fallback for helm/student)
   const linkedCrewEntries = linkedCrew.map(x => {
     const cn = _crewNameEntry(x.kennitala);
-    const xHelm = (x.helm && x.helm!=='false') || !!(cn?.helm);
+    const xHelm = (x.helm && x.helm!=='false') || !!(cn?.helm) || confirmedHelmConfs.some(c=>String(c.toKennitala)===String(x.kennitala));
     const xStudent = (x.student && x.student!=='false') || !!(cn?.student) || studentConfs.some(c=>String(c.toKennitala)===String(x.kennitala));
     return esc(x.memberName||x.crewMemberName||'?') + _personBadges({
       helm: xHelm, student: xStudent, guest: _memberIsGuest(x.kennitala),
@@ -257,6 +264,15 @@ function tripCard(t){
       const isGuest = cn.guest || !cn.kennitala || _memberIsGuest(cn.kennitala);
       helmEntries.push(esc(cn.name) + (isGuest ? guestBadge : ''));
       helmPlainNames.push(cn.name);
+    });
+    // Confirmed helm from handshake confirmations (fallback when trip record not yet refreshed)
+    confirmedHelmConfs.forEach(c => {
+      const kt = String(c.toKennitala || c.fromKennitala || '');
+      if (!kt || _helmKts.has(kt)) return;
+      _helmKts.add(kt);
+      const name = c.toName || c.fromName || '?';
+      helmEntries.push(esc(name) + (_memberIsGuest(kt) ? guestBadge : ''));
+      helmPlainNames.push(name);
     });
     // Pending helm confirmations
     const pendingHelmEntries = pendingHelmConfs.map(c => {


### PR DESCRIPTION
Two root causes:
1. Backend: helm confirmations created at check-in don't include tripId, only linkedCheckoutId. The confirmation handler only set helm when tripId was present, so it never wrote helm:true to the trip record. Now falls back to lookup by toKennitala + linkedCheckoutId (matching the student confirmation pattern).

2. Frontend: after a confirmation changed from pending to confirmed, the pending filters excluded it and no other data source had helm:true. Now also reads confirmed helm confirmations as a source for helm display in crew-aboard badges, the helm section, and the card face.

https://claude.ai/code/session_01Dsh8M8HqkwHWyb3MdB8Qqo