### PR TITLE
Add 'Active share tokens' label above token list

### DIFF
--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1484,7 +1484,9 @@ function renderShareTokens(tokens){
   var el=document.getElementById('shareActiveTokens');if(!el)return;
   var active=tokens.filter(function(t){return!t.revokedAt||!String(t.revokedAt).trim();});
   if(!active.length){el.innerHTML='';return;}
-  el.innerHTML='<div style="border-top:1px solid var(--border);margin-top:8px;padding-top:8px">'+active.map(function(tk){
+  el.innerHTML='<div style="border-top:1px solid var(--border);margin-top:8px;padding-top:8px">'
+    +'<div class="text-sm text-muted" style="font-weight:600;margin-bottom:4px">'+s('logbook.activeTokens')+'</div>'
+    +active.map(function(tk){
     return '<div class="flex-center gap-8 text-sm" style="margin-top:6px">'
       +'<span class="text-green">●</span>'
       +'<span class="flex-1 text-muted">'+s('logbook.upTo')+' '+esc(tk.cutOffDate||'')+' · '+(tk.accessCount||0)+' '+s('logbook.views')+'</span>'

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -205,6 +205,7 @@ var _STRINGS_FLAT = {
   "logbook.shareTracks": "Include GPS tracks",
   "logbook.shareCopy": "Generate & copy link",
   "logbook.shareCopied": "Link copied!",
+  "logbook.activeTokens": "Active share tokens",
   "logbook.editTrip": "Edit trip",
   "logbook.addGps": "Add GPS",
   "logbook.addPhotos": "Add photos",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -205,6 +205,7 @@ var _STRINGS_FLAT = {
   "logbook.shareTracks": "Taka GPS-leiðir með",
   "logbook.shareCopy": "Búa til og afrita hlekk",
   "logbook.shareCopied": "Hlekkur afritaður!",
+  "logbook.activeTokens": "Virk deilingartóken",
   "logbook.editTrip": "Breyta ferð",
   "logbook.addGps": "Bæta við GPS",
   "logbook.addPhotos": "Bæta við myndum",


### PR DESCRIPTION
Adds localized label (EN/IS) displayed as a heading above the always-visible share tokens section.

https://claude.ai/code/session_01PBNbJqLzKsqH41CnFZZSXr