### PR TITLE
Fix stale helm/student data from caching and confirmation lifecycle

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1190,20 +1190,21 @@ async function confirmCheckIn(coId) {
       });
     }
     if(handshakeRequests.length) await Promise.all(handshakeRequests);
-    // Update crewNames with helm/student flags set directly for guests (no handshake needed)
+    // Update crewNames with helm/student flags for all crew (not just guests)
+    // so the skipper's trip record always has the data for display
     var _updatedCrewNames=parseJson(co.crewNames,[]);
-    var _guestUpdated=false;
+    var _crewNamesChanged=false;
     document.querySelectorAll('.helm-toggle').forEach(function(cb){
-      if(!cb.checked||cb.dataset.helmSelf||!cb.dataset.guest) return;
+      if(!cb.checked||cb.dataset.helmSelf) return;
       var cn=_updatedCrewNames.find(function(c){return c.name&&String(c.kennitala)===String(cb.dataset.helmKt);});
-      if(cn){cn.helm=true;_guestUpdated=true;}
+      if(cn&&!cn.helm){cn.helm=true;_crewNamesChanged=true;}
     });
     document.querySelectorAll('.student-toggle').forEach(function(cb){
-      if(!cb.checked||!cb.dataset.guest) return;
+      if(!cb.checked) return;
       var cn=_updatedCrewNames.find(function(c){return c.name&&String(c.kennitala)===String(cb.dataset.stuKt);});
-      if(cn){cn.student=true;_guestUpdated=true;}
+      if(cn&&!cn.student){cn.student=true;_crewNamesChanged=true;}
     });
-    if(_guestUpdated&&_skipperTripId){
+    if(_crewNamesChanged&&_skipperTripId){
       apiPost('saveTrip',{id:_skipperTripId,crewNames:JSON.stringify(_updatedCrewNames)}).catch(function(){});
     }
     window._retCrewTrips=[]; window._retCrewTripsFetched=false;

--- a/shared/api.js
+++ b/shared/api.js
@@ -4,9 +4,18 @@ const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbxDOdwZGy2gDt99PEENS
 const API_TOKEN  = "ymirsc2026";
 const BASE_URL   = "https://skarfur.github.io/ymir";
 
-// ── Service Worker Registration ─────────────────────────────────────────────
+// ── Service Worker Cleanup ──────────────────────────────────────────────────
+// Unregister any previously-installed service worker and purge its caches
+// so users always get fresh static assets.
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register(BASE_URL + '/sw.js', { scope: BASE_URL + '/' }).catch(function() {});
+  navigator.serviceWorker.getRegistrations().then(function(regs) {
+    regs.forEach(function(r) { r.unregister(); });
+  }).catch(function() {});
+  if (typeof caches !== 'undefined') {
+    caches.keys().then(function(names) {
+      names.forEach(function(n) { caches.delete(n); });
+    }).catch(function() {});
+  }
 }
 
 async function apiGet(action, params) {

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1611,10 +1611,15 @@ async function loadConfirmations(){
     if (resolved.length) {
       resolved.forEach(c => apiPost('dismissConfirmation', { id: c.id }).catch(function(){}));
     }
-    // Only keep pending in local state
-    _confirmations={incoming:incoming.filter(c=>c.status==='pending'),outgoing:outgoing.filter(c=>c.status==='pending')};
+    // Keep pending + confirmed in local state (confirmed needed for helm/student display)
+    _confirmations={
+      incoming:incoming.filter(c=>c.status==='pending'||c.status==='confirmed'),
+      outgoing:outgoing.filter(c=>c.status==='pending'||c.status==='confirmed'),
+    };
     _confirmationsLoaded=true;
     updateConfBadge();
+    // Re-render trips so confirmation badges (pending/helm/student) appear
+    if (typeof applyFilter === 'function') applyFilter();
   }catch(e){
     console.warn('loadConfirmations:',e.message);
     _confirmationsLoaded=true;
@@ -1664,7 +1669,7 @@ function renderConfirmations(){
   if (dismissAllEl) dismissAllEl.innerHTML = '';
 
   // Group incoming confirmations by trip (linkedCheckoutId or tripId)
-  var incoming=_confirmations.incoming.sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
+  var incoming=_confirmations.incoming.filter(function(c){return c.status==='pending';}).sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
   if(!incoming.length){
     inEl.innerHTML='<div class="empty-note">'+s('member.noIncoming')+'</div>';
   }else{
@@ -1696,7 +1701,7 @@ function renderConfirmations(){
   }
 
   // Group outgoing confirmations by trip
-  var outgoing=_confirmations.outgoing.sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
+  var outgoing=_confirmations.outgoing.filter(function(c){return c.status==='pending';}).sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
   if(!outgoing.length){
     outEl.innerHTML='<div class="empty-note">'+s('member.noOutgoing')+'</div>';
   }else{
@@ -1728,9 +1733,9 @@ function renderConfirmations(){
 async function respondConf(confId,response,rejectComment){
   try{
     await apiPost('respondConfirmation',{id:confId,response:response,rejectComment:rejectComment||''});
-    // Auto-dismiss resolved confirmation from local state
-    _confirmations.incoming = _confirmations.incoming.filter(c => c.id !== confId);
-    // Fire server-side dismiss in background (non-blocking)
+    // Update local state: mark as confirmed/rejected (keep for display), dismiss server-side
+    var _conf = _confirmations.incoming.find(c => c.id === confId);
+    if (_conf) _conf.status = response === 'confirmed' ? 'confirmed' : 'rejected';
     apiPost('dismissConfirmation', { id: confId }).catch(function(){});
     updateConfBadge();
     renderConfirmations();


### PR DESCRIPTION
Root causes of inconsistent badge display:

1. Service worker (sw.js) was still registered via api.js, serving cache-first copies of logbook.js and other shared JS. Replaced registration with unregistration + cache purge so existing users get fresh code on next visit.

2. loadConfirmations() filtered to only pending and auto-dismissed confirmed entries server-side. This meant confirmedHelmConfs and studentConfs were always empty — helm/student badges vanished the moment a handshake completed. Now keeps pending + confirmed in local state for display. Modal rendering filters to pending so confirmed items don't show action buttons.

3. loadConfirmations() ran 1.5s after init but never called applyFilter(), so trips rendered before confirmations loaded never showed pending badges. Added re-render after load.

4. respondConf() removed the confirmation from local state entirely. Now marks it confirmed/rejected so it stays available for trip card display until next page load.

5. At check-in, crewNames only got helm/student flags for guests. Non-guest crew relied entirely on confirmation flow. Now writes flags for all crew so the skipper's trip record always has the data for display regardless of confirmation state.

https://claude.ai/code/session_01Dsh8M8HqkwHWyb3MdB8Qqo