### PR TITLE
Save skipper helm status and crewNames on manual trip log

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -365,6 +365,10 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
       </div>
       <!-- Crew member inputs: shown when crew > 1 -->
       <div id="mCrewSection" class="mb-12" style="display:none">
+        <label class="check-label" style="margin-bottom:8px">
+          <input type="checkbox" id="mHelmSelf" class="accent-checkbox">
+          <span style="font-size:11px">I was at the helm</span>
+        </label>
         <label style="font-size:9px;letter-spacing:.8px">Crew members <span style="font-weight:400;opacity:.6">(search by name)</span></label>
         <div id="mCrewInputs"></div>
         <div class="text-xs text-muted" style="margin-top:4px">Named crew get this trip logged in their logbook automatically.</div>

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1170,6 +1170,16 @@ async function submitManual(){
   btn.disabled=false; btn.textContent=s('logbook.saveToLogbook');
 
   try{
+    // Build crewNames JSON from crew inputs
+    const crewInputs = Array.from(document.querySelectorAll('#mCrewInputs .manual-crew-row'));
+    const _crewNamesArr = crewInputs.map(row => {
+      const inp = row.querySelector('input[type="text"]');
+      const cbs = row.querySelectorAll('input[type="checkbox"]');
+      const nm = inp?.value.trim();
+      if (!nm) return null;
+      return { name: nm, kennitala: inp?.dataset.kennitala||'', helm: cbs[0]?.checked||false, student: cbs[1]?.checked||false, guest: !!(inp?.dataset.guest) };
+    }).filter(Boolean);
+    const helmSelf = !!(document.getElementById('mHelmSelf')?.checked);
     const tripBase = {
       date, boatId, boatName, boatCategory,
       locationId:locId, locationName:locName,
@@ -1180,13 +1190,14 @@ async function submitManual(){
       photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
       photoMeta: Object.keys(photoMeta).length ? JSON.stringify(photoMeta) : '',
       nonClub: isNonClub||false,
+      helm: helmSelf,
+      crewNames: _crewNamesArr.length ? JSON.stringify(_crewNamesArr) : '',
     };
     const res=await apiPost('saveTrip', tripBase);
     const savedTrip = Object.assign({id:res.id, kennitala:user.kennitala}, tripBase);
     myTrips.unshift(savedTrip);
 
     // Save linked crew trips for named crew members
-    const crewInputs = Array.from(document.querySelectorAll('#mCrewInputs .manual-crew-row'));
     const linkedId = res.id; // use the skipper trip id as the link
     for(const row of crewInputs){
       const inp = row.querySelector('input[type="text"]');


### PR DESCRIPTION
Two root causes fixed:

1) Skipper helm not showing: the manual logbook save (tripBase) never
   included a 'helm' field. Added "I was at the helm" checkbox to the
   form and include helm:true/false in the saved trip record.

2) Guest names not appearing in trip cards: the manual logbook save
   never included crewNames JSON on the skipper's trip. The card
   rendering falls back to crewNames when linked trips aren't in
   allTrips (which only contains the current user's trips — guest
   trips with empty/different kennitala are never fetched). Now
   crewNames is built from crew inputs and saved on the skipper's
   trip, matching what the launch→return flow already does.

https://claude.ai/code/session_01VfaHc8JvH87kDbMWAcYjmw