### PR TITLE
Fix guest status not being set on crew inputs in logbook

### DIFF
--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -820,6 +820,7 @@ function searchManualMember(inp, dropOrId){
       e.preventDefault();
       inp.value=m.name;
       inp.dataset.kennitala=m.kennitala||'';
+      inp.dataset.guest=m.role==='guest'?'1':'';
       drop.style.display='none';
     });
     drop.appendChild(item);
@@ -831,7 +832,7 @@ function searchManualMember(inp, dropOrId){
     guest.addEventListener('mousedown',function(e){
       e.preventDefault();
       drop.style.display='none';
-      _lgGuestCallback=function(g){ inp.value=g.name; inp.dataset.kennitala=g.kennitala||g.id||''; };
+      _lgGuestCallback=function(g){ inp.value=g.name; inp.dataset.kennitala=g.kennitala||g.id||''; inp.dataset.guest='1'; };
       openLgGuestModal(inp.value.trim());
     });
     drop.appendChild(guest);


### PR DESCRIPTION
The logbook crew dropdown and guest modal callback were not setting inp.dataset.guest, so guest status was always read as false on submit. The member page already did this correctly.

https://claude.ai/code/session_014qD8gfBmf5e7sRm2X41LrN