### PR TITLE
Fix logbook back nav and remove weather header button (#349)

### DIFF
--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1545,7 +1545,6 @@ async function reload(){
 (async function init(){
   if (window._logbookSkipInit) return;
   applyStrings();
-  buildHeader('member');
   try{
     const [tripsRes,cfgRes,membersRes]=await Promise.all([
       window._earlyTrips || apiGet('getTrips',{limit:500}),

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -267,9 +267,8 @@ window.buildHeader = function (page) {
     if (isCaptainUser && page !== 'captain') left.appendChild(link(depth + 'captain/', s('nav.captainQuarters'), 'hbtn'));
   }
 
-  // RIGHT: Settings · Weather · lang · sign out
+  // RIGHT: Settings · lang · sign out
   if (user && page !== 'settings') right.appendChild(link(depth + 'settings/', s('nav.settings'), 'hbtn'));
-  if (page !== 'weather') right.appendChild(link(depth + 'weather/', s('nav.weather'), 'hbtn'));
   right.appendChild(btn(s('nav.langToggle'), () => { if (typeof toggleLang === 'function') toggleLang(); }));
   right.appendChild(btn(s('nav.signOut'),    () => { if (typeof signOut    === 'function') signOut();    }));
 };


### PR DESCRIPTION
- shared/logbook.js init no longer overwrites the page header with buildHeader('member'), which was clobbering the back-to-member link on the standalone logbook page.
- shared/ui.js no longer renders a Weather button in the standard page header.