### PR TITLE
Add Request Verification button to trip cards

### DIFF
--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -336,6 +336,7 @@ function tripCard(t){
     ${canEditTrip ? `<button class="trip-action-btn primary" onclick="event.stopPropagation();openEditTrip('${esc(t.id)}')">${s('tc.editTrip')}</button>` : ''}
     ${!t.trackFileUrl ? `<button class="trip-action-btn" onclick="event.stopPropagation();inlineUploadTrack('${esc(t.id)}')">${s('tc.addGps')}</button>` : ''}
     <button class="trip-action-btn" onclick="event.stopPropagation();inlineUploadPhotos('${esc(t.id)}')">${s('tc.addPhotos')}</button>
+    ${(!isVer && !t.validationRequested && !_confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) ? `<button class="trip-action-btn" onclick="event.stopPropagation();requestTripValidation('${esc(t.id)}')">${s('tc.requestVerification')}</button>` : ''}
   </div>` : '';
   const hasWeather = !!(eWs||eDir||eGust||eCond||eAir||eFeel||eSst||eWv||ePres||eFlag);
   const hasNotes   = !!(skipperNoteRow||notesRow||photosRow||trackRow||isOwner||actionsRow);

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1250,6 +1250,7 @@ var _STRINGS_FLAT = {
   "tc.nonClub": "Non-club",
   "tc.pending": "pending",
   "tc.verificationPending": "Verification pending",
+  "tc.requestVerification": "Request verification",
   "tc.windSpeed": "Wind speed",
   "tc.direction": "Direction",
   "tc.gusts": "Gusts",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1250,6 +1250,7 @@ var _STRINGS_FLAT = {
   "tc.nonClub": "Utan félags",
   "tc.pending": "í bið",
   "tc.verificationPending": "Staðfesting í bið",
+  "tc.requestVerification": "Óska eftir staðfestingu",
   "tc.windSpeed": "Vindhraði",
   "tc.direction": "Átt",
   "tc.gusts": "Vindhviður",


### PR DESCRIPTION
The requestTripValidation() helper existed in shared/logbook.js but had no UI entry point, so members and non-captain skippers had no way to submit a trip for staff/captain validation. Add an action button on unverified, owned trips that calls it, plus the en/is string. Captain keelboat trips continue to auto-verify via tryAutoVerify_ once all handshakes resolve.

Fixes #350