### PR TITLE
Add captain profiles with trips, heatmap to public dashboard

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -6,7 +6,6 @@
 <title>Ýmir — Captain's Quarters</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com">
-<link rel="preconnect" href="https://unpkg.com">
 <link rel="stylesheet" href="../shared/style.css">
 <link rel="stylesheet" href="../shared/tripcard.css">
 <script src="../shared/api.js"></script>
@@ -84,24 +83,6 @@
 .filter-bar .filter-search-row input { flex:1; min-width:0; }
 .filter-count { font-size:10px; color:var(--muted); white-space:nowrap; }
 
-/* ── Member heatmap ── */
-.cq-heatmap{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:12px;overflow:hidden}
-.cq-heatmap-header{display:flex;align-items:center;justify-content:space-between;padding:10px 14px 0}
-.cq-heatmap-title{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase}
-.cq-heatmap-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden}
-.cq-heatmap-toggle button{background:var(--surface);border:none;color:var(--muted);font-family:inherit;font-size:10px;padding:4px 10px;cursor:pointer;transition:background .15s,color .15s;border-right:1px solid var(--border)}
-.cq-heatmap-toggle button:last-child{border-right:none}
-.cq-heatmap-toggle button.active{background:var(--brass);color:#000;font-weight:500}
-#cqHeatmap{height:260px;border-radius:0 0 8px 8px}
-
-/* ── Compact trip rows ── */
-.cq-trip-row{display:flex;align-items:center;gap:10px;padding:8px 12px;border-bottom:1px solid var(--border);font-size:12px}
-.cq-trip-row:last-child{border-bottom:none}
-.cq-trip-date{font-size:11px;color:var(--muted);min-width:70px}
-.cq-trip-boat{font-weight:500;min-width:80px}
-.cq-trip-loc{color:var(--muted);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.cq-trip-stats{font-size:11px;color:var(--brass);white-space:nowrap}
-
 /* ── Bio section ── */
 .cq-bio-area { width:100%; min-height:80px; background:var(--surface); border:1px solid var(--border);
   border-radius:8px; color:var(--text); font-family:inherit; font-size:12px; padding:10px 12px;
@@ -173,30 +154,6 @@
         <a id="publicProfileLink" href="#" target="_blank" style="font-size:11px;color:var(--brass);text-decoration:none" data-s="cq.viewPublicProfile"></a>
         <button class="btn btn-primary" style="font-size:11px;padding:6px 14px" onclick="saveBio()" data-s="btn.save"></button>
       </div>
-    </div>
-  </div>
-
-  <!-- ══ MY KEELBOAT TRIPS (compact) ══ -->
-  <div class="cq-section" id="sectMyTrips">
-    <div class="cq-section-hdr">MY KEELBOAT TRIPS <span class="badge" id="myTripsCount" style="background:var(--brass)22;color:var(--brass)"></span></div>
-    <div class="cq-card" style="padding:0;overflow:hidden">
-      <div id="myTripList"><div class="empty-note" data-s="lbl.loading"></div></div>
-    </div>
-    <button class="cq-show-more" id="myTripsShowMore" style="display:none" onclick="showMoreMyTrips()">Show more…</button>
-  </div>
-
-  <!-- ══ PERSONAL HEATMAP ══ -->
-  <div class="cq-section" id="sectHeatmap" style="display:none">
-    <div class="cq-heatmap">
-      <div class="cq-heatmap-header">
-        <span class="cq-heatmap-title">Heatmap</span>
-        <div class="cq-heatmap-toggle">
-          <button class="active" data-mode="trips" onclick="setCqHeatMode('trips')">Trips</button>
-          <button data-mode="time" onclick="setCqHeatMode('time')">Time</button>
-          <button data-mode="tracks" onclick="setCqHeatMode('tracks')">GPS tracks</button>
-        </div>
-      </div>
-      <div id="cqHeatmap"></div>
     </div>
   </div>
 
@@ -472,8 +429,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     allLocs    = _locations;
 
     renderStats();
-    renderMyTrips();
-    initCqHeatmap();
     buildMaintBoatFilter();
     renderMaint();
     renderValidation();
@@ -499,167 +454,6 @@ function renderStats() {
   document.getElementById('statTrips').textContent = ytd.length;
   document.getElementById('statHours').textContent = hours.toFixed(1);
   document.getElementById('statDist').textContent  = dist.toFixed(1) + ' ' + s('cq.nm');
-}
-
-// ══ MY KEELBOAT TRIPS (compact single-line) ═════════════════════════════
-var _myTripsShown = 10;
-function renderMyTrips() {
-  var el = document.getElementById('myTripList');
-  var trips = _myKeelboatTrips.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
-  document.getElementById('myTripsCount').textContent = trips.length;
-  if (!trips.length) { el.innerHTML = '<div class="empty-note">' + s('cq.noTripsMatch') + '</div>'; return; }
-  var shown = trips.slice(0, _myTripsShown);
-  el.innerHTML = shown.map(function(t) {
-    var dur = t.hoursDecimal ? (parseFloat(t.hoursDecimal)||0).toFixed(1)+'h' : '';
-    var dist = t.distanceNm ? (parseFloat(t.distanceNm)||0).toFixed(1)+' nm' : '';
-    var loc = t.locationName || t.departurePort || '';
-    var stats = [dur, dist].filter(Boolean).join(' · ');
-    return '<div class="cq-trip-row">'
-      + '<span class="cq-trip-date">' + esc((t.date||'').slice(0,10)) + '</span>'
-      + '<span class="cq-trip-boat">' + esc(t.boatName||'') + '</span>'
-      + '<span class="cq-trip-loc">' + esc(loc) + '</span>'
-      + '<span class="cq-trip-stats">' + esc(stats) + '</span>'
-      + '</div>';
-  }).join('');
-  document.getElementById('myTripsShowMore').style.display = trips.length > _myTripsShown ? '' : 'none';
-}
-function showMoreMyTrips() {
-  _myTripsShown += 20;
-  renderMyTrips();
-}
-
-// ══ CAPTAIN HEATMAP ═════════════════════════════════════════════════════
-var _cqHmMap = null, _cqHmHeatLayer = null, _cqHmMarkers = [], _cqHmTrackLines = [];
-var _cqHmMode = 'trips';
-
-function buildCqLocStats() {
-  var stats = {};
-  _myKeelboatTrips.forEach(function(t) {
-    var lid = t.locationId || '';
-    if (!lid) return;
-    if (!stats[lid]) stats[lid] = { count: 0, hours: 0 };
-    stats[lid].count++;
-    stats[lid].hours += parseFloat(t.hoursDecimal) || 0;
-  });
-  var result = [];
-  Object.keys(stats).forEach(function(lid) {
-    var loc = allLocs.find(function(l) { return l.id === lid; });
-    if (!loc || !loc.coordinates) return;
-    var parts = String(loc.coordinates).split(',');
-    if (parts.length < 2) return;
-    var lat = parseFloat(parts[0]), lng = parseFloat(parts[1]);
-    if (isNaN(lat) || isNaN(lng)) return;
-    result.push({ id: lid, name: loc.name || lid, lat: lat, lng: lng, tripCount: stats[lid].count, totalHours: Math.round(stats[lid].hours * 10) / 10 });
-  });
-  return result;
-}
-
-function getCqTrackLines() {
-  var lines = [];
-  _myKeelboatTrips.forEach(function(t) {
-    if (!t.trackSimplified) return;
-    try {
-      var pts = JSON.parse(t.trackSimplified);
-      if (Array.isArray(pts) && pts.length >= 2) {
-        lines.push(pts.filter(function(p) { return typeof p.lat === 'number' && typeof p.lng === 'number'; }));
-      }
-    } catch(e) {}
-  });
-  return lines;
-}
-
-function getCqAllTrackPoints() {
-  var allPts = [];
-  _myKeelboatTrips.forEach(function(t) {
-    if (!t.trackSimplified) return;
-    try {
-      var pts = JSON.parse(t.trackSimplified);
-      if (Array.isArray(pts)) pts.forEach(function(p) {
-        if (typeof p.lat === 'number' && typeof p.lng === 'number') allPts.push(p);
-      });
-    } catch(e) {}
-  });
-  return allPts;
-}
-
-async function initCqHeatmap() {
-  var locData = buildCqLocStats();
-  var trackPts = getCqAllTrackPoints();
-  if (!locData.length && !trackPts.length) return;
-
-  document.getElementById('sectHeatmap').style.display = '';
-
-  await loadLeaflet();
-  if (_cqHmMap) { _cqHmMap.remove(); _cqHmMap = null; }
-  _cqHmMap = L.map('cqHeatmap', { zoomControl: true, attributionControl: true, scrollWheelZoom: false, zoomSnap: 0.25, zoomDelta: 0.25 });
-  addSeaLayers(_cqHmMap);
-
-  renderCqHeatMode();
-}
-
-function clearCqHeatLayers() {
-  if (_cqHmHeatLayer) { _cqHmMap.removeLayer(_cqHmHeatLayer); _cqHmHeatLayer = null; }
-  _cqHmMarkers.forEach(function(m) { _cqHmMap.removeLayer(m); });
-  _cqHmMarkers = [];
-  _cqHmTrackLines.forEach(function(l) { _cqHmMap.removeLayer(l); });
-  _cqHmTrackLines = [];
-}
-
-function renderCqHeatMode() {
-  if (!_cqHmMap) return;
-  clearCqHeatLayers();
-  if (_cqHmMode === 'tracks') { renderCqTrackMode(); } else { renderCqLocationMode(); }
-}
-
-function renderCqLocationMode() {
-  var locData = buildCqLocStats();
-  if (!locData.length) { _cqHmMap.setView([64.148, -21.965], 11.25); return; }
-  var isTime = _cqHmMode === 'time';
-  var maxVal = locData.reduce(function(m, l) { return Math.max(m, isTime ? l.totalHours : l.tripCount); }, 1);
-  var heatData = locData.map(function(l) { return [l.lat, l.lng, (isTime ? l.totalHours : l.tripCount) / maxVal]; });
-  _cqHmHeatLayer = L.heatLayer(heatData, {
-    radius: 30, blur: 20, maxZoom: 14, max: 1.0,
-    gradient: { 0.2: '#1e3f6e', 0.4: '#2e86c1', 0.6: '#f1c40f', 0.8: '#e67e22', 1.0: '#e74c3c' }
-  }).addTo(_cqHmMap);
-  locData.forEach(function(l) {
-    var intensity = (isTime ? l.totalHours : l.tripCount) / maxVal;
-    var radius = Math.max(6, Math.min(20, 6 + intensity * 14));
-    var valLabel = isTime ? l.totalHours + 'h' : l.tripCount + (l.tripCount === 1 ? ' trip' : ' trips');
-    var marker = L.circleMarker([l.lat, l.lng], {
-      radius: radius, color: '#d4af37', fillColor: '#d4af37', fillOpacity: 0.3, weight: 1,
-    }).bindTooltip('<strong>' + esc(l.name) + '</strong><br>' + valLabel + ' &middot; ' + l.totalHours + 'h', { className: 'map-tooltip' }).addTo(_cqHmMap);
-    _cqHmMarkers.push(marker);
-  });
-  var bounds = L.latLngBounds(locData.map(function(l) { return [l.lat, l.lng]; }));
-  _cqHmMap.fitBounds(bounds.pad(0.15), { maxZoom: 11 });
-}
-
-function renderCqTrackMode() {
-  var lines = getCqTrackLines();
-  if (!lines.length) { _cqHmMap.setView([64.148, -21.965], 11.25); return; }
-  var allPts = [];
-  lines.forEach(function(pts) {
-    var latlngs = pts.map(function(p) { return [p.lat, p.lng]; });
-    allPts.push.apply(allPts, latlngs);
-    var line = L.polyline(latlngs, { color: '#d4af37', weight: 2, opacity: 0.6 }).addTo(_cqHmMap);
-    _cqHmTrackLines.push(line);
-  });
-  if (allPts.length) {
-    _cqHmHeatLayer = L.heatLayer(allPts.map(function(p) { return [p[0], p[1], 0.5]; }), {
-      radius: 20, blur: 15, maxZoom: 14, max: 1.0,
-      gradient: { 0.2: '#1e3f6e', 0.4: '#2e86c1', 0.6: '#f1c40f', 0.8: '#e67e22', 1.0: '#e74c3c' }
-    }).addTo(_cqHmMap);
-  }
-  var bounds = L.latLngBounds(allPts);
-  _cqHmMap.fitBounds(bounds.pad(0.1), { maxZoom: 11 });
-}
-
-function setCqHeatMode(mode) {
-  _cqHmMode = mode;
-  document.querySelectorAll('.cq-heatmap-toggle button').forEach(function(b) {
-    b.classList.toggle('active', b.dataset.mode === mode);
-  });
-  renderCqHeatMode();
 }
 
 // ══ MAINTENANCE ══════════════════════════════════════════════════════════════

--- a/code.gs
+++ b/code.gs
@@ -4193,12 +4193,59 @@ function publicDashboard_() {
       return { certId: c.certId, sub: c.sub || '', label: label };
     });
 
-    // Captain trip stats
+    // Captain keelboat trips
     var captTrips = allTrips.filter(function(t) {
-      return String(t.kennitala) === String(m.kennitala) && (t.role === 'skipper' || t.role === 'captain');
+      return String(t.kennitala) === String(m.kennitala)
+        && (t.role === 'skipper' || t.role === 'captain');
+    }).sort(function(a, b) { return (b.date || '') > (a.date || '') ? 1 : -1; });
+    var captHours = 0, captDist = 0;
+    captTrips.forEach(function(t) { captHours += Number(t.hoursDecimal) || 0; captDist += Number(t.distanceNm) || 0; });
+
+    // Single-line trip rows for display
+    var tripRows = captTrips.map(function(t) {
+      var boat = boatMap[t.boatId] || {};
+      return {
+        date: t.date || '',
+        boatName: t.boatName || '',
+        makeModel: boat.typeModel || '',
+        location: t.locationName || t.departurePort || '',
+        crew: parseInt(t.crew) || 1,
+        duration: t.hoursDecimal ? Number(t.hoursDecimal).toFixed(1) : '',
+        distance: t.distanceNm ? Number(t.distanceNm).toFixed(1) : '',
+      };
     });
-    var captHours = 0;
-    captTrips.forEach(function(t) { captHours += Number(t.hoursDecimal) || 0; });
+
+    // Per-captain location stats for heatmap
+    var captLocStats = {};
+    captTrips.forEach(function(t) {
+      var lid = t.locationId || '';
+      if (!lid) return;
+      if (!captLocStats[lid]) captLocStats[lid] = { count: 0, hours: 0 };
+      captLocStats[lid].count++;
+      captLocStats[lid].hours += parseFloat(t.hoursDecimal) || 0;
+    });
+    var captLocData = [];
+    Object.keys(captLocStats).forEach(function(lid) {
+      var loc = locMap[lid];
+      if (!loc || !loc.coordinates) return;
+      var parts = String(loc.coordinates).split(',');
+      if (parts.length < 2) return;
+      var lat = parseFloat(parts[0]), lng = parseFloat(parts[1]);
+      if (isNaN(lat) || isNaN(lng)) return;
+      captLocData.push({ name: loc.name || lid, lat: lat, lng: lng, count: captLocStats[lid].count, hours: Math.round(captLocStats[lid].hours * 10) / 10 });
+    });
+
+    // Per-captain GPS track lines
+    var captTrackLines = [];
+    captTrips.forEach(function(t) {
+      if (!t.trackSimplified) return;
+      try {
+        var pts = typeof t.trackSimplified === 'string' ? JSON.parse(t.trackSimplified) : t.trackSimplified;
+        if (Array.isArray(pts) && pts.length >= 2) {
+          captTrackLines.push(pts.filter(function(p) { return typeof p.lat === 'number' && typeof p.lng === 'number'; }));
+        }
+      } catch(e) {}
+    });
 
     captains.push({
       id: m.id,
@@ -4208,7 +4255,11 @@ function publicDashboard_() {
       certs: certLabels,
       tripCount: captTrips.length,
       totalHours: Math.round(captHours * 10) / 10,
+      totalDist: Math.round(captDist * 10) / 10,
       captainRecordUrl: scriptUrl + '?action=captain&id=' + m.id,
+      trips: tripRows,
+      locations: captLocData,
+      trackLines: captTrackLines,
     });
   });
 

--- a/public/index.html
+++ b/public/index.html
@@ -118,18 +118,35 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .future-text p{color:var(--muted);font-size:12px;font-style:italic}
 
 /* ── Captains ───────────────────────────────────────────────────── */
-.captain-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:14px}
-.captain-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:18px 20px;display:flex;flex-direction:column;gap:10px}
-.captain-name{font-size:15px;font-weight:500;color:var(--text)}
-.captain-stats{display:flex;gap:16px;font-size:11px;color:var(--muted)}
+.captain-list{display:flex;flex-direction:column;gap:20px}
+.captain-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:20px;display:flex;flex-direction:column;gap:12px}
+.captain-header{display:flex;align-items:center;gap:16px}
+.captain-headshot{width:72px;height:72px;border-radius:50%;object-fit:cover;border:2px solid var(--brass);flex-shrink:0}
+.captain-headshot-ph{width:72px;height:72px;border-radius:50%;background:var(--surface);border:2px dashed var(--border);display:flex;align-items:center;justify-content:center;font-size:24px;color:var(--muted);flex-shrink:0}
+.captain-name{font-size:16px;font-weight:500;color:var(--text)}
+.captain-stats{display:flex;gap:16px;font-size:11px;color:var(--muted);flex-wrap:wrap}
 .captain-stats span{display:flex;align-items:center;gap:4px}
 .captain-certs{display:flex;flex-wrap:wrap;gap:4px}
 .cert-badge{display:inline-flex;align-items:center;gap:5px;background:var(--surface);border:1px solid var(--border);border-radius:5px;padding:4px 8px;font-size:10px;color:var(--text)}
 .cert-badge::before{content:'\2713';color:var(--green);font-weight:bold;font-size:9px}
-.captain-bio{font-size:11px;color:var(--muted);font-style:italic;line-height:1.5}
+.captain-bio{font-size:12px;color:var(--muted);font-style:italic;line-height:1.5;max-width:600px}
 .captain-link{font-size:11px;color:var(--brass)}
 .captain-placeholder{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:24px;text-align:center}
 .captain-placeholder p{color:var(--muted);font-size:12px;font-style:italic}
+/* ── Captain trip table ── */
+.cap-trip-table{width:100%;border-collapse:collapse;font-size:11px}
+.cap-trip-table th{text-align:left;font-size:9px;text-transform:uppercase;letter-spacing:.6px;color:var(--muted);padding:6px 8px;border-bottom:1px solid var(--border);background:var(--surface)}
+.cap-trip-table td{padding:6px 8px;border-bottom:1px solid var(--border);color:var(--text);white-space:nowrap}
+.cap-trip-table tr:last-child td{border-bottom:none}
+.cap-trip-table td.loc-col{white-space:normal;max-width:140px;overflow:hidden;text-overflow:ellipsis}
+.cap-show-more{width:100%;background:var(--surface);border:1px solid var(--border);border-radius:0 0 8px 8px;padding:6px;font-size:10px;color:var(--muted);cursor:pointer;font-family:inherit;text-align:center}
+.cap-show-more:hover{border-color:var(--brass);color:var(--text)}
+/* ── Captain heatmap ── */
+.cap-heatmap{height:240px;border-radius:8px;border:1px solid var(--border);overflow:hidden;margin-top:8px}
+.cap-hm-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden;margin-bottom:8px}
+.cap-hm-btn{background:var(--surface);border:none;color:var(--muted);font-family:inherit;font-size:10px;padding:4px 10px;cursor:pointer;border-right:1px solid var(--border)}
+.cap-hm-btn:last-child{border-right:none}
+.cap-hm-btn.active{background:var(--brass);color:#000;font-weight:500}
 
 /* ── Loading / error ────────────────────────────────────────────── */
 .loading{text-align:center;padding:60px 20px;color:var(--muted);font-size:13px}
@@ -319,11 +336,96 @@ function renderDashboard(data) {
   html += '</section>';
 
   // ═══════════════════════════════════════════════════════════════════
-  // 4) CAPTAIN DATA — placeholder for future content
+  // 4) CAPTAINS — profile, trips, heatmap per captain
   // ═══════════════════════════════════════════════════════════════════
   html += '<section>';
   html += '<h2>' + esc(s('pub.dash.captainData')) + '</h2>';
-  html += '<div class="captain-placeholder"><p>' + esc(s('pub.dash.captainSoon')) + '</p></div>';
+  if (data.captains && data.captains.length) {
+    html += '<div class="captain-list">';
+    data.captains.forEach(function(cap, ci) {
+      html += '<div class="captain-card">';
+
+      // ── Header: headshot + name/stats ──
+      html += '<div class="captain-header">';
+      if (cap.headshotUrl) {
+        var hsUrl = cap.headshotUrl;
+        var dm = hsUrl.match(/\/d\/([a-zA-Z0-9_-]+)/);
+        if (dm) hsUrl = 'https://drive.google.com/thumbnail?id=' + dm[1] + '&sz=w200';
+        html += '<img class="captain-headshot" src="' + esc(hsUrl) + '" alt="' + esc(cap.name) + '">';
+      } else {
+        html += '<div class="captain-headshot-ph">&#9875;</div>';
+      }
+      html += '<div>';
+      html += '<div class="captain-name">' + esc(cap.name) + '</div>';
+      html += '<div class="captain-stats">'
+        + '<span>' + esc(cap.tripCount) + ' ' + esc(s('pub.dash.trips')) + '</span>'
+        + '<span>' + esc(cap.totalHours) + 'h</span>'
+        + '<span>' + esc(cap.totalDist || 0) + ' nm</span>'
+        + '</div>';
+      html += '</div></div>';
+
+      // ── Bio ──
+      if (cap.bio) {
+        html += '<div class="captain-bio">' + esc(cap.bio) + '</div>';
+      }
+
+      // ── Certs ──
+      if (cap.certs && cap.certs.length) {
+        html += '<div class="captain-certs">';
+        cap.certs.forEach(function(c) { html += '<span class="cert-badge">' + esc(c.label) + '</span>'; });
+        html += '</div>';
+      }
+
+      // ── Heatmap ──
+      if ((cap.locations && cap.locations.length) || (cap.trackLines && cap.trackLines.length)) {
+        html += '<div style="display:flex;align-items:center;justify-content:space-between">'
+          + '<span style="font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase">Heatmap</span>'
+          + '<div class="cap-hm-toggle" data-ci="' + ci + '">'
+          + '<button class="cap-hm-btn active" data-mode="trips" onclick="setCapHM(' + ci + ',\'trips\')">Trips</button>'
+          + '<button class="cap-hm-btn" data-mode="time" onclick="setCapHM(' + ci + ',\'time\')">Time</button>'
+          + '<button class="cap-hm-btn" data-mode="tracks" onclick="setCapHM(' + ci + ',\'tracks\')">Tracks</button>'
+          + '</div></div>';
+        html += '<div class="cap-heatmap" id="capmap-' + ci + '"></div>';
+      }
+
+      // ── Keelboat trips table ──
+      if (cap.trips && cap.trips.length) {
+        var initShow = 10;
+        html += '<div style="overflow-x:auto;margin-top:8px;border:1px solid var(--border);border-radius:8px">'
+          + '<table class="cap-trip-table"><tr>'
+          + '<th>' + esc(IS ? 'Dags.' : 'Date') + '</th>'
+          + '<th>' + esc(IS ? 'Bátur' : 'Boat') + '</th>'
+          + '<th>' + esc(IS ? 'Gerð' : 'Make/Model') + '</th>'
+          + '<th>' + esc(IS ? 'Staðsetning' : 'Location') + '</th>'
+          + '<th>' + esc(IS ? 'Áhöfn' : 'Crew') + '</th>'
+          + '<th>' + esc(IS ? 'Tími' : 'Time') + '</th>'
+          + '<th>' + esc(IS ? 'Vegalengd' : 'Distance') + '</th>'
+          + '</tr>';
+        cap.trips.forEach(function(t, ti) {
+          html += '<tr' + (ti >= initShow ? ' class="cap-extra-row-' + ci + '" style="display:none"' : '') + '>'
+            + '<td>' + esc(t.date) + '</td>'
+            + '<td>' + esc(t.boatName) + '</td>'
+            + '<td>' + esc(t.makeModel) + '</td>'
+            + '<td class="loc-col">' + esc(t.location) + '</td>'
+            + '<td style="text-align:center">' + esc(t.crew) + '</td>'
+            + '<td>' + (t.duration ? esc(t.duration) + 'h' : '') + '</td>'
+            + '<td>' + (t.distance ? esc(t.distance) + ' nm' : '') + '</td>'
+            + '</tr>';
+        });
+        html += '</table></div>';
+        if (cap.trips.length > initShow) {
+          html += '<button class="cap-show-more" id="cap-more-' + ci + '" onclick="showCapTrips(' + ci + ',' + cap.trips.length + ')">'
+            + esc(IS ? 'Sýna fleiri' : 'Show all') + ' (' + (cap.trips.length - initShow) + ' ' + esc(IS ? 'í viðbót' : 'more') + ')</button>';
+        }
+      }
+
+      html += '<a class="captain-link" href="' + esc(cap.captainRecordUrl) + '" target="_blank">' + esc(s('pub.dash.viewProfile')) + ' &rarr;</a>';
+      html += '</div>';
+    });
+    html += '</div>';
+  } else {
+    html += '<div class="captain-placeholder"><p>' + esc(s('pub.dash.captainSoon')) + '</p></div>';
+  }
   html += '</section>';
 
   main.innerHTML = html;
@@ -496,11 +598,110 @@ function initMap(locations) {
   });
 }
 
+// ── Captain heatmaps ──
+var _capData = [];         // captains array from API
+var _capMaps = {};         // ci → Leaflet map
+var _capHeatLayers = {};   // ci → heat layer
+var _capMarkers = {};      // ci → [markers]
+var _capTrkLines = {};     // ci → [polylines]
+var _capModes = {};        // ci → 'trips'|'time'|'tracks'
+
+function initCapMaps() {
+  if (!_capData.length) return;
+  _capData.forEach(function(cap, ci) {
+    var el = document.getElementById('capmap-' + ci);
+    if (!el) return;
+    if (_capMaps[ci]) { _capMaps[ci].remove(); _capMaps[ci] = null; }
+    _capModes[ci] = 'trips';
+    _capMarkers[ci] = [];
+    _capTrkLines[ci] = [];
+    var map = L.map(el, { zoomControl: true, attributionControl: true, scrollWheelZoom: false, zoomSnap: 0.25, zoomDelta: 0.25 });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map);
+    L.tileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', { maxNativeZoom: 17, maxZoom: 19, opacity: 0.9 }).addTo(map);
+    _capMaps[ci] = map;
+    renderCapHM(ci);
+  });
+}
+
+function clearCapHM(ci) {
+  var map = _capMaps[ci]; if (!map) return;
+  if (_capHeatLayers[ci]) { map.removeLayer(_capHeatLayers[ci]); _capHeatLayers[ci] = null; }
+  (_capMarkers[ci] || []).forEach(function(m) { map.removeLayer(m); }); _capMarkers[ci] = [];
+  (_capTrkLines[ci] || []).forEach(function(l) { map.removeLayer(l); }); _capTrkLines[ci] = [];
+}
+
+function renderCapHM(ci) {
+  var map = _capMaps[ci]; if (!map) return;
+  var cap = _capData[ci]; if (!cap) return;
+  clearCapHM(ci);
+  var mode = _capModes[ci] || 'trips';
+
+  if (mode === 'tracks') {
+    var lines = cap.trackLines || [];
+    if (!lines.length) { map.setView([64.148, -21.965], 11.25); return; }
+    var all = [];
+    lines.forEach(function(pts) {
+      var ll = pts.map(function(p) { return [p.lat, p.lng]; });
+      all = all.concat(ll);
+      var ln = L.polyline(ll, { color: '#d4af37', weight: 2, opacity: 0.6 }).addTo(map);
+      _capTrkLines[ci].push(ln);
+    });
+    if (all.length) {
+      _capHeatLayers[ci] = L.heatLayer(all.map(function(p) { return [p[0], p[1], 0.5]; }), {
+        radius: 20, blur: 15, maxZoom: 14, max: 1.0,
+        gradient: { 0.2: '#1e3f6e', 0.4: '#2e86c1', 0.6: '#f1c40f', 0.8: '#e67e22', 1.0: '#e74c3c' }
+      }).addTo(map);
+      map.fitBounds(L.latLngBounds(all).pad(0.1), { maxZoom: 11 });
+    }
+  } else {
+    var locs = cap.locations || [];
+    if (!locs.length) { map.setView([64.148, -21.965], 11.25); return; }
+    var isTime = mode === 'time';
+    var maxV = locs.reduce(function(m, l) { return Math.max(m, isTime ? l.hours : l.count); }, 1);
+    var hd = locs.map(function(l) { return [l.lat, l.lng, (isTime ? l.hours : l.count) / maxV]; });
+    _capHeatLayers[ci] = L.heatLayer(hd, {
+      radius: 30, blur: 20, maxZoom: 14, max: 1.0,
+      gradient: { 0.2: '#1e3f6e', 0.4: '#2e86c1', 0.6: '#f1c40f', 0.8: '#e67e22', 1.0: '#e74c3c' }
+    }).addTo(map);
+    locs.forEach(function(l) {
+      var int = (isTime ? l.hours : l.count) / maxV;
+      var r = Math.max(6, Math.min(20, 6 + int * 14));
+      var vl = isTime ? l.hours + 'h' : l.count + (l.count === 1 ? ' trip' : ' trips');
+      var mk = L.circleMarker([l.lat, l.lng], { radius: r, color: '#d4af37', fillColor: '#d4af37', fillOpacity: 0.3, weight: 1 })
+        .bindTooltip('<strong>' + esc(l.name) + '</strong><br>' + vl + ' &middot; ' + l.hours + 'h').addTo(map);
+      _capMarkers[ci].push(mk);
+    });
+    map.fitBounds(L.latLngBounds(locs.map(function(l) { return [l.lat, l.lng]; })).pad(0.15), { maxZoom: 11 });
+  }
+}
+
+function setCapHM(ci, mode) {
+  _capModes[ci] = mode;
+  var toggle = document.querySelector('.cap-hm-toggle[data-ci="' + ci + '"]');
+  if (toggle) {
+    toggle.querySelectorAll('.cap-hm-btn').forEach(function(b) { b.classList.toggle('active', b.dataset.mode === mode); });
+  }
+  renderCapHM(ci);
+}
+
+function showCapTrips(ci, total) {
+  document.querySelectorAll('.cap-extra-row-' + ci).forEach(function(r) { r.style.display = ''; });
+  var btn = document.getElementById('cap-more-' + ci);
+  if (btn) btn.style.display = 'none';
+}
+
+function fmtTimeNow() {
+  var n = new Date();
+  return n.getHours() + ':' + String(n.getMinutes()).padStart(2, '0');
+}
+
 async function load() {
   applyStaticText();
   try {
     var data = await fetchDashboard();
+    _capData = data.captains || [];
     renderDashboard(data);
+    setTimeout(function() { initCapMaps(); }, 100);
   } catch (e) {
     console.error('Dashboard load error:', e);
     document.getElementById('main-content').innerHTML = '<div class="error-msg">' + esc(s('pub.dash.error')) + '</div>';

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -994,6 +994,8 @@ var _STRINGS_FLAT = {
   "pub.dash.boatsOut": "Boats Out",
   "pub.dash.captainData": "Captain Data",
   "pub.dash.captainSoon": "Captain profiles and statistics will appear here soon.",
+  "pub.dash.trips": "trips",
+  "pub.dash.viewProfile": "View full profile",
   "pub.dash.comingSoon": "More information coming soon.",
   "admin.expectedColumns": "EXPECTED COLUMNS",
   "admin.colName": "Full name (required)",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -994,6 +994,8 @@ var _STRINGS_FLAT = {
   "pub.dash.boatsOut": "Bátar úti",
   "pub.dash.captainData": "Skipstjóragögn",
   "pub.dash.captainSoon": "Upplýsingar um skipstjóra og tölfræði birtast hér fljótlega.",
+  "pub.dash.trips": "siglingar",
+  "pub.dash.viewProfile": "Sjá fulla prófíl",
   "pub.dash.comingSoon": "Frekari upplýsingar birtast fljótlega.",
   "admin.expectedColumns": "VÆNTIR DÁLKAR",
   "admin.colName": "Fullt nafn (áskilið)",


### PR DESCRIPTION
Public dashboard (/public):
- Replace captain placeholder with full captain cards showing: headshot, name, bio, stats, cert badges
- Single-line keelboat trip table per captain with: date, boat name, make/model, location, crew count, duration, distance
- Show-more pagination (10 initially, expand to show all)
- Interactive heatmap per captain with trips/time/GPS-tracks toggle
- Scales to any number of captains

Backend (code.gs):
- Enhance publicDashboard_() to include per-captain: trip rows, location stats with coordinates, GPS track lines, totalDist

Captain dashboard:
- Remove compact trips + heatmap sections (moved to public page)
- Keep allLocs bugfix and bio section repositioning

Strings: add pub.dash.trips, pub.dash.viewProfile (EN + IS)

Addresses skarfur/ymir#369

https://claude.ai/code/session_0149DwtY5QHLdLYW5jdCevwP