### PR TITLE
Disambiguate duplicate member names by appending birth year

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1224,6 +1224,7 @@ function renderMembers() {
 }
 
 var _memberListData = [];
+var _memberDupNames = null;
 var _memberRendered = 0;
 var _memberObserver = null;
 var _MEMBER_BATCH = 50;
@@ -1232,6 +1233,7 @@ function renderMemberList(list) {
   const card = document.getElementById("membersCard");
   if (!list.length) { card.innerHTML = `<div class="empty-state">${s('admin.noMembers')}</div>`; return; }
   _memberListData = list;
+  _memberDupNames = duplicateMemberNames(list);
   _memberRendered = 0;
   card.innerHTML = '';
   _renderMemberBatch(card);
@@ -1246,7 +1248,7 @@ function _renderMemberBatch(card) {
     var row = document.createElement('div');
     row.className = 'member-row';
     row.innerHTML =
-      `<span class="member-name">${esc(m.name || "—")}</span>` +
+      `<span class="member-name">${esc((_memberDupNames && _memberDupNames.has(m.name) && m.birthYear) ? (m.name + ' (' + m.birthYear + ')') : (m.name || "—"))}</span>` +
       `<span class="member-kt">${esc(m.kennitala || "")}</span>` +
       `<span style="font-size:10px;color:var(--muted);min-width:50px">${esc(m.membershipType || m.membership_type || "")}</span>` +
       `<button class="row-edit" onclick="openMemberModal('${m.id}')">Edit</button>` +
@@ -1567,7 +1569,7 @@ function searchBoatOwner(q) {
   const hits = members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
   if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
   drop.innerHTML = hits.map(m => `<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"
-    onclick="selectBoatOwner('${esc(m.kennitala)}','${esc(m.name)}')">${esc(m.name)}</div>`).join('');
+    onclick="selectBoatOwner('${esc(m.kennitala)}','${esc(memberDisplayName(m, members))}')">${esc(memberDisplayName(m, members))}</div>`).join('');
   drop.style.display = 'block';
 }
 
@@ -1611,7 +1613,7 @@ function renderAllowlistChips() {
   if (!_editAllowlist.length) { el.innerHTML = ''; return; }
   el.innerHTML = _editAllowlist.map(function(kt) {
     var m = members.find(function(x) { return x.kennitala === kt; });
-    var name = m ? m.name : kt;
+    var name = m ? memberDisplayName(m, members) : kt;
     return '<span style="font-size:10px;padding:3px 8px;border-radius:12px;background:var(--surface);border:1px solid var(--border);color:var(--text);display:inline-flex;align-items:center;gap:4px">'
       + esc(name)
       + '<span style="cursor:pointer;color:var(--red);font-size:12px" onclick="removeFromAllowlist(\'' + esc(kt) + '\')">&times;</span>'
@@ -1627,7 +1629,7 @@ function searchAllowlistMember(q) {
   if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
   drop.innerHTML = hits.map(function(m) {
     return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-      + 'onclick="addToAllowlist(\'' + esc(m.kennitala) + '\')">' + esc(m.name) + '</div>';
+      + 'onclick="addToAllowlist(\'' + esc(m.kennitala) + '\')">' + esc(memberDisplayName(m, members)) + '</div>';
   }).join('');
   drop.style.display = 'block';
 }
@@ -1680,7 +1682,7 @@ function searchResMember(q) {
   if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
   drop.innerHTML = hits.map(function(m) {
     return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-      + 'onclick="selectResMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>';
+      + 'onclick="selectResMember(\'' + esc(m.kennitala) + '\',\'' + esc(memberDisplayName(m, members)) + '\')">' + esc(memberDisplayName(m, members)) + '</div>';
   }).join('');
   drop.style.display = 'block';
 }

--- a/captain/index.html
+++ b/captain/index.html
@@ -752,7 +752,7 @@ function searchCqResMember(q) {
     }
     if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
     drop.innerHTML = hits.map(m => '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-      + 'onclick="selectCqResMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>').join('');
+      + 'onclick="selectCqResMember(\'' + esc(m.kennitala) + '\',\'' + esc(memberDisplayName(m, _cqMembers)) + '\')">' + esc(memberDisplayName(m, _cqMembers)) + '</div>').join('');
     drop.style.display = 'block';
   }, 150);
 }
@@ -831,7 +831,7 @@ function buildFilters() {
   _captains = _cqMembers.filter(function(m) { return isCaptain(m); }).sort(function(a, b) { return (a.name || '').localeCompare(b.name || ''); });
   var capSel = document.getElementById('fCaptain');
   capSel.innerHTML = '<option value="">' + s('cq.allCaptains') + '</option>';
-  _captains.forEach(function(c) { var o = document.createElement('option'); o.value = c.kennitala; o.textContent = c.name; capSel.appendChild(o); });
+  _captains.forEach(function(c) { var o = document.createElement('option'); o.value = c.kennitala; o.textContent = memberDisplayName(c, _captains); capSel.appendChild(o); });
 
   // Member filter (anyone with keelboat_crew endorsement)
   var keelboatMembers = _cqMembers.filter(function(m) {
@@ -841,7 +841,7 @@ function buildFilters() {
   }).sort(function(a, b) { return (a.name || '').localeCompare(b.name || ''); });
   var mSel = document.getElementById('fMember');
   mSel.innerHTML = '<option value="">' + s('cq.allMembers') + '</option>';
-  keelboatMembers.forEach(function(m) { var o = document.createElement('option'); o.value = m.kennitala; o.textContent = m.name; mSel.appendChild(o); });
+  keelboatMembers.forEach(function(m) { var o = document.createElement('option'); o.value = m.kennitala; o.textContent = memberDisplayName(m, keelboatMembers); mSel.appendChild(o); });
 
   ['fYear', 'fCat', 'fBoatName', 'fCaptain', 'fMember', 'fWind'].forEach(function(id) { document.getElementById(id).addEventListener('change', applyFilter); });
   document.getElementById('fText').addEventListener('input', applyFilter);

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -486,10 +486,10 @@ function renderSeat(crew, pairId, seatIdx, member, isOpen, isMine) {
   var isYou = member && String(member.kennitala) === kt;
   var roleLabel = '<span class="cb-seat-role">' + (seatIdx === 0 ? s('cox.bow') : s('cox.stern')) + '</span>';
   if (isYou) {
-    return '<div class="cb-seat cb-seat--you">' + roleLabel + '<span class="cb-seat-name">' + esc(member.name) + '</span></div>';
+    return '<div class="cb-seat cb-seat--you">' + roleLabel + '<span class="cb-seat-name">' + esc(memberDisplayName(member, _members)) + '</span></div>';
   }
   if (member) {
-    return '<div class="cb-seat cb-seat--filled">' + roleLabel + '<span class="cb-seat-name">' + esc(member.name) + '</span></div>';
+    return '<div class="cb-seat cb-seat--filled">' + roleLabel + '<span class="cb-seat-name">' + esc(memberDisplayName(member, _members)) + '</span></div>';
   }
   if (isOpen && _isReleasedRower && !isMine) {
     return '<div class="cb-seat cb-seat--open" onclick="joinSeat(\'' + esc(crew.id) + '\',\'' + esc(pairId) + '\',' + seatIdx + ')">'
@@ -642,7 +642,7 @@ function searchCrewInvMember(q) {
     if (!hits.length) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
     drop.innerHTML = hits.map(function(m) {
       return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-        + 'onclick="selectCrewInvMember(\'' + esc(m.kennitala) + '\',\'' + esc(m.name) + '\')">' + esc(m.name) + '</div>';
+        + 'onclick="selectCrewInvMember(\'' + esc(m.kennitala) + '\',\'' + esc(memberDisplayName(m, _members)) + '\')">' + esc(memberDisplayName(m, _members)) + '</div>';
     }).join('');
     drop.style.display = 'block';
   }, 150);

--- a/shared/mcm.js
+++ b/shared/mcm.js
@@ -164,9 +164,10 @@
       // Pre-populated mode (e.g. admin member list)
       var m = _findMember(_memberId);
       searchField.style.display = 'none';
-      nameEl.textContent = m ? m.name : '';
+      var dispName = m ? memberDisplayName(m, _members()) : '';
+      nameEl.textContent = dispName;
       nameEl.style.display = '';
-      titleEl.innerHTML = '<span data-s="admin.credentialsTitle"></span> — <span>' + esc(m ? m.name : '') + '</span>';
+      titleEl.innerHTML = '<span data-s="admin.credentialsTitle"></span> — <span>' + esc(dispName) + '</span>';
       if (m) _renderCurrentCerts(m);
     } else {
       // Search mode (e.g. captain page)
@@ -197,7 +198,7 @@
     }).slice(0, 8);
     el.innerHTML = matches.map(function(m) {
       return '<div class="list-row" style="cursor:pointer;padding:6px 8px;font-size:12px" onclick="mcmSelectMember(\'' + m.id + '\')">'
-        + '<div>' + esc(m.name || '\u2014') + '</div>'
+        + '<div>' + esc(memberDisplayName(m, _members()) || '\u2014') + '</div>'
         + '<div style="font-size:10px;color:var(--muted);margin-left:8px">' + esc(m.kennitala || '') + '</div></div>';
     }).join('');
   };
@@ -209,7 +210,7 @@
     var el = document.getElementById('mcmMemberName');
     document.getElementById('mcmMemberResults').innerHTML = '';
     document.getElementById('mcmMemberSearch').value = '';
-    el.textContent = m ? m.name : id;
+    el.textContent = m ? memberDisplayName(m, _members()) : id;
     el.style.display = '';
     if (m) _renderCurrentCerts(m);
   };

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -67,6 +67,37 @@ window.esc = function (s) {
   return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 };
 
+// ── MEMBER NAME DISAMBIGUATION ────────────────────────────────────────────────
+// When multiple people in an array share the same name, append the birth year
+// to distinguish them. Pass the member (or any {name, birthYear}-like object)
+// and the array it belongs to. Returns a plain string (not HTML-escaped).
+window.memberDisplayName = function (member, allMembers) {
+  if (!member) return '';
+  var name = member.name || '';
+  if (!name || !Array.isArray(allMembers)) return name;
+  var dupes = 0;
+  for (var i = 0; i < allMembers.length; i++) {
+    if (allMembers[i] && allMembers[i].name === name) {
+      if (++dupes > 1) break;
+    }
+  }
+  if (dupes > 1 && member.birthYear) return name + ' (' + member.birthYear + ')';
+  return name;
+};
+
+// Build a Set of names that occur more than once in the given array.
+window.duplicateMemberNames = function (allMembers) {
+  var seen = Object.create(null), dupes = new Set();
+  if (!Array.isArray(allMembers)) return dupes;
+  for (var i = 0; i < allMembers.length; i++) {
+    var n = allMembers[i] && allMembers[i].name;
+    if (!n) continue;
+    if (seen[n]) dupes.add(n);
+    else seen[n] = true;
+  }
+  return dupes;
+};
+
 // ── CACHED DOM REFS ────────────────────────────────────────────────────────────
 window.domRefs = function (idMap) {
   const cache = {};

--- a/staff/index.html
+++ b/staff/index.html
@@ -746,8 +746,8 @@ function searchMember(q) {
   ).slice(0,6);
   let html = matches.map(m =>
     `<div style="padding:6px 10px;cursor:pointer;border:1px solid var(--border);border-top:none;
-      background:var(--card);font-size:12px" onmousedown="selectMember('${m.kennitala}','${esc(m.name)}')"
-    >${esc(m.name)} <span style="color:var(--muted)">${m.kennitala}</span>${m.isMinor?`<span class="badge badge-yellow" style="margin-left:6px">${s('lbl.minor')}</span>`:''}</div>`
+      background:var(--card);font-size:12px" onmousedown="selectMember('${m.kennitala}','${esc(memberDisplayName(m, members))}')"
+    >${esc(memberDisplayName(m, members))} <span style="color:var(--muted)">${m.kennitala}</span>${m.isMinor?`<span class="badge badge-yellow" style="margin-left:6px">${s('lbl.minor')}</span>`:''}</div>`
   ).join('');
   if (q.length >= 3) {
     html += `<div class="guest-add-hint" onmousedown="promptGuestSkipper('${esc(q.trim())}')"


### PR DESCRIPTION
When multiple members in a list share the same name, append their birth year in parentheses so they can be told apart. Adds two helpers in shared/ui.js (memberDisplayName, duplicateMemberNames) and applies them to the admin member list, member/captain/owner/allowlist/reservation search dropdowns, captain & member filter dropdowns, coxswain crew seats and crew-invite search, staff member search, and the shared member-credential modal.

Fixes #358