### PR TITLE
Manual log entry: layout polish + current weather (#368)

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -320,9 +320,14 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
           <span class="text-muted" style="font-size:9px;font-weight:400" data-s="logbook.nonClubHint">— log a trip outside the club system</span>
         </label>
       </div>
-      <!-- Club boat (default) -->
-      <div id="mBoatClub" class="form-field"><label>Boat</label>
-        <select id="mBoat" onchange="onBoatChange()"><option value="">Select boat…</option></select>
+      <!-- Club boat + location (default) -->
+      <div id="mClubRow" class="form-row">
+        <div id="mBoatClub" class="form-field"><label>Boat</label>
+          <select id="mBoat" onchange="onBoatChange()"><option value="">Select boat…</option></select>
+        </div>
+        <div id="mLocClub" class="form-field"><label>Location</label>
+          <select id="mLocation"><option value="">Select location…</option></select>
+        </div>
       </div>
       <!-- Non-club boat (hidden by default) -->
       <div id="mBoatFree" style="display:none">
@@ -356,15 +361,12 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
           </div>
         </div>
       </div>
-      <!-- Club location (default) -->
-      <div id="mLocClub" class="form-field"><label>Location</label>
-        <select id="mLocation"><option value="">Select location…</option></select>
-      </div>
       <!-- Non-club location (hidden by default) -->
       <div id="mLocFree" class="form-field" style="display:none">
         <label data-s="lbl.location">Location</label>
         <input type="text" id="mLocFreeInput" placeholder="e.g. Lake Thingvallavatn" autocomplete="off">
-        <div id="mLocGeoStatus" class="text-xs text-muted" style="margin-top:4px;display:none"></div>
+        <button type="button" class="text-xs text-brass" id="mLocGeoBtn" onclick="useMyLocation('mLocFreeInput','mLocGeoStatus')" style="background:none;border:none;padding:4px 0;cursor:pointer;display:block" data-s="logbook.useMyLocation">📍 Use my location</button>
+        <div id="mLocGeoStatus" class="text-xs text-muted" style="margin-top:2px;display:none"></div>
       </div>
       <div class="form-row">
         <div class="form-field"><label>Departed</label><input type="text" id="mTimeOut" placeholder="HH:MM" maxlength="5"
@@ -409,7 +411,11 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
       </details>
 
       <!-- Weather -->
-      <div class="section-label" style="margin:12px 0 8px">WEATHER (OPTIONAL)</div>
+      <div class="flex-center gap-6" style="margin:12px 0 8px;justify-content:space-between">
+        <div class="section-label">WEATHER (OPTIONAL)</div>
+        <button type="button" class="text-xs text-brass" id="mWxFetchBtn" onclick="fetchCurrentWeather()" style="background:none;border:none;padding:0;cursor:pointer">🌤 Use current weather</button>
+      </div>
+      <div id="mWxFetchStatus" class="text-xs text-muted" style="display:none;margin-bottom:6px"></div>
       <div class="wx-row">
         <div class="form-field"><label>Beaufort</label>
           <select id="mBft" onchange="onBftChange()">

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -669,6 +669,62 @@ function useMyLocation(inputId,statusId){
   );
 }
 
+// ── Fetch current weather from Open-Meteo using geolocation ──────────────────
+async function fetchCurrentWeather(){
+  const status=document.getElementById('mWxFetchStatus');
+  const btn=document.getElementById('mWxFetchBtn');
+  function setStatus(msg,err){ if(!status) return; status.textContent=msg; status.style.display=''; status.style.color=err?'var(--red)':'var(--muted)'; }
+  if(!navigator.geolocation){ setStatus('Geolocation not available',true); return; }
+  // Try to reuse coords from non-club location input if already set
+  let lat=null,lng=null;
+  const locInp=document.getElementById('mLocFreeInput');
+  if(locInp && locInp.dataset.lat && locInp.dataset.lng){ lat=locInp.dataset.lat; lng=locInp.dataset.lng; }
+  btn && (btn.disabled=true);
+  setStatus('Locating…');
+  try{
+    if(lat==null){
+      const pos=await new Promise((res,rej)=>navigator.geolocation.getCurrentPosition(res,rej,{enableHighAccuracy:false,timeout:10000}));
+      lat=pos.coords.latitude.toFixed(4); lng=pos.coords.longitude.toFixed(4);
+    }
+    setStatus('Fetching weather…');
+    const cur='wind_speed_10m,wind_direction_10m,wind_gusts_10m,temperature_2m,apparent_temperature,surface_pressure';
+    const url=`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current=${cur}&wind_speed_unit=ms&timezone=auto`;
+    const marineUrl=`https://marine-api.open-meteo.com/v1/marine?latitude=${lat}&longitude=${lng}&current=wave_height,sea_surface_temperature&timezone=auto`;
+    const [wxRes,marRes]=await Promise.all([
+      fetch(url).then(r=>r.ok?r.json():null).catch(()=>null),
+      fetch(marineUrl).then(r=>r.ok?r.json():null).catch(()=>null),
+    ]);
+    const c=wxRes&&wxRes.current;
+    if(!c){ setStatus('Could not fetch weather',true); btn&&(btn.disabled=false); return; }
+    function setVal(id,v){ const el=document.getElementById(id); if(el && v!=null && v!==''){ el.value=v; } }
+    // Wind speed: convert m/s into user's display unit
+    if(c.wind_speed_10m!=null){
+      const ws=convertWind(c.wind_speed_10m, _mWindUnit);
+      setVal('mWindMs', ws);
+      onWindInput(); // sync Beaufort
+    }
+    if(c.wind_gusts_10m!=null) setVal('mWindGust', convertWind(c.wind_gusts_10m, _mWindUnit));
+    if(c.wind_direction_10m!=null){
+      const dirs=['N','NE','E','SE','S','SW','W','NW'];
+      const idx=Math.round(((c.wind_direction_10m%360)+360)%360/45)%8;
+      setVal('mWindDir', dirs[idx]);
+    }
+    if(c.temperature_2m!=null) setVal('mAirTemp', c.temperature_2m.toFixed(1));
+    if(c.apparent_temperature!=null) setVal('mFeelsLike', c.apparent_temperature.toFixed(1));
+    if(c.surface_pressure!=null) setVal('mPressure', Math.round(c.surface_pressure));
+    const m=marRes&&marRes.current;
+    if(m){
+      if(m.wave_height!=null) setVal('mWave', m.wave_height.toFixed(1));
+      if(m.sea_surface_temperature!=null) setVal('mSeaTemp', m.sea_surface_temperature.toFixed(1));
+    }
+    setStatus('Weather loaded ✓');
+  }catch(e){
+    setStatus('Location denied or unavailable',true);
+  }finally{
+    btn && (btn.disabled=false);
+  }
+}
+
 // ── Wind unit + Beaufort sync helpers ────────────────────────────────────────
 // Determine the numeric wind unit for manual inputs (bft pref → default to m/s for inputs)
 let _mWindUnit = (function(){ var p = getPref('windUnit','bft'); return p === 'bft' ? 'ms' : p; })();


### PR DESCRIPTION
- Pair Boat and Location into a single row for club trips so the primary fields read as one logical group.
- Re-introduce the "Use my location" action under the non-club location field, restyled as a subtle inline link rather than a pill button.
- Add a "Use current weather" action in the weather section that uses the browser geolocation API + Open-Meteo (forecast + marine) to populate Beaufort, wind speed/gusts/direction, air/feels-like temperature, sea temperature, wave height and pressure.