### PR TITLE
add rowing passport with auto-promotion to released rower

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -232,6 +232,7 @@
         <button class="tab-btn"        data-tab="flags"      onclick="showTab('flags')"      data-s="admin.tabFlags"></button>
         <button class="tab-btn"        data-tab="alerts"     onclick="showTab('alerts')"     data-s="admin.tabAlerts"></button>
         <button class="tab-btn"        data-tab="slotCal"    onclick="showTab('slotCal')"    data-s="admin.tabReservations"></button>
+        <button class="tab-btn"        data-tab="passport"   onclick="showTab('passport')"   data-s="passport.adminTitle">Rowing Passport</button>
       </div>
 
     <!-- ══ BOATS ════════════════════════════════════════════════════════════ -->
@@ -490,6 +491,25 @@
         <span id="fcSaveMsg" style="font-size:11px;margin-left:4px"></span>
       </div>
     </div><!-- /tab-flags -->
+
+    <!-- ══ ROWING PASSPORT ═════════════════════════════════════════════════ -->
+    <div id="tab-passport" class="hidden">
+      <div class="col-section">
+        <div class="col-head open" onclick="toggleSection(this)">
+          <div class="col-title" data-s="passport.adminTitle">Rowing Passport</div>
+          <span class="col-toggle open">▼</span>
+        </div>
+        <div class="col-body" id="passportAdminCard">
+          <div style="font-size:11px;color:var(--muted);margin-bottom:10px;line-height:1.5" data-s="passport.csvHelp"></div>
+          <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
+            <input type="file" id="passportCsvFile" accept=".csv,text/csv" style="font-size:11px">
+            <button class="btn btn-primary" style="font-size:11px" onclick="passportImportCsv()" data-s="passport.importCsv">Import CSV</button>
+            <button class="btn btn-secondary" style="font-size:11px" onclick="passportExportCsv()" data-s="passport.exportCsv">Export CSV</button>
+          </div>
+          <div id="passportAdminPreview" style="font-size:11px"></div>
+        </div>
+      </div>
+    </div>
 
     <!-- ══ RESERVATION SLOT CALENDAR ════════════════════════════════════════ -->
     <div id="tab-slotCal" class="hidden">
@@ -1179,6 +1199,7 @@ function showTab(tab) {
 
   if (tab === 'certs') renderCertDefs();
   if (tab === 'slotCal') initSlotCalendar();
+  if (tab === 'passport') renderPassportAdmin();
 
   const url = new URL(window.location.href);
   url.searchParams.set('tab', tab);
@@ -3144,6 +3165,68 @@ async function saveRecurringSlots() {
     toast(s('slot.created', { count: res.count || 0 }));
     loadSlotCalendar();
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// ── ROWING PASSPORT ADMIN ─────────────────────────────────────────────────────
+async function renderPassportAdmin() {
+  const card = document.getElementById('passportAdminPreview');
+  card.innerHTML = '<div class="loading-state"><span class="spinner"></span></div>';
+  try {
+    const res = await apiGet('getRowingPassport', {});
+    const def = res.definition || { passports: [] };
+    let html = '';
+    (def.passports || []).forEach(p => {
+      const totalItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => !i.retired).length, 0);
+      const retiredItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => i.retired).length, 0);
+      html += `<div style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:10px">
+        <div style="font-weight:600;margin-bottom:4px">${esc(p.name?.EN || p.id)} <span style="color:var(--muted);font-weight:400;font-size:10px">(${p.id})</span></div>
+        <div style="font-size:10px;color:var(--muted);margin-bottom:8px">v${def.version || 1} · ${totalItems} active items${retiredItems ? ' · ' + retiredItems + ' retired' : ''} · requires ${p.requiredSigs || 2} signatures</div>`;
+      (p.categories || []).forEach(cat => {
+        html += `<div style="margin-top:8px"><div style="font-size:10px;color:var(--brass);letter-spacing:.5px;text-transform:uppercase;margin-bottom:4px">${esc(cat.name?.EN || cat.id)}</div>`;
+        (cat.items || []).forEach(it => {
+          html += `<div style="font-size:11px;padding:3px 0;${it.retired ? 'opacity:.5;text-decoration:line-through' : ''}">• ${esc(it.name?.EN || it.id)} <span style="color:var(--muted);font-size:9px">${esc(it.id)}</span></div>`;
+        });
+        html += '</div>';
+      });
+      html += '</div>';
+    });
+    card.innerHTML = html || '<div class="empty-note">No passport defined.</div>';
+  } catch(e) { card.innerHTML = '<div style="color:var(--red)">' + esc(e.message) + '</div>'; }
+}
+
+async function passportImportCsv() {
+  const file = document.getElementById('passportCsvFile').files[0];
+  if (!file) { toast('Choose a CSV file first', 'err'); return; }
+  const text = await file.text();
+  if (!confirm('Import this CSV? Items missing from the CSV will be marked retired (not deleted).')) return;
+  try {
+    await apiPost('importRowingPassportCsv', { csv: text });
+    toast('Passport imported.');
+    renderPassportAdmin();
+  } catch(e) { toast(e.message, 'err'); }
+}
+
+async function passportExportCsv() {
+  try {
+    const res = await apiGet('getRowingPassport', {});
+    const def = res.definition || { passports: [] };
+    const lines = ['passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is'];
+    const q = v => '"' + String(v || '').replace(/"/g,'""') + '"';
+    (def.passports || []).forEach(p => {
+      (p.categories || []).forEach(cat => {
+        (cat.items || []).forEach(it => {
+          if (it.retired) return;
+          lines.push([p.id, cat.id, cat.name?.EN || '', cat.name?.IS || '', it.id, it.name?.EN || '', it.name?.IS || '', it.desc?.EN || '', it.desc?.IS || ''].map(q).join(','));
+        });
+      });
+    });
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'rowing-passport.csv';
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch(e) { toast(e.message, 'err'); }
 }
 
 // ── Utilities ──────────────────────────────────────────────────────────────────

--- a/code.gs
+++ b/code.gs
@@ -32,6 +32,7 @@ const TABS_ = {
   reservationSlots: 'reservation_slots',
   crews: 'crews',
   crewInvites: 'crew_invites',
+  passportSignoffs: 'passport_signoffs',
 };
 
 const CLUB_LANG_ = 'IS';
@@ -418,6 +419,12 @@ function route_(action, b) {
     case 'inviteToCrew':          return inviteToCrew_(b);
     case 'respondCrewInvite':     return respondCrewInvite_(b);
     case 'getCrewInvites':        return getCrewInvites_(b);
+    // ── ROWING PASSPORT ───────────────────────────────────────────────────────
+    case 'getRowingPassport':       return getRowingPassport_(b);
+    case 'saveRowingPassportDef':   return saveRowingPassportDef_(b);
+    case 'signPassportItem':        return signPassportItem_(b);
+    case 'revokePassportSignoff':   return revokePassportSignoff_(b);
+    case 'importRowingPassportCsv': return importRowingPassportCsv_(b);
     case 'saveCaptainBio': return saveCaptainBio_(b);
     case 'uploadHeadshot': return uploadHeadshot_(b);
     case 'getTrips': return getTrips_(b.kennitala, parseInt(b.limit) || 100, b);
@@ -1279,7 +1286,13 @@ function getConfig_() {
     keelboatCalendarId: getConfigValue_('keelboatCalendarId', cfgMap) || '',
     keelboatCalendarSyncActive: getConfigValue_('keelboatCalendarSyncActive', cfgMap) === 'true',
   };
-  const config = { activityTypes, dailyChecklist, overdueAlerts, flagConfig, certDefs, certCategories, boats, locations, launchChecklists, boatCategories, staffStatus, allowBreaks, charterCalendars };
+  let rowingPassport = null;
+  try {
+    const rpRaw = getConfigValue_('rowingPassport', cfgMap);
+    if (rpRaw) rowingPassport = JSON.parse(rpRaw);
+  } catch (e) {}
+  if (!rowingPassport) rowingPassport = DEFAULT_ROWING_PASSPORT_();
+  const config = { activityTypes, dailyChecklist, overdueAlerts, flagConfig, certDefs, certCategories, boats, locations, launchChecklists, boatCategories, staffStatus, allowBreaks, charterCalendars, rowingPassport };
   cPut_('config', config);
   return okJ(config);
 }
@@ -1330,6 +1343,10 @@ function saveConfig_(b) {
   }
   if (b.boatCategories)    { setConfigSheetValue_('boatCategories',    JSON.stringify(b.boatCategories));    }
 
+  if (b.rowingPassport !== undefined) {
+    setConfigSheetValue_('rowingPassport', JSON.stringify(b.rowingPassport));
+    saved.rowingPassport = true;
+  }
   if (b.activityTypes) { setConfigSheetValue_('activity_types', JSON.stringify(b.activityTypes)); saved.activityTypes = true; }
   if (b.allowBreaks !== undefined) { setConfigSheetValue_('allowBreaks', b.allowBreaks ? 'true' : 'false'); saved.allowBreaks = true; }
   cDel_('config');
@@ -4987,6 +5004,12 @@ var SCHEMA_ = {
     'toKennitala','toName',
     'status','createdAt','respondedAt',
   ],
+  passport_signoffs: [
+    'id','memberId','passportId','itemId',
+    'signerId','signerName','signerRole',
+    'timestamp','note',
+    'revokedBy','revokedAt','revokeReason',
+  ],
   config: ['key','value'],
   employees: [
     'id','kt','name','title','bankAccount','orlofsreikningur',
@@ -5199,5 +5222,392 @@ function addReservationAndCrewTabs() {
   Logger.log('crews tab ready');
   ensureTab_(ss, 'crew_invites', SCHEMA_.crew_invites);
   Logger.log('crew_invites tab ready');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ROWING PASSPORT
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Definition lives in config key 'rowingPassport' (JSON). Sign-offs live in the
+// passport_signoffs sheet (append-only with revocation columns). A passport item
+// is "complete" when it has >= requiredSigs (default 2) non-revoked signatures
+// from distinct signers. When ALL non-retired items in the rower passport are
+// complete, the member is auto-promoted from rowing_division/restricted ->
+// rowing_division/released.
+//
+// Stable identifiers: passport.id ('rower'), category.id, item.id. Labels are
+// editable; ids must never change once a sign-off references them.
+
+function DEFAULT_ROWING_PASSPORT_() {
+  return {
+    version: 1,
+    passports: [
+      {
+        id: 'rower',
+        name: { EN: 'Rower Passport', IS: 'Ræðarapassi' },
+        promoteCertId: 'rowing_division',
+        fromSub: 'restricted',
+        toSub: 'released',
+        requiredSigs: 2,
+        categories: [
+          {
+            id: 'safety',
+            name: { EN: 'Safety', IS: 'Öryggi' },
+            items: [
+              { id: 'pfd-use',          name: { EN: 'PFD use & fitting',        IS: 'Notkun og stilling björgunarvestis' }, desc: { EN: '', IS: '' } },
+              { id: 'capsize-recovery', name: { EN: 'Capsize recovery',         IS: 'Endurheimt eftir hvolfi' },             desc: { EN: '', IS: '' } },
+              { id: 'cold-water',       name: { EN: 'Cold water awareness',     IS: 'Þekking á köldu vatni' },               desc: { EN: '', IS: '' } },
+            ],
+          },
+          {
+            id: 'boat-handling',
+            name: { EN: 'Boat handling', IS: 'Bátastjórnun' },
+            items: [
+              { id: 'launching',     name: { EN: 'Launching & landing',     IS: 'Sjósetning og lending' }, desc: { EN: '', IS: '' } },
+              { id: 'steering',      name: { EN: 'Steering straight',       IS: 'Bein stýring' },          desc: { EN: '', IS: '' } },
+              { id: 'stopping',      name: { EN: 'Stopping & emergency stop', IS: 'Stöðvun og neyðarstöðvun' }, desc: { EN: '', IS: '' } },
+            ],
+          },
+          {
+            id: 'etiquette',
+            name: { EN: 'Etiquette & comms', IS: 'Siðir og samskipti' },
+            items: [
+              { id: 'right-of-way', name: { EN: 'Right of way',     IS: 'Forgangur' },     desc: { EN: '', IS: '' } },
+              { id: 'radio-checkin', name: { EN: 'Radio check-in', IS: 'Talstöðvarinnskráning' }, desc: { EN: '', IS: '' } },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function getRowingPassport_(b) {
+  // Returns: { definition, progress (if memberId provided) }
+  const cfgMap = getConfigMap_();
+  let def = null;
+  try {
+    const raw = getConfigValue_('rowingPassport', cfgMap);
+    if (raw) def = JSON.parse(raw);
+  } catch (e) {}
+  if (!def) def = DEFAULT_ROWING_PASSPORT_();
+
+  const result = { definition: def };
+  if (b && b.memberId) {
+    result.progress = computePassportProgress_(b.memberId, def);
+  }
+  return okJ(result);
+}
+
+function computePassportProgress_(memberId, def) {
+  const all = readAll_('passportSignoffs') || [];
+  const mine = all.filter(r => String(r.memberId) === String(memberId) && !r.revokedAt);
+  // Group by passportId + itemId
+  const byKey = {};
+  mine.forEach(r => {
+    const k = (r.passportId || 'rower') + '::' + r.itemId;
+    if (!byKey[k]) byKey[k] = [];
+    byKey[k].push({
+      id: r.id, signerId: r.signerId, signerName: r.signerName,
+      signerRole: r.signerRole, timestamp: r.timestamp, note: r.note || '',
+    });
+  });
+  const out = { passports: {} };
+  (def.passports || []).forEach(p => {
+    const required = Number(p.requiredSigs || 2);
+    const items = {};
+    let completeCount = 0, totalCount = 0;
+    (p.categories || []).forEach(cat => {
+      (cat.items || []).forEach(it => {
+        if (it.retired) return;
+        totalCount++;
+        const sigs = byKey[p.id + '::' + it.id] || [];
+        const distinct = {};
+        sigs.forEach(s => { if (s.signerId) distinct[s.signerId] = s; });
+        const distinctCount = Object.keys(distinct).length;
+        const complete = distinctCount >= required;
+        if (complete) completeCount++;
+        items[it.id] = { signoffs: sigs, complete, distinctSigners: distinctCount, required };
+      });
+    });
+    out.passports[p.id] = { items, totalCount, completeCount, percent: totalCount ? Math.round(100 * completeCount / totalCount) : 0 };
+  });
+  return out;
+}
+
+function signPassportItem_(b) {
+  if (!b.memberId)  return failJ('memberId required');
+  if (!b.itemId)    return failJ('itemId required');
+  if (!b.signerId)  return failJ('signerId required');
+  const passportId = b.passportId || 'rower';
+
+  // Verify signer is staff (or released rower) — reuse existing signer record
+  const signer = readAll_('members').find(m => String(m.id) === String(b.signerId) || String(m.kennitala) === String(b.signerId));
+  if (!signer) return failJ('Signer not found', 404);
+  const signerRole = (signer.role || '').toString().toLowerCase();
+  let signerCerts = [];
+  try { signerCerts = JSON.parse(signer.certifications || '[]'); } catch (e) {}
+  const isStaff = signerRole === 'staff' || signerRole === 'admin' || signerRole === 'manager';
+  const isReleased = signerCerts.some(c => c.certId === 'rowing_division' && (c.sub === 'released' || c.sub === 'coxswain'));
+  if (!isStaff && !isReleased) return failJ('Signer not authorised to sign passport items', 403);
+
+  // Refuse self-sign
+  if (String(signer.id) === String(b.memberId) || String(signer.kennitala) === String(b.memberId)) {
+    return failJ('Cannot sign your own passport', 403);
+  }
+
+  // Verify item exists in current definition
+  const cfgMap = getConfigMap_();
+  let def = null;
+  try { const raw = getConfigValue_('rowingPassport', cfgMap); if (raw) def = JSON.parse(raw); } catch (e) {}
+  if (!def) def = DEFAULT_ROWING_PASSPORT_();
+  const passport = (def.passports || []).find(p => p.id === passportId);
+  if (!passport) return failJ('Unknown passport: ' + passportId, 404);
+  let item = null;
+  (passport.categories || []).forEach(c => (c.items || []).forEach(i => { if (i.id === b.itemId) item = i; }));
+  if (!item) return failJ('Unknown item: ' + b.itemId, 404);
+  if (item.retired) return failJ('Item retired', 410);
+
+  // Refuse duplicate sign by same signer for same item (non-revoked)
+  const existing = (readAll_('passportSignoffs') || [])
+    .filter(r => !r.revokedAt && String(r.memberId) === String(b.memberId)
+              && r.passportId === passportId && r.itemId === b.itemId
+              && String(r.signerId) === String(signer.id));
+  if (existing.length) return failJ('You have already signed this item', 409);
+
+  insertRow_('passportSignoffs', {
+    id: uid_(),
+    memberId: b.memberId,
+    passportId: passportId,
+    itemId: b.itemId,
+    signerId: signer.id,
+    signerName: signer.name || '',
+    signerRole: isStaff ? 'staff' : 'released_rower',
+    timestamp: now_(),
+    note: b.note || '',
+    revokedBy: '', revokedAt: '', revokeReason: '',
+  });
+
+  // Recompute progress and auto-promote if complete
+  const progress = computePassportProgress_(b.memberId, def);
+  let promoted = false;
+  const pProg = progress.passports[passportId];
+  if (pProg && pProg.totalCount > 0 && pProg.completeCount === pProg.totalCount) {
+    promoted = maybePromoteRower_(b.memberId, passport, signer.name || 'passport');
+  }
+  return okJ({ saved: true, progress, promoted });
+}
+
+function revokePassportSignoff_(b) {
+  if (!b.signoffId) return failJ('signoffId required');
+  const ok = updateRow_('passportSignoffs', 'id', b.signoffId, {
+    revokedBy: b.revokedBy || '',
+    revokedAt: now_(),
+    revokeReason: b.reason || '',
+  });
+  if (!ok) return failJ('Sign-off not found', 404);
+  return okJ({ revoked: true });
+}
+
+function maybePromoteRower_(memberId, passport, byName) {
+  const member = readAll_('members').find(m => String(m.id) === String(memberId));
+  if (!member) return false;
+  let certs = [];
+  try { certs = JSON.parse(member.certifications || '[]'); } catch (e) {}
+  if (!Array.isArray(certs)) certs = [];
+  const certId = passport.promoteCertId || 'rowing_division';
+  const toSub  = passport.toSub || 'released';
+  const fromSub = passport.fromSub || 'restricted';
+  const idx = certs.findIndex(c => c.certId === certId);
+  if (idx >= 0) {
+    if (certs[idx].sub === toSub || certs[idx].sub === 'coxswain') return false; // already at/above
+    certs[idx].sub = toSub;
+    certs[idx].verifiedBy = byName;
+    certs[idx].verifiedAt = now_();
+  } else {
+    certs.push({
+      certId: certId, sub: toSub, category: 'Club Endorsement',
+      assignedBy: byName, assignedAt: now_(), verifiedBy: byName, verifiedAt: now_(),
+      issuingAuthority: '', expires: false, expiresAt: '',
+      description: 'Auto-promoted on passport completion',
+    });
+  }
+  // Drop a stale 'restricted' record if duplicated
+  certs = certs.filter((c, i) => !(c.certId === certId && c.sub === fromSub && i !== idx));
+  updateRow_('members', 'id', memberId, { certifications: JSON.stringify(certs), updatedAt: now_() });
+  cDel_('members');
+  return true;
+}
+
+function saveRowingPassportDef_(b) {
+  if (!b.definition) return failJ('definition required');
+  // Minimal shape validation
+  const def = b.definition;
+  if (!Array.isArray(def.passports)) return failJ('definition.passports must be array');
+  setConfigSheetValue_('rowingPassport', JSON.stringify(def));
+  cDel_('config');
+  return okJ({ saved: true });
+}
+
+function importRowingPassportCsv_(b) {
+  // CSV columns: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is
+  // Existing items not present in CSV are marked retired (NOT deleted) so historical sign-offs remain valid.
+  if (!b.csv) return failJ('csv required');
+  const rows = parsePassportCsv_(b.csv);
+  if (!rows.length) return failJ('CSV is empty or unparseable');
+
+  // Load current def to preserve passport-level fields & retire missing items
+  const cfgMap = getConfigMap_();
+  let current = null;
+  try { const raw = getConfigValue_('rowingPassport', cfgMap); if (raw) current = JSON.parse(raw); } catch (e) {}
+  if (!current) current = DEFAULT_ROWING_PASSPORT_();
+
+  // Build new shape from CSV
+  const passports = {};
+  rows.forEach(r => {
+    const pid = r.passport_id || 'rower';
+    if (!passports[pid]) {
+      const existing = (current.passports || []).find(p => p.id === pid);
+      passports[pid] = existing
+        ? Object.assign({}, existing, { categories: [] })
+        : { id: pid, name: { EN: pid, IS: pid }, promoteCertId: 'rowing_division', fromSub: 'restricted', toSub: 'released', requiredSigs: 2, categories: [] };
+      passports[pid].categories = [];
+      passports[pid]._catIndex = {};
+    }
+    const p = passports[pid];
+    let cat = p._catIndex[r.category_id];
+    if (!cat) {
+      cat = { id: r.category_id, name: { EN: r.category_label_en || r.category_id, IS: r.category_label_is || r.category_label_en || r.category_id }, items: [] };
+      p._catIndex[r.category_id] = cat;
+      p.categories.push(cat);
+    }
+    cat.items.push({
+      id: r.item_id,
+      name: { EN: r.item_label_en || r.item_id, IS: r.item_label_is || r.item_label_en || r.item_id },
+      desc: { EN: r.description_en || '', IS: r.description_is || '' },
+    });
+  });
+
+  // Retire items present in old def but absent from CSV
+  (current.passports || []).forEach(oldP => {
+    const newP = passports[oldP.id];
+    if (!newP) {
+      // Whole passport removed — keep retired copy
+      passports[oldP.id] = Object.assign({}, oldP, {
+        categories: (oldP.categories || []).map(c => Object.assign({}, c, {
+          items: (c.items || []).map(i => Object.assign({}, i, { retired: true })),
+        })),
+      });
+      return;
+    }
+    const newItemIds = new Set();
+    newP.categories.forEach(c => c.items.forEach(i => newItemIds.add(i.id)));
+    (oldP.categories || []).forEach(oldCat => {
+      (oldCat.items || []).forEach(oldItem => {
+        if (!newItemIds.has(oldItem.id)) {
+          // Find or create the matching new category to host the retired item
+          let hostCat = newP.categories.find(c => c.id === oldCat.id);
+          if (!hostCat) {
+            hostCat = { id: oldCat.id, name: oldCat.name, items: [] };
+            newP.categories.push(hostCat);
+          }
+          hostCat.items.push(Object.assign({}, oldItem, { retired: true }));
+        }
+      });
+    });
+  });
+
+  // Strip _catIndex helpers
+  const newDef = { version: (current.version || 0) + 1, passports: Object.values(passports).map(p => {
+    const copy = Object.assign({}, p);
+    delete copy._catIndex;
+    return copy;
+  }) };
+
+  setConfigSheetValue_('rowingPassport', JSON.stringify(newDef));
+  cDel_('config');
+  return okJ({ saved: true, definition: newDef });
+}
+
+function parsePassportCsv_(text) {
+  const lines = String(text || '').split(/\r?\n/).filter(l => l.trim().length > 0);
+  if (lines.length < 2) return [];
+  const headers = splitCsvLine_(lines[0]).map(h => h.trim().toLowerCase());
+  const out = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = splitCsvLine_(lines[i]);
+    const row = {};
+    headers.forEach((h, j) => { row[h] = (cells[j] || '').trim(); });
+    if (row.item_id) out.push(row);
+  }
+  return out;
+}
+function splitCsvLine_(line) {
+  const out = [];
+  let cur = '', q = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (q) {
+      if (ch === '"' && line[i+1] === '"') { cur += '"'; i++; }
+      else if (ch === '"') { q = false; }
+      else { cur += ch; }
+    } else {
+      if (ch === '"') { q = true; }
+      else if (ch === ',' || ch === ';') { out.push(cur); cur = ''; }
+      else { cur += ch; }
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+// One-shot migration: convert legacy 'released_rower' cert assignments to
+// rowing_division sub 'released'; ensure all rowing_division members have a sub.
+// Run manually from the Apps Script editor.
+function migrateRowingDivisionToSubcats() {
+  const sheet = getSheet_('members');
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const certIdx = headers.indexOf('certifications');
+  if (certIdx < 0) throw new Error('certifications column missing');
+  let changed = 0;
+  for (let r = 1; r < data.length; r++) {
+    const raw = data[r][certIdx];
+    if (!raw) continue;
+    let certs;
+    try { certs = JSON.parse(raw); } catch (e) { continue; }
+    if (!Array.isArray(certs)) continue;
+    const hasReleasedLegacy = certs.some(c => c.certId === 'released_rower');
+    const rdIdx = certs.findIndex(c => c.certId === 'rowing_division');
+    let didChange = false;
+
+    if (rdIdx >= 0 && !certs[rdIdx].sub) {
+      certs[rdIdx].sub = hasReleasedLegacy ? 'released' : 'restricted';
+      didChange = true;
+    } else if (rdIdx < 0 && hasReleasedLegacy) {
+      certs.push({
+        certId: 'rowing_division', sub: 'released', category: 'Club Endorsement',
+        assignedBy: 'migration', assignedAt: now_(), verifiedBy: 'migration', verifiedAt: now_(),
+        issuingAuthority: '', expires: false, expiresAt: '', description: '',
+      });
+      didChange = true;
+    }
+    if (hasReleasedLegacy) {
+      certs = certs.filter(c => c.certId !== 'released_rower');
+      didChange = true;
+    }
+    if (didChange) {
+      sheet.getRange(r + 1, certIdx + 1).setValue(JSON.stringify(certs));
+      changed++;
+    }
+  }
+  cDel_('members');
+  Logger.log('migrated ' + changed + ' members');
+}
+
+function ensurePassportSignoffsTab() {
+  const ss = SpreadsheetApp.openById(SHEET_ID_);
+  ensureTab_(ss, 'passport_signoffs', SCHEMA_.passport_signoffs);
+  Logger.log('passport_signoffs tab ready');
 }
 

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -73,6 +73,22 @@
 .cb-needs { font-size:10px; color:var(--brass); margin-top:6px; }
 .cb-color-dot { width:10px; height:10px; border-radius:50%; flex-shrink:0; }
 
+/* ── Passport ── */
+.pp-cat { margin-bottom:14px; }
+.pp-cat-hdr { font-size:10px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; margin-bottom:6px; display:flex; align-items:center; gap:8px; }
+.pp-cat-count { font-size:9px; color:var(--brass); }
+.pp-item { display:flex; align-items:flex-start; gap:10px; background:var(--card); border:1px solid var(--border); border-radius:6px; padding:8px 12px; margin-bottom:4px; font-size:11px; }
+.pp-item-signable { cursor:pointer; transition:border-color .15s; }
+.pp-item-signable:hover { border-color:var(--brass); }
+.pp-item-complete { border-left:3px solid var(--green); }
+.pp-item-icon { font-size:14px; color:var(--brass); width:18px; text-align:center; flex-shrink:0; }
+.pp-item-complete .pp-item-icon { color:var(--green); }
+.pp-item-body { flex:1; min-width:0; }
+.pp-item-name { color:var(--text); font-weight:500; }
+.pp-item-desc { color:var(--muted); font-size:10px; margin-top:2px; }
+.pp-item-sigs { color:var(--muted); font-size:9px; margin-top:3px; font-style:italic; }
+.pp-item-count { font-size:10px; color:var(--muted); flex-shrink:0; }
+
 /* ── Responsive ── */
 @media(max-width:600px){
   .cx-stats { grid-template-columns:1fr 1fr; }
@@ -96,6 +112,17 @@
 
   <!-- Read-only banner for non-released rowers -->
   <div class="cx-readonly hidden" id="cxReadOnly" data-s="cox.readOnly"></div>
+
+  <!-- ══ ROWING PASSPORT ══ -->
+  <div class="cx-section" id="sectPassport">
+    <div class="cx-section-hdr" data-s="passport.title">ROWING PASSPORT</div>
+    <div id="passportProgressBar" style="height:6px;background:var(--surface);border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-bottom:10px">
+      <div id="passportProgressFill" style="height:100%;width:0%;background:var(--brass);transition:width .3s"></div>
+    </div>
+    <div id="passportProgressLabel" style="font-size:10px;color:var(--muted);letter-spacing:.5px;margin-bottom:10px"></div>
+    <div id="passportSignerBanner" class="hidden" style="font-size:10px;color:var(--brass);background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 10px;margin-bottom:10px" data-s="passport.signerMode">Sign-off mode — tap items to sign.</div>
+    <div id="passportCategories"><div class="empty-note" data-s="lbl.loading"></div></div>
+  </div>
 
   <!-- ══ YTD STATS ══ -->
   <div class="cx-stats" id="cxStats">
@@ -275,6 +302,8 @@
 const user = requireAuth();
 if (!user || !hasRowingEndorsement(user)) { window.location.href = '../member/'; throw new Error('No rowing endorsement'); }
 const _isReleasedRower = isReleasedRower(user);
+const _rowingSub = (typeof getRowingSub === 'function') ? getRowingSub(user) : (_isReleasedRower ? 'released' : 'restricted');
+const _isStaffSigner = ['staff','admin','manager'].indexOf(String(user.role || '').toLowerCase()) >= 0;
 
 // ══ Wait for deferred scripts (boats.js, certs.js, maintenance.js) ══════════
 document.addEventListener('DOMContentLoaded', function() {
@@ -282,6 +311,10 @@ document.addEventListener('DOMContentLoaded', function() {
 // ══ STATE ════════════════════════════════════════════════════════════════════
 var _boats = [], _locations = [], _members = [], _allMaint = [], _allTrips = [];
 var _membersLoaded = false;
+var _passportDef = null, _passportProgress = null;
+var _passportLang = (localStorage.getItem('ymirLang') || 'EN').toUpperCase();
+var _passportSignerMode = false;
+var _passportTargetMemberId = user.id; // own passport by default
 
 // ══ INIT ═════════════════════════════════════════════════════════════════════
 (async function init() {
@@ -295,14 +328,24 @@ var _membersLoaded = false;
     document.getElementById('cxReadOnly').classList.remove('hidden');
   }
 
+  // Hide non-passport sections for restricted rowers
+  if (_rowingSub === 'restricted') {
+    var hideIds = ['sectMaint','sectCrews','sectSlots','cxStats'];
+    hideIds.forEach(function(id){ var el = document.getElementById(id); if (el) el.style.display = 'none'; });
+  }
+
   try {
-    const [cfgRes, maintRes, tripsRes, boardRes, invRes] = await Promise.all([
+    const [cfgRes, maintRes, tripsRes, boardRes, invRes, passportRes] = await Promise.all([
       apiGet('getConfig'),
       apiGet('getMaintenance'),
       apiGet('getTrips', { limit: 200 }),
       apiGet('getCrewBoard', {}),
       apiGet('getCrewInvites', { kennitala: user.kennitala }),
+      apiGet('getRowingPassport', { memberId: user.id }),
     ]);
+    _passportDef = passportRes.definition;
+    _passportProgress = passportRes.progress;
+    renderPassport();
 
     _boats     = (cfgRes.boats     || []);
     _locations = (cfgRes.locations || []).filter(l => l.active !== false && l.active !== 'false');
@@ -910,6 +953,76 @@ function cxWeekToday() {
   _cxWeekStart = d;
   loadCxSlots();
 }
+
+// ══ ROWING PASSPORT ══════════════════════════════════════════════════════════
+function _passportLocal(obj) {
+  if (!obj) return '';
+  if (typeof obj === 'string') return obj;
+  return obj[_passportLang] || obj.EN || obj.IS || '';
+}
+function renderPassport() {
+  if (!_passportDef) return;
+  var passport = (_passportDef.passports || []).find(function(p){ return p.id === 'rower'; });
+  if (!passport) { document.getElementById('passportCategories').innerHTML = ''; return; }
+  var prog = (_passportProgress && _passportProgress.passports && _passportProgress.passports.rower) || { items: {}, totalCount: 0, completeCount: 0, percent: 0 };
+  document.getElementById('passportProgressFill').style.width = prog.percent + '%';
+  var label = prog.completeCount + ' / ' + prog.totalCount + ' (' + prog.percent + '%)';
+  if (_rowingSub !== 'restricted') label += ' — ' + s('passport.historyNote');
+  document.getElementById('passportProgressLabel').textContent = label;
+
+  // Show sign-mode banner if staff/released viewing someone else's passport
+  var canSign = (_isStaffSigner || _rowingSub === 'released' || _rowingSub === 'coxswain');
+  var signingSomeoneElse = canSign && String(_passportTargetMemberId) !== String(user.id);
+  document.getElementById('passportSignerBanner').classList.toggle('hidden', !signingSomeoneElse);
+
+  var html = '';
+  (passport.categories || []).forEach(function(cat) {
+    var items = (cat.items || []).filter(function(i){ return !i.retired; });
+    if (!items.length) return;
+    var catName = _passportLocal(cat.name);
+    var catDone = 0;
+    items.forEach(function(it){ if (prog.items[it.id] && prog.items[it.id].complete) catDone++; });
+    html += '<div class="pp-cat"><div class="pp-cat-hdr">' + _esc(catName) + ' <span class="pp-cat-count">' + catDone + '/' + items.length + '</span></div>';
+    items.forEach(function(it) {
+      var st = prog.items[it.id] || { signoffs: [], complete: false, distinctSigners: 0, required: passport.requiredSigs || 2 };
+      var name = _passportLocal(it.name);
+      var desc = _passportLocal(it.desc);
+      var icon = st.complete ? '✔' : (st.distinctSigners > 0 ? '◐' : '○');
+      var cls = 'pp-item' + (st.complete ? ' pp-item-complete' : '') + (signingSomeoneElse ? ' pp-item-signable' : '');
+      var sigText = st.distinctSigners + '/' + st.required;
+      var signersList = st.signoffs.map(function(so){ return _esc(so.signerName || '?') + ' · ' + String(so.timestamp || '').slice(0,10); }).join(' · ');
+      var onclick = signingSomeoneElse ? ' onclick="signPassportItemClick(\'' + it.id + '\')"' : '';
+      html += '<div class="' + cls + '"' + onclick + '>'
+        + '<div class="pp-item-icon">' + icon + '</div>'
+        + '<div class="pp-item-body"><div class="pp-item-name">' + _esc(name) + '</div>'
+        + (desc ? '<div class="pp-item-desc">' + _esc(desc) + '</div>' : '')
+        + (signersList ? '<div class="pp-item-sigs">' + signersList + '</div>' : '')
+        + '</div><div class="pp-item-count">' + sigText + '</div></div>';
+    });
+    html += '</div>';
+  });
+  document.getElementById('passportCategories').innerHTML = html;
+}
+function _esc(s) { return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+async function signPassportItemClick(itemId) {
+  if (!confirm(s('passport.confirmSign'))) return;
+  try {
+    var res = await apiPost('signPassportItem', {
+      memberId: _passportTargetMemberId,
+      passportId: 'rower',
+      itemId: itemId,
+      signerId: user.id,
+    });
+    _passportProgress = res.progress;
+    renderPassport();
+    if (res.promoted) showToast(s('passport.promoted'), 'ok');
+    else showToast(s('passport.signed'), 'ok');
+  } catch (e) {
+    showToast(e.message, 'err');
+  }
+}
+window.signPassportItemClick = signPassportItemClick;
 
 // ── Expose onclick handlers to global scope (they live inside DOMContentLoaded closure) ──
 window.openCrewModal = openCrewModal;

--- a/shared/api.js
+++ b/shared/api.js
@@ -118,18 +118,31 @@ function isCaptain(u) {
   var certs = typeof u.certifications === 'string' ? parseJson(u.certifications, []) : (u.certifications || []);
   return Array.isArray(certs) && certs.some(function(c) { return c.sub === 'captain' && _certNotExpired(c); });
 }
+// Returns the highest-rank rowing subcat key the user holds, or null.
+// One of: 'restricted' | 'released' | 'coxswain' | null.
+// Also recognises the legacy standalone 'released_rower' cert as 'released' (pre-migration).
+function getRowingSub(u) {
+  if (!u || !u.certifications) return null;
+  var certs = typeof u.certifications === 'string' ? parseJson(u.certifications, []) : (u.certifications || []);
+  if (!Array.isArray(certs)) return null;
+  var rank = { restricted: 1, released: 2, coxswain: 3 };
+  var best = null;
+  for (var i = 0; i < certs.length; i++) {
+    var c = certs[i];
+    if (!_certNotExpired(c)) continue;
+    var sub = null;
+    if (c.certId === 'rowing_division' && c.sub && rank[c.sub]) sub = c.sub;
+    else if (c.certId === 'released_rower' || c.sub === 'released_rower') sub = 'released'; // legacy
+    if (sub && (!best || rank[sub] > rank[best])) best = sub;
+  }
+  return best;
+}
 function isReleasedRower(u) {
-  if (!u || !u.certifications) return false;
-  var certs = typeof u.certifications === 'string' ? parseJson(u.certifications, []) : (u.certifications || []);
-  return Array.isArray(certs) && certs.some(function(c) { return (c.certId === 'released_rower' || c.sub === 'released_rower') && _certNotExpired(c); });
+  var sub = getRowingSub(u);
+  return sub === 'released' || sub === 'coxswain';
 }
-function hasRowingEndorsement(u) {
-  if (!u || !u.certifications) return false;
-  var certs = typeof u.certifications === 'string' ? parseJson(u.certifications, []) : (u.certifications || []);
-  return Array.isArray(certs) && certs.some(function(c) {
-    return (c.certId === 'rowing_division' || c.sub === 'rowing_division' || c.certId === 'released_rower' || c.sub === 'released_rower') && _certNotExpired(c);
-  });
-}
+function isCoxswain(u) { return getRowingSub(u) === 'coxswain'; }
+function hasRowingEndorsement(u) { return getRowingSub(u) !== null; }
 
 function signOut() {
   clearUser();

--- a/shared/certs.js
+++ b/shared/certs.js
@@ -5,8 +5,12 @@
 const DEFAULT_CERT_DEFS = [
   { id:'world_sailing', name:'World Sailing Certification', description:'', color:'', renewalDays:0,
     subcats:[{key:'ws1',label:'Level 1',description:'',rank:1},{key:'ws2',label:'Level 2',description:'',rank:2},{key:'ws3',label:'Level 3',description:'',rank:3}] },
-  { id:'rowing_division', name:'Rowing Division', description:'Member of the rowing division.', color:'', renewalDays:0, clubEndorsement:true, subcats:[] },
-  { id:'released_rower', name:'Released Rower', description:'Certified to row independently, form crews, and book slots.', color:'', renewalDays:0, clubEndorsement:true, subcats:[] },
+  { id:'rowing_division', name:'Rowing Division', description:'Member of the rowing division.', color:'', renewalDays:0, clubEndorsement:true,
+    subcats:[
+      {key:'restricted', label:'Restricted Rower', description:'Member of the rowing division. Must complete the rowing passport to be released.', rank:1},
+      {key:'released',   label:'Released Rower',   description:'Certified to row independently, form crews, and book slots.',                       rank:2},
+      {key:'coxswain',   label:'Coxswain',         description:'Authorized coxswain — may lead crews and supervise other rowers.',                  rank:3},
+    ]},
   { id:'support_boat_skipper', name:'Support Boat Skipper', description:'', color:'', renewalDays:0, subcats:[] },
   { id:'keelboat_crew', name:'Keelboat Crew', description:'Certified to sail on club keelboats.', color:'#d4af37', renewalDays:0, hasIdNumber:false,
     subcats:[

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1561,5 +1561,15 @@ var _STRINGS_FLAT = {
   "sauma.selectCategory": "Please select a category.",
   "sauma.selectPriority": "Please select a priority.",
   "sauma.describeProject": "Please describe the project.",
-  "sauma.selectBoat": "Please select a boat."
+  "sauma.selectBoat": "Please select a boat.",
+  "passport.title": "ROWING PASSPORT",
+  "passport.historyNote": "history",
+  "passport.signerMode": "Sign-off mode — tap items to sign.",
+  "passport.confirmSign": "Sign off this passport item?",
+  "passport.signed": "Signed off.",
+  "passport.promoted": "Passport complete — promoted to Released Rower!",
+  "passport.adminTitle": "Rowing Passport",
+  "passport.importCsv": "Import CSV",
+  "passport.exportCsv": "Export CSV",
+  "passport.csvHelp": "Columns: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is"
 };

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1561,5 +1561,15 @@ var _STRINGS_FLAT = {
   "sauma.selectCategory": "Vinsamlegast veldu flokk.",
   "sauma.selectPriority": "Vinsamlegast veldu forgang.",
   "sauma.describeProject": "Vinsamlegast lýstu verkefninu.",
-  "sauma.selectBoat": "Vinsamlegast veldu bát."
+  "sauma.selectBoat": "Vinsamlegast veldu bát.",
+  "passport.title": "RÆÐARAPASSI",
+  "passport.historyNote": "saga",
+  "passport.signerMode": "Undirritunarstilling — smelltu á atriði til að undirrita.",
+  "passport.confirmSign": "Undirrita þetta atriði?",
+  "passport.signed": "Undirritað.",
+  "passport.promoted": "Passi kláraður — uppfærð(ur) í Released Rower!",
+  "passport.adminTitle": "Ræðarapassi",
+  "passport.importCsv": "Flytja inn CSV",
+  "passport.exportCsv": "Flytja út CSV",
+  "passport.csvHelp": "Dálkar: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is"
 };


### PR DESCRIPTION
- Restructure rowing_division cert with restricted/released/coxswain ranked subcats; drop standalone released_rower def. Legacy assignments still recognised by getRowingSub() until migrateRowingDivisionToSubcats() is run from the Apps Script editor.
- New passport_signoffs sheet (append-only with revocation columns) and rowingPassport config key holding the editable definition. Default seed passport with 8 placeholder items across 3 categories ships in code.gs so the UI is testable before the real list is imported.
- Backend handlers: getRowingPassport, signPassportItem (staff or released rower signers, no self-sign, no double-sign, >=2 distinct sigs), revokePassportSignoff, saveRowingPassportDef, importRowingPassportCsv (retires rather than deletes missing items to preserve history). Completing all non-retired items auto-promotes the member from rowing_division/restricted to released.
- Coxswain page (rowing division landing) shows the passport for every rower; restricted rowers see only the passport section, released rowers keep maintenance/crews/slots and get a read-only passport history. Staff/released signers tap items to sign when viewing another member.
- Admin settings tab for the passport with CSV import/export and a preview of the current definition. CSV round-trip columns documented in passport.csvHelp string.