### PR TITLE
Fix helm status redundancy in trip cards and restore guest modal in l…

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -233,6 +233,25 @@
   </div>
 </div>
 
+<!-- ══ GUEST MODAL (launch crew) ══ -->
+<div class="modal-overlay hidden" id="launchGuestModal" style="z-index:700" onclick="if(event.target===this)closeLaunchGuestModal()">
+  <div style="background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:20px;width:90%;max-width:360px;margin:auto">
+    <div class="flex-between mb-14">
+      <div class="text-md text-brass fw-500" style="letter-spacing:.5px">Add guest</div>
+      <button class="modal-close-x" onclick="closeLaunchGuestModal()">&times;</button>
+    </div>
+    <div class="text-sm text-muted mb-12">This person is not in the member list. Enter their details to add them as a guest.</div>
+    <div class="form-field"><label>Name</label><input type="text" id="launchGuestName" readonly></div>
+    <div class="form-field"><label>Kennitala or birth year</label><input type="text" id="launchGuestKtOrYear" placeholder="e.g. 1234567890 or 1995"></div>
+    <div class="form-field"><label>Phone number</label><input type="text" id="launchGuestPhone" placeholder="e.g. 555-1234"></div>
+    <div id="launchGuestErr" class="text-sm text-red mb-6" style="display:none"></div>
+    <div class="flex-center gap-8" style="justify-content:flex-end">
+      <button class="btn-secondary" style="width:auto;padding:6px 14px" onclick="closeLaunchGuestModal()">Cancel</button>
+      <button class="btn-primary" style="width:auto;padding:6px 14px" onclick="confirmLaunchGuest()">Add guest</button>
+    </div>
+  </div>
+</div>
+
 <script>
 // ══ STATE ════════════════════════════════════════════════════════════════════
 const user = requireAuth();
@@ -658,7 +677,48 @@ function searchCrewMembers(inp,drop) {
     });
     drop.appendChild(item);
   });
+  // Add "add as guest" option when typed name has 3+ chars
+  if(q.length>=3){
+    const guest=document.createElement('div');
+    guest.style.cssText='padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border);color:var(--brass)';
+    guest.textContent=s('logbook.addAsGuest',{name:inp.value.trim()});
+    guest.addEventListener('mousedown',function(e){
+      e.preventDefault(); drop.style.display='none';
+      window._launchGuestCallback=function(g){ inp.value=g.name; inp.dataset.kennitala=g.kennitala||g.id||''; inp.dataset.guest='1'; };
+      openLaunchGuestModal(inp.value.trim());
+    });
+    drop.appendChild(guest);
+  }
   drop.style.display='block';
+}
+
+// ── Guest modal (launch flow) ────────────────────────────────────────────────
+function openLaunchGuestModal(name){
+  document.getElementById('launchGuestName').value=name;
+  document.getElementById('launchGuestKtOrYear').value='';
+  document.getElementById('launchGuestPhone').value='';
+  document.getElementById('launchGuestErr').style.display='none';
+  document.getElementById('launchGuestModal').classList.remove('hidden');
+}
+function closeLaunchGuestModal(){
+  document.getElementById('launchGuestModal').classList.add('hidden');
+  window._launchGuestCallback=null;
+}
+async function confirmLaunchGuest(){
+  const name=document.getElementById('launchGuestName').value.trim();
+  const ktOrYear=document.getElementById('launchGuestKtOrYear').value.trim();
+  const phone=document.getElementById('launchGuestPhone').value.trim();
+  const err=document.getElementById('launchGuestErr');
+  if(!ktOrYear&&!phone){err.textContent=s('logbook.errKtOrPhone');err.style.display='';return;}
+  err.style.display='none';
+  const isYear=/^\d{4}$/.test(ktOrYear);
+  try{
+    const res=await apiPost('saveMember',{name,kennitala:isYear?'':ktOrYear,birthYear:isYear?ktOrYear:'',phone,role:'guest',active:true});
+    const guest={id:res.id,name,kennitala:isYear?'':ktOrYear,birthYear:isYear?ktOrYear:'',phone,role:'guest',active:true};
+    if(window._launchMembers) window._launchMembers.push(guest);
+    closeLaunchGuestModal();
+    if(window._launchGuestCallback) window._launchGuestCallback(guest);
+  }catch(e){err.textContent=e.message;err.style.display='';}
 }
 
 // Submit — reads stashed form values so they survive the step-3 checklist transition.

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -159,15 +159,17 @@ function tripCard(t){
     return _storedCrewNames.find(cn => cn.kennitala && String(cn.kennitala) === String(kt));
   }
 
-  // Helper: build badges string for a person
-  function _personBadges(opts) {
-    let b = '';
-    if (opts.skipper) b += skipperBadge;
-    if (opts.helm)    b += helmBadge;
-    if (opts.student) b += studentBadge;
-    if (opts.guest)   b += guestBadge;
-    if (opts.pending) b += ' ' + pendingTag;
-    return b;
+  // Helper: build formatted name + badges for a person in the expanded card crew list
+  function _personEntry(name, opts) {
+    let suffix = '';
+    if (opts.skipper) suffix += ' <span style="font-size:10px;color:var(--muted)">(skipper)</span>';
+    if (opts.student) suffix += studentBadge;
+    if (opts.guest)   suffix += guestBadge;
+    if (opts.pending) suffix += ' ' + pendingTag;
+    if (opts.helm) {
+      return '<span class="text-brass">⎈ ' + name + '</span>' + suffix;
+    }
+    return name + suffix;
   }
   function _memberIsGuest(kt) {
     if (!kt) return false;
@@ -179,7 +181,7 @@ function tripCard(t){
   const _ownerCn = _crewNameEntry(t.kennitala);
   const ownerIsStudent = (t.student && t.student!=='false') || !!(_ownerCn?.student) || studentConfs.some(c=>String(c.toKennitala)===String(t.kennitala)) || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)));
   const ownerIsHelm = isHelm || !!(_ownerCn?.helm) || confirmedHelmConfs.some(c=>String(c.toKennitala)===String(t.kennitala));
-  const ownerEntry = esc(t.memberName||'?') + _personBadges({
+  const ownerEntry = _personEntry(esc(t.memberName||'?'), {
     skipper: isSki,
     helm: ownerIsHelm,
     student: ownerIsStudent,
@@ -188,7 +190,7 @@ function tripCard(t){
 
   // 2. Linked skipper (when current trip is a crew trip)
   const _skipCn = linkedSkipper ? _crewNameEntry(linkedSkipper.kennitala) : null;
-  const skipperEntry = linkedSkipper ? esc(linkedSkipper.memberName||'?') + _personBadges({
+  const skipperEntry = linkedSkipper ? _personEntry(esc(linkedSkipper.memberName||'?'), {
     skipper: true,
     helm: (linkedSkipper.helm && linkedSkipper.helm!=='false') || !!(_skipCn?.helm),
     student: false,
@@ -200,7 +202,7 @@ function tripCard(t){
     const cn = _crewNameEntry(x.kennitala);
     const xHelm = (x.helm && x.helm!=='false') || !!(cn?.helm) || confirmedHelmConfs.some(c=>String(c.toKennitala)===String(x.kennitala));
     const xStudent = (x.student && x.student!=='false') || !!(cn?.student) || studentConfs.some(c=>String(c.toKennitala)===String(x.kennitala));
-    return esc(x.memberName||x.crewMemberName||'?') + _personBadges({
+    return _personEntry(esc(x.memberName||x.crewMemberName||'?'), {
       helm: xHelm, student: xStudent, guest: _memberIsGuest(x.kennitala),
     });
   });
@@ -210,7 +212,7 @@ function tripCard(t){
     const cnMember = cn.kennitala ? allMembers.find(m=>String(m.kennitala)===String(cn.kennitala)) : null;
     const isGuest = cn.guest || (cnMember ? cnMember.role==='guest' : !cn.kennitala);
     const isStudent = !!cn.student || studentConfs.some(c=>String(c.toKennitala)===String(cn.kennitala));
-    return esc(cn.name) + _personBadges({
+    return _personEntry(esc(cn.name), {
       helm: !!cn.helm, student: isStudent, guest: isGuest,
     });
   });
@@ -218,10 +220,10 @@ function tripCard(t){
   // 5. Pending crew (awaiting handshake)
   const pendingEntries = pendingCrewConfs.map(c => {
     const cn = _crewNameEntry(c.toKennitala);
-    return esc(c.toName||'?') + _personBadges({ guest: _memberIsGuest(c.toKennitala), student: !!(cn?.student), pending: true });
+    return _personEntry(esc(c.toName||'?'), { guest: _memberIsGuest(c.toKennitala), student: !!(cn?.student), pending: true });
   }).concat(pendingCrewIn.map(c => {
     const cn = _crewNameEntry(c.fromKennitala);
-    return esc(c.fromName||'?') + _personBadges({ guest: _memberIsGuest(c.fromKennitala), student: !!(cn?.student), pending: true });
+    return _personEntry(esc(c.fromName||'?'), { guest: _memberIsGuest(c.fromKennitala), student: !!(cn?.student), pending: true });
   }));
 
   // Assemble: owner first, then skipper (if crew view), then crew, then pending
@@ -229,67 +231,40 @@ function tripCard(t){
   if (skipperEntry) allAboard.push(skipperEntry);
   allAboard.push(...linkedCrewEntries, ...unlinkedEntries, ...pendingEntries);
   const aboardCount = Math.max(allAboard.length, parseInt(t.crew||1));
-  const crewCountRow = `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${s('tc.crewAboard')}</span><span class="trip-exp-val">${aboardCount} — ${allAboard.join(', ')}</span></div>`;
+  const crewCountRow = `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${s('tc.crewAboard')} <span style="text-transform:none;letter-spacing:0;font-style:italic">(⎈ = ${s('tc.helm').toLowerCase()})</span></span><span class="trip-exp-val">${aboardCount} — ${allAboard.join(', ')}</span></div>`;
   const crewNamesRow = '';
 
-  // Helm assignment row — read-only display showing who was at the helm
+  // Collect helm plain names for compact card badge (no separate helm section in expanded card)
   const isOwner = String(t.kennitala) === String(user.kennitala);
   const isLinked = !!(t.linkedCheckoutId || t.linkedTripId || t.isLinked);
-  const showHelmSection = aboardCount > 1;
-  let helmRow = '';
   const helmPlainNames = [];
-  if (showHelmSection) {
-    // Collect confirmed helm from: trip records + crewNames fallback
+  const helmRow = '';
+  if (aboardCount > 1) {
     const _helmKts = new Set();
-    const helmEntries = [];
     if (ownerIsHelm) {
       _helmKts.add(String(t.kennitala));
-      helmEntries.push(esc(t.memberName||'') + (_memberIsGuest(t.kennitala) ? guestBadge : ''));
       helmPlainNames.push(t.memberName||'?');
     }
     linkedCrew.forEach(x => {
       const cn = _crewNameEntry(x.kennitala);
       if ((x.helm && x.helm!=='false') || cn?.helm) {
         _helmKts.add(String(x.kennitala));
-        helmEntries.push(esc(x.memberName||x.crewMemberName||'?') + (_memberIsGuest(x.kennitala) ? guestBadge : ''));
         helmPlainNames.push(x.memberName||x.crewMemberName||'?');
       }
     });
-    // Helm from crewNames (guests or anyone not yet in helmEntries)
     _storedCrewNames.forEach(cn => {
       if (!cn.helm || !cn.name) return;
       const kt = cn.kennitala ? String(cn.kennitala) : cn.name;
       if (_helmKts.has(kt)) return;
       _helmKts.add(kt);
-      const isGuest = cn.guest || !cn.kennitala || _memberIsGuest(cn.kennitala);
-      helmEntries.push(esc(cn.name) + (isGuest ? guestBadge : ''));
       helmPlainNames.push(cn.name);
     });
-    // Confirmed helm from handshake confirmations (fallback when trip record not yet refreshed)
     confirmedHelmConfs.forEach(c => {
       const kt = String(c.toKennitala || c.fromKennitala || '');
       if (!kt || _helmKts.has(kt)) return;
       _helmKts.add(kt);
-      const name = c.toName || c.fromName || '?';
-      helmEntries.push(esc(name) + (_memberIsGuest(kt) ? guestBadge : ''));
-      helmPlainNames.push(name);
+      helmPlainNames.push(c.toName || c.fromName || '?');
     });
-    // Pending helm confirmations
-    const pendingHelmEntries = pendingHelmConfs.map(c => {
-      return esc(c.toName||'?') + (_memberIsGuest(c.toKennitala) ? guestBadge : '');
-    }).concat(pendingHelmIn.map(c => {
-      return esc(c.fromName||'?') + (_memberIsGuest(c.fromKennitala) ? guestBadge : '');
-    }));
-    if (helmEntries.length || pendingHelmEntries.length) {
-      const confirmedPills = helmEntries.map(n =>
-        `<span class="text-sm text-brass flex-center gap-4" style="display:inline-flex;border:1px solid var(--brass)55;border-radius:12px;padding:2px 8px;background:var(--brass)08"><span class="text-xs">⎈</span> ${n}</span>`
-      );
-      const pendingPills = pendingHelmEntries.map(n =>
-        `<span class="text-sm flex-center gap-4" style="display:inline-flex;color:var(--yellow);border:1px solid var(--yellow)55;border-radius:12px;padding:2px 8px;background:var(--yellow)08"><span class="text-xs">⎈</span> ${n} <span style="font-size:9px;opacity:.8">${s('tc.pending')}</span></span>`
-      );
-      const allPills = confirmedPills.concat(pendingPills).join(' ');
-      helmRow = `<div class="trip-exp-row trip-exp-full"><span class="trip-exp-lbl">${s('tc.atTheHelm')}</span><span class="trip-exp-val"><div class="flex-center flex-wrap gap-4">${allPills}</div></span></div>`;
-    }
   }
 
   // Vessel/boat detail rows from boats config


### PR DESCRIPTION
…aunch flow

- Expanded card: replace helm/skipper badges in "Crew aboard" with inline styling (⎈ wheel emoji + brass text for helm, (skipper) parenthetical)
- Add legend parenthetical to "Crew aboard" label explaining ⎈ = helm
- Remove redundant "At the helm" section from expanded card
- Retain helm badge in compact card
- Restore "Add as guest" option in member launch crew search dropdown with guest registration modal (name, kennitala/birth year, phone)

https://claude.ai/code/session_01VfaHc8JvH87kDbMWAcYjmw