### PR TITLE
Improve launch-a-boat modal: 3-column grid, correct emojis, reorder n…

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -213,7 +213,7 @@
 
 <!-- ══ LAUNCH MODAL ══ -->
 <div class="modal-overlay hidden" id="launchModal" onclick="if(event.target===this)closeModal('launchModal')">
-  <div class="modal" style="max-width:480px;max-height:92vh;overflow-y:auto">
+  <div class="modal" style="max-width:640px;max-height:92vh;overflow-y:auto">
     <div class="modal-header">
       <h3 id="launchModalTitle"></h3>
       <button class="modal-close-x" onclick="closeModal('launchModal')">×</button>
@@ -397,18 +397,20 @@ function renderLaunchPicker(preselectedBoatId) {
   const grouped={};
   avail.forEach(b=>{const cat=(b.category||'other').toLowerCase();if(!grouped[cat])grouped[cat]=[];grouped[cat].push(b);});
   document.getElementById('launchModalBody').innerHTML=
+    Object.entries(grouped).sort(([a],[b])=>a.localeCompare(b)).map(([cat,catBoats])=>
+      `<div class="mb-12">
+        <div class="section-label">${_fmtCatLabel(cat)}</div>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px">
+        ${catBoats.map(b=>`<button class="btn btn-secondary mb-6" style="width:100%;text-align:left"
+          onclick="renderLaunchForm(boats.find(x=>x.id==='${b.id}'))">${boatEmoji(cat)} ${esc(b.name)}</button>`).join('')}
+        </div>
+      </div>`).join('')+
     '<div class="mb-12">'+
       '<button class="btn btn-secondary mb-6" style="width:100%;text-align:left" onclick="renderNonClubLaunchForm()">'+
         '🚣 '+s('member.nonClubBoat')+
         ' <span class="text-muted" style="font-size:9px;font-weight:400;margin-left:4px">'+s('member.nonClubHint')+'</span>'+
       '</button>'+
-    '</div>'+
-    Object.entries(grouped).sort(([a],[b])=>a.localeCompare(b)).map(([cat,catBoats])=>
-      `<div class="mb-12">
-        <div class="section-label">${_fmtCatLabel(cat)}</div>
-        ${catBoats.map(b=>`<button class="btn btn-secondary mb-6" style="width:100%;text-align:left"
-          onclick="renderLaunchForm(boats.find(x=>x.id==='${b.id}'))">⛵ ${esc(b.name)}</button>`).join('')}
-      </div>`).join('');
+    '</div>';
 }
 
 // ── Checklists — config wins per-category; defaults fill missing categories ──


### PR DESCRIPTION
…on-club option

- Use 3-column CSS grid layout for boat buttons within each category
- Replace hardcoded ⛵ emoji with category-specific emojis via boatEmoji()
- Move non-club boat option to the bottom of the picker list
- Widen modal from 480px to 640px to accommodate the grid layout

Closes #365

https://claude.ai/code/session_01NBc1iUoJH2gMuVZ7Qaqy3a