### PR TITLE
Fix unresponsive daily log page from duplicate activity-type click ha…

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -641,13 +641,6 @@ document.addEventListener('DOMContentLoaded', () => {
     markDirty();
   });
 
-  dom.actTypeBtns.addEventListener('click', e => {
-    const btn = e.target.closest('[data-type-id]');
-    if (!btn) return;
-    _selectedActType = btn.dataset.typeId;
-    dom.actTypeBtns.querySelectorAll('.type-btn').forEach(b => b.classList.toggle('selected', b === btn));
-  });
-
   dom.tripsCard.addEventListener('click', e => {
     const row = e.target.closest('[data-trip-id]');
     if (!row) return;


### PR DESCRIPTION
…ndlers

The activity type buttons had both an inline click handler (which calls renderActTypeBtns and populateActSubtypes) and a delegated listener on the container. The delegated handler fired on the same click via bubbling after the inline handler had already replaced the buttons, leaving the UI in an inconsistent state. Remove the redundant delegated handler.