### PR TITLE
Add fetch timeout and surface load errors on daily log

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -956,6 +956,9 @@ async function loadTodayLog() {
     renderIncidentSection(incidents);
   } catch(e) {
     console.warn('loadTodayLog failed:', e.message);
+    ['tripsCard','amCard','pmCard'].forEach(id => {
+      dom[id].innerHTML = '<div class="empty-state">Could not load: ' + (e && e.message ? e.message : 'network error') + '</div>';
+    });
   }
   renderChecklists();
   renderActivities();

--- a/shared/api.js
+++ b/shared/api.js
@@ -74,16 +74,26 @@ async function apiPost(action, payload) {
 async function _call(action, payload) {
   payload = payload || {};
   var body = JSON.stringify(Object.assign({ action: action, token: API_TOKEN }, payload));
-  var res  = await fetch(SCRIPT_URL, {
-    method:   "POST",
-    redirect: "follow",
-    headers:  { "Content-Type": "text/plain" },
-    body:     body,
-  });
-  if (!res.ok) throw new Error("HTTP " + res.status);
-  var data = await res.json();
-  if (!data.success) throw new Error(data.error || action + " failed");
-  return data;
+  var ctrl = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+  var timer = ctrl ? setTimeout(function() { ctrl.abort(); }, 20000) : null;
+  try {
+    var res = await fetch(SCRIPT_URL, {
+      method:   "POST",
+      redirect: "follow",
+      headers:  { "Content-Type": "text/plain" },
+      body:     body,
+      signal:   ctrl ? ctrl.signal : undefined,
+    });
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    var data = await res.json();
+    if (!data.success) throw new Error(data.error || action + " failed");
+    return data;
+  } catch (e) {
+    if (e && e.name === 'AbortError') throw new Error(action + " timed out");
+    throw e;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 var AUTH_KEY = "ymirUser";


### PR DESCRIPTION
The Apps Script fetch had no timeout, so a slow/unreachable backend left the daily log page on spinners forever with no console errors. Add a 20s AbortController timeout to _call and render the error in the cards instead of only console.warn.