### PR TITLE
Re-enable tide widget and sanitize incident description on backend

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1581,7 +1581,7 @@ function createIncident_(b) {
     date: b.date || ts.slice(0, 10), time: b.time || ts.slice(11, 16),
     locationId: b.locationId || '', locationName: b.locationName || '',
     boatId: b.boatId || '', boatName: b.boatName || '',
-    description: b.description || '', involved: b.involved || '',
+    description: String(b.description == null ? '' : b.description), involved: b.involved || '',
     witnesses: b.witnesses || '', immediateAction: b.immediateAction || '',
     followUp: b.followUp || '', handOffTo: b.handOffTo || '',
     handOffName: b.handOffName || '', handOffNotes: b.handOffNotes || '',

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -901,7 +901,6 @@ function populateTideFields() {
 }
 
 function _autoFillTide() {
-  return; // TEMP DISABLED: investigating runaway CPU hang on daily log page
   if (typeof tideExtrema !== 'function') return;
   const extrema = tideExtrema(viewDate);
   tideData = tideToDailyLog(extrema);
@@ -909,7 +908,6 @@ function _autoFillTide() {
 
 let _tideWidgetInstance = null;
 function _renderDailyTide() {
-  return; // TEMP DISABLED: investigating runaway CPU hang on daily log page
   const el = document.getElementById('dailyTideWidget');
   if (!el || typeof tideWidget !== 'function') return;
   if (!_tideWidgetInstance) {
@@ -1001,19 +999,11 @@ async function loadPastLog() {
 }
 
 async function loadTodayTrips() {
-  console.log('[dailylog] loadTodayTrips: start');
   try {
-    console.log('[dailylog] loadTodayTrips: calling apiGet(getActiveCheckouts)');
     const res = await apiGet('getActiveCheckouts').then(r => { window._activeCheckouts = (r.checkouts||[]); return r; });
-    console.log('[dailylog] loadTodayTrips: apiGet resolved', res);
     tripsData = res.checkouts || [];
-    console.log('[dailylog] getActiveCheckouts returned',
-      Array.isArray(tripsData) ? tripsData.length + ' trips' : 'NON-ARRAY: ' + typeof tripsData,
-      tripsData);
-  } catch(e) { console.warn('[dailylog] getActiveCheckouts failed:', e); tripsData = []; }
-  console.log('[dailylog] loadTodayTrips: calling renderTrips with', tripsData.length, 'trips');
+  } catch(e) { tripsData = []; }
   renderTrips();
-  console.log('[dailylog] loadTodayTrips: renderTrips returned');
 }
 
 async function loadPastTrips() {


### PR DESCRIPTION
The daily log CPU hang is fixed by coercing inc.description to a string before slicing (previous commit). Restore the tide widget calls that were temporarily disabled during debugging, drop the diagnostic logging from loadTodayTrips, and also coerce description to a string in saveIncident on the backend so no client ever sees a non-string value.