### PR TITLE
Show active share tokens without requiring button click

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -204,8 +204,8 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
         </label>
       </div>
       <button class="btn-primary text-sm" style="width:auto;padding:7px 16px" onclick="generateAndCopyShareLink()" data-s="logbook.shareCopy"></button>
-      <div id="shareActiveTokens" class="mt-8"></div>
     </div>
+    <div id="shareActiveTokens" style="width:100%"></div>
   </div>
 
   <!-- Credentials -->

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1459,7 +1459,7 @@ async function deleteTripPhoto(tripId, photoUrl) {
 // ── Share tokens ─────────────────────────────────────────────────────────────
 function toggleSharePanel(){
   var p=document.getElementById('sharePanel');
-  if(p.style.display==='none'){p.style.display='';renderShareCatChecks();loadShareTokens();}
+  if(p.style.display==='none'){p.style.display='';renderShareCatChecks();}
   else p.style.display='none';
 }
 function renderShareCatChecks(){
@@ -1484,14 +1484,14 @@ function renderShareTokens(tokens){
   var el=document.getElementById('shareActiveTokens');if(!el)return;
   var active=tokens.filter(function(t){return!t.revokedAt||!String(t.revokedAt).trim();});
   if(!active.length){el.innerHTML='';return;}
-  el.innerHTML=active.map(function(tk){
+  el.innerHTML='<div style="border-top:1px solid var(--border);margin-top:8px;padding-top:8px">'+active.map(function(tk){
     return '<div class="flex-center gap-8 text-sm" style="margin-top:6px">'
       +'<span class="text-green">●</span>'
       +'<span class="flex-1 text-muted">'+s('logbook.upTo')+' '+esc(tk.cutOffDate||'')+' · '+(tk.accessCount||0)+' '+s('logbook.views')+'</span>'
       +'<button class="btn-ghost-sm" style="font-size:10px;padding:2px 8px" onclick="copyShareLink(\''+tk.id+'\')">'+s('logbook.copy')+'</button>'
       +'<button class="btn-ghost-sm" style="font-size:10px;padding:2px 8px;color:var(--red)" onclick="revokeShareToken(\''+tk.id+'\')">'+s('logbook.revoke')+'</button>'
       +'</div>';
-  }).join('');
+  }).join('')+'</div>';
 }
 async function generateAndCopyShareLink(){
   try{
@@ -1565,6 +1565,7 @@ async function reload(){
     buildFilters();
     applyFilter();
     renderCerts();
+    loadShareTokens();
     warmContainer();
   }catch(e){
     document.getElementById('tripList').innerHTML=


### PR DESCRIPTION
Move share tokens display outside the collapsible share panel so active tokens (with copy/revoke actions) are always visible below the share/log/pending buttons. Tokens now load on page init.

Closes #142

https://claude.ai/code/session_01PBNbJqLzKsqH41CnFZZSXr