### PR TITLE
Increase spacing between weather and tide widgets to 24px

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -153,12 +153,12 @@
   </div>
 
   <!-- ══ WEATHER WIDGET ══ -->
-  <div class="wx-widget mb-16" id="wxWidget">
+  <div class="wx-widget" style="margin-bottom:24px" id="wxWidget">
     <div class="text-muted text-sm" style="padding:6px 0" data-s="wx.loading"></div>
   </div>
 
   <!-- ══ TIDE WIDGET ══ -->
-  <div id="tideWidget" class="mb-16"></div>
+  <div id="tideWidget" style="margin-bottom:24px"></div>
 
     <!-- ══ QUICK ACTION STRIP ══ -->
   <div class="member-actions">

--- a/staff/index.html
+++ b/staff/index.html
@@ -281,14 +281,14 @@ border-bottom:1px solid var(--border)44; }
   </div>
 
   <!-- ══ WEATHER WIDGET ══ -->
-  <div class="wx-widget mb-16" id="wxWidget">
+  <div class="wx-widget" style="margin-bottom:24px" id="wxWidget">
     <div class="text-muted text-sm" style="padding:6px 0" data-s="lbl.loading"></div>
   </div>
 
   <!-- ══ STAFF STATUS ══ -->
 
     <!-- ══ TIDES ══ -->
-  <div id="tideWidget" class="mb-16"></div>
+  <div id="tideWidget" style="margin-bottom:24px"></div>
 
   <div id="staffStatusStrip" class="mb-12">
     <div class="section-label mb-8">DUTY STATUS</div>


### PR DESCRIPTION
The mb-16 (16px) utility class wasn't enough visual separation. Switched to inline margin-bottom:24px on both pages.

https://claude.ai/code/session_01QgBX7fz4BEWhc3np2iSG5x