### PR TITLE
Temporarily disable tide widget on daily log to isolate CPU hang

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -887,6 +887,7 @@ function populateTideFields() {
 }
 
 function _autoFillTide() {
+  return; // TEMP DISABLED: investigating runaway CPU hang on daily log page
   if (typeof tideExtrema !== 'function') return;
   const extrema = tideExtrema(viewDate);
   tideData = tideToDailyLog(extrema);
@@ -894,6 +895,7 @@ function _autoFillTide() {
 
 let _tideWidgetInstance = null;
 function _renderDailyTide() {
+  return; // TEMP DISABLED: investigating runaway CPU hang on daily log page
   const el = document.getElementById('dailyTideWidget');
   if (!el || typeof tideWidget !== 'function') return;
   if (!_tideWidgetInstance) {


### PR DESCRIPTION
Chrome task manager shows >100% CPU with no JS console responsiveness when loading the daily log page. Disable the synchronous tide widget call path as the prime suspect so we can verify whether it is the source of the runaway.