### PR TITLE
Manual log entry UI improvements (#368)

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -325,10 +325,11 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
         <select id="mBoat" onchange="onBoatChange()"><option value="">Select boat…</option></select>
       </div>
       <!-- Non-club boat (hidden by default) -->
-      <div id="mBoatFree" class="form-field" style="display:none">
-        <label data-s="logbook.boatNameLabel">Boat name</label>
-        <input type="text" id="mBoatFreeInput" placeholder="e.g. Sunfish, RIB, etc." autocomplete="off">
-        <div class="form-row mt-4">
+      <div id="mBoatFree" style="display:none">
+        <div class="form-row">
+          <div class="form-field"><label data-s="logbook.boatNameLabel">Boat name</label>
+            <input type="text" id="mBoatFreeInput" placeholder="e.g. Sunfish, RIB, etc." autocomplete="off">
+          </div>
           <div class="form-field"><label data-s="logbook.boatCategory">Category</label>
             <select id="mBoatFreeCat">
               <option value="dinghy">Dinghy</option><option value="keelboat">Keelboat</option>
@@ -336,6 +337,22 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
               <option value="sup">SUP</option><option value="wingfoil">Wingfoil</option>
               <option value="other">Other</option>
             </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-field"><label>Model / make <span class="text-muted" style="font-size:9px">optional</span></label>
+            <input type="text" id="mBoatFreeModel" placeholder="e.g. Laser Pico" autocomplete="off">
+          </div>
+          <div class="form-field"><label>Sail number <span class="text-muted" style="font-size:9px">optional</span></label>
+            <input type="text" id="mBoatFreeSail" placeholder="e.g. ISL 1234" autocomplete="off">
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-field"><label>Registration <span class="text-muted" style="font-size:9px">optional</span></label>
+            <input type="text" id="mBoatFreeReg" placeholder="e.g. RE-001" autocomplete="off">
+          </div>
+          <div class="form-field"><label>Length (m) <span class="text-muted" style="font-size:9px">optional</span></label>
+            <input type="number" id="mBoatFreeLen" min="0" step="0.1" placeholder="e.g. 6.5">
           </div>
         </div>
       </div>
@@ -346,10 +363,7 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
       <!-- Non-club location (hidden by default) -->
       <div id="mLocFree" class="form-field" style="display:none">
         <label data-s="lbl.location">Location</label>
-        <div style="display:flex;gap:6px;align-items:center">
-          <input type="text" id="mLocFreeInput" placeholder="e.g. Lake Thingvallavatn" autocomplete="off" style="flex:1">
-          <button type="button" class="btn-secondary" id="mLocGeoBtn" onclick="useMyLocation('mLocFreeInput','mLocGeoStatus')" style="white-space:nowrap;font-size:10px;padding:6px 10px" data-s="logbook.useMyLocation">📍 Use my location</button>
-        </div>
+        <input type="text" id="mLocFreeInput" placeholder="e.g. Lake Thingvallavatn" autocomplete="off">
         <div id="mLocGeoStatus" class="text-xs text-muted" style="margin-top:4px;display:none"></div>
       </div>
       <div class="form-row">
@@ -357,12 +371,10 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
           oninput="var v=this.value.replace(/[^0-9]/g,'');if(v.length>=2)v=v.slice(0,2)+':'+v.slice(2,4);this.value=v"></div>
         <div class="form-field"><label>Returned</label><input type="text" id="mTimeIn" placeholder="HH:MM" maxlength="5"
           oninput="var v=this.value.replace(/[^0-9]/g,'');if(v.length>=2)v=v.slice(0,2)+':'+v.slice(2,4);this.value=v"></div>
-      </div>
-      <div class="form-row">
-        <div class="form-field"><label>Crew aboard (total incl. you)</label><input type="number" id="mCrew" min="1" value="1" oninput="onCrewChange()"></div>
-        <div class="form-field"><label>Distance (nm) <span class="text-muted" style="font-size:9px">optional</span></label>
+        <div class="form-field"><label>Distance (nm) <span class="text-muted" style="font-size:9px">auto from GPS</span></label>
           <input type="number" id="mDistanceNm" min="0" step="0.1" placeholder="e.g. 12.5"></div>
       </div>
+      <div class="form-field"><label>Crew aboard (total incl. you)</label><input type="number" id="mCrew" min="1" value="1" oninput="onCrewChange()"></div>
       <!-- Crew member inputs: shown when crew > 1 -->
       <div id="mCrewSection" class="mb-12" style="display:none">
         <label class="check-label" style="margin-bottom:8px">
@@ -455,7 +467,14 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
           <label><input type="checkbox" id="mPhotoClubUse"> Club may use</label>
         </div>
       </div>
-      <div class="form-field"><label>Notes</label><textarea id="mNotes" rows="2" placeholder="Optional notes…"></textarea></div>
+      <div class="form-field" id="mSkipperNoteWrap">
+        <label>Skipper's note <span class="text-muted" style="font-size:9px">visible to crew</span></label>
+        <textarea id="mSkipperNote" rows="2" placeholder="Notes for the crew…"></textarea>
+      </div>
+      <div class="form-field" id="mPersonalNoteWrap">
+        <label>Personal note <span class="text-muted" style="font-size:9px">only you</span></label>
+        <textarea id="mNotes" rows="2" placeholder="Private notes…"></textarea>
+      </div>
       <div id="mErr" class="text-sm text-red mb-8" style="display:none"></div>
       <button class="btn-primary" id="mSubmitBtn" onclick="submitManual()">Save to logbook</button>
     </div>

--- a/member/index.html
+++ b/member/index.html
@@ -1006,10 +1006,10 @@ function renderLandingChecklist() {
       '<div style="font-size:10px;color:var(--muted);margin-bottom:6px">'+s('member.notesVisibleAll')+'</div>'+
       '<textarea id="retSkipperNote" rows="2" placeholder="'+s('member.notesPlaceholder')+'" style="width:100%;resize:none;font-size:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px;font-family:inherit;box-sizing:border-box"></textarea>'+
     '</div>'+
-    '<div class="field" style="margin-bottom:14px">'+
+    (((returnCo.crew||1)>1)?('<div class="field" style="margin-bottom:14px">'+
       '<label style="display:block;font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">'+s('member.personalNotes')+'</label>'+
       '<textarea id="retNotes" rows="2" placeholder="'+s('member.onlyVisibleYou')+'" style="width:100%;resize:none;font-size:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px;font-family:inherit;box-sizing:border-box"></textarea>'+
-    '</div>'+
+    '</div>'):'')+
     '<div class="btn-row">'+
       '<button class="btn btn-secondary" onclick="renderReturnForm()">&#8592; '+s('member.back')+'</button>'+
       '<button class="btn btn-primary" id="retSubmitBtn" onclick="confirmCheckIn(\''+returnCo.id+'\')">&#10003; '+s('member.checkInBtn')+'</button>'+

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -599,9 +599,14 @@ function showManualForm(){
   const pd=document.getElementById('portDetails');
   pd.removeAttribute('open');
   onBoatChange();
+  // Reset notes
+  const sn=document.getElementById('mSkipperNote'); if(sn) sn.value='';
+  document.getElementById('mNotes').value='';
   // Reset non-club state
   document.getElementById('mNonClub').checked=false;
   onNonClubToggle();
+  // Apply crew=1 conditional (hides personal note initially)
+  onCrewChange();
 }
 
 // ── Non-club trip toggle ─────────────────────────────────────────────────────
@@ -614,10 +619,14 @@ function onNonClubToggle(){
   if(!on){
     document.getElementById('mBoatFreeInput').value='';
     document.getElementById('mBoatFreeCat').value='dinghy';
+    document.getElementById('mBoatFreeModel').value='';
+    document.getElementById('mBoatFreeSail').value='';
+    document.getElementById('mBoatFreeReg').value='';
+    document.getElementById('mBoatFreeLen').value='';
     document.getElementById('mLocFreeInput').value='';
     delete document.getElementById('mLocFreeInput').dataset.lat;
     delete document.getElementById('mLocFreeInput').dataset.lng;
-    document.getElementById('mLocGeoStatus').style.display='none';
+    const gs=document.getElementById('mLocGeoStatus'); if(gs) gs.style.display='none';
   }
 }
 
@@ -755,6 +764,9 @@ function onCrewChange(){
   const n = parseInt(document.getElementById('mCrew').value)||1;
   const sec = document.getElementById('mCrewSection');
   const wrap = document.getElementById('mCrewInputs');
+  // Personal note only makes sense when there's crew besides skipper
+  const personalWrap=document.getElementById('mPersonalNoteWrap');
+  if(personalWrap) personalWrap.style.display = (n < 2) ? 'none' : '';
   if(n < 2){ sec.style.display='none'; return; }
   sec.style.display='';
   const existing = Array.from(wrap.querySelectorAll('.manual-crew-row')).map(row => {
@@ -1048,6 +1060,10 @@ async function submitManual(){
     boatCategory=document.getElementById('mBoatFreeCat').value;
     locId='';
     locName=document.getElementById('mLocFreeInput').value.trim();
+    var _ncModel=(document.getElementById('mBoatFreeModel')?.value||'').trim();
+    var _ncSail=(document.getElementById('mBoatFreeSail')?.value||'').trim();
+    var _ncReg=(document.getElementById('mBoatFreeReg')?.value||'').trim();
+    var _ncLen=(document.getElementById('mBoatFreeLen')?.value||'').trim();
   } else {
     boatId=document.getElementById('mBoat').value;
     boatName=document.getElementById('mBoat').selectedOptions[0]?.text||'';
@@ -1072,7 +1088,10 @@ async function submitManual(){
   const feelsLike = document.getElementById('mFeelsLike').value;
   const seaTemp   = document.getElementById('mSeaTemp').value;
   const pressure  = document.getElementById('mPressure').value;
-  const notes     = document.getElementById('mNotes').value.trim();
+  const skipperNote = (document.getElementById('mSkipperNote')?.value||'').trim();
+  // Personal note is only used when there are crew besides the skipper
+  const _crewN    = parseInt(document.getElementById('mCrew').value)||1;
+  const notes     = (_crewN>1) ? document.getElementById('mNotes').value.trim() : '';
   const distInput = parseFloat(document.getElementById('mDistanceNm').value)||'';
   let   depPort   = document.getElementById('mDeparturePort').value.trim();
   let   arrPort   = document.getElementById('mArrivalPort').value.trim();
@@ -1147,7 +1166,11 @@ async function submitManual(){
         trackFileUrl=tr.trackFileUrl||'';
         trackSimplified=tr.trackSimplified||'';
         trackSource=tr.trackSource||'';
-        if(!distanceNm && tr.distanceNm) distanceNm=tr.distanceNm;
+        if(!distanceNm && tr.distanceNm){
+          distanceNm=tr.distanceNm;
+          const dEl=document.getElementById('mDistanceNm');
+          if(dEl) dEl.value=tr.distanceNm;
+        }
       } else {
         showToast(s('logbook.uploadNoConfig'),'warn');
       }
@@ -1187,12 +1210,16 @@ async function submitManual(){
       date, boatId, boatName, boatCategory,
       locationId:locId, locationName:locName,
       timeOut, timeIn, hoursDecimal, crew, role,
-      beaufort:bft, windDir:wdir, notes, wxSnapshot,
+      beaufort:bft, windDir:wdir, notes, skipperNote, wxSnapshot,
       distanceNm, departurePort:depPort, arrivalPort:arrPort,
       trackFileUrl, trackSimplified, trackSource,
       photoUrls: photoUrls.length ? JSON.stringify(photoUrls) : '',
       photoMeta: Object.keys(photoMeta).length ? JSON.stringify(photoMeta) : '',
       nonClub: isNonClub||false,
+      boatModel: isNonClub ? (typeof _ncModel!=='undefined'?_ncModel:'') : '',
+      boatSailNumber: isNonClub ? (typeof _ncSail!=='undefined'?_ncSail:'') : '',
+      boatRegistration: isNonClub ? (typeof _ncReg!=='undefined'?_ncReg:'') : '',
+      boatLengthM: isNonClub ? (typeof _ncLen!=='undefined'?_ncLen:'') : '',
       helm: helmSelf,
       crewNames: _crewNamesArr.length ? JSON.stringify(_crewNamesArr) : '',
     };


### PR DESCRIPTION
- Reorganize manual log form columns: group times+distance into one row, place crew on its own row, and pair non-club boat fields into logical 2-column rows.
- Add non-club boat metadata fields: model/make, sail number, registration, and length.
- Remove the standalone "Use my location" pill button next to the non-club location field.
- Add a Skipper's note field (visible to crew) alongside the existing Personal note. The personal note is hidden when the trip has only a single crew member (skipper alone), so only the skipper's note is shown.
- Apply the same single-crew conditional to the check-in (return) modal: hide the personal note when crew=1.
- Auto-populate the manual entry distance field from uploaded GPS track data, matching behaviour elsewhere in the app.