### PR TITLE
passport: add member picker, sign-off revocation, inline admin editor

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3168,31 +3168,109 @@ async function saveRecurringSlots() {
 }
 
 // ── ROWING PASSPORT ADMIN ─────────────────────────────────────────────────────
+let _passportDef = null;
+let _passportDirty = false;
+
 async function renderPassportAdmin() {
   const card = document.getElementById('passportAdminPreview');
   card.innerHTML = '<div class="loading-state"><span class="spinner"></span></div>';
   try {
     const res = await apiGet('getRowingPassport', {});
-    const def = res.definition || { passports: [] };
-    let html = '';
-    (def.passports || []).forEach(p => {
-      const totalItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => !i.retired).length, 0);
-      const retiredItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => i.retired).length, 0);
-      html += `<div style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:10px">
-        <div style="font-weight:600;margin-bottom:4px">${esc(p.name?.EN || p.id)} <span style="color:var(--muted);font-weight:400;font-size:10px">(${p.id})</span></div>
-        <div style="font-size:10px;color:var(--muted);margin-bottom:8px">v${def.version || 1} · ${totalItems} active items${retiredItems ? ' · ' + retiredItems + ' retired' : ''} · requires ${p.requiredSigs || 2} signatures</div>`;
-      (p.categories || []).forEach(cat => {
-        html += `<div style="margin-top:8px"><div style="font-size:10px;color:var(--brass);letter-spacing:.5px;text-transform:uppercase;margin-bottom:4px">${esc(cat.name?.EN || cat.id)}</div>`;
-        (cat.items || []).forEach(it => {
-          html += `<div style="font-size:11px;padding:3px 0;${it.retired ? 'opacity:.5;text-decoration:line-through' : ''}">• ${esc(it.name?.EN || it.id)} <span style="color:var(--muted);font-size:9px">${esc(it.id)}</span></div>`;
-        });
-        html += '</div>';
-      });
-      html += '</div>';
-    });
-    card.innerHTML = html || '<div class="empty-note">No passport defined.</div>';
+    _passportDef = res.definition || { version: 1, passports: [] };
+    _passportDirty = false;
+    drawPassportEditor();
   } catch(e) { card.innerHTML = '<div style="color:var(--red)">' + esc(e.message) + '</div>'; }
 }
+
+function drawPassportEditor() {
+  const card = document.getElementById('passportAdminPreview');
+  const def = _passportDef;
+  let html = '';
+  (def.passports || []).forEach((p, pi) => {
+    const totalItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => !i.retired).length, 0);
+    const retiredItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => i.retired).length, 0);
+    html += `<div style="border:1px solid var(--border);border-radius:6px;padding:12px;margin-bottom:12px">
+      <div style="font-weight:600;margin-bottom:4px">${esc(p.name?.EN || p.id)} <span style="color:var(--muted);font-weight:400;font-size:10px">(${p.id})</span></div>
+      <div style="font-size:10px;color:var(--muted);margin-bottom:10px">v${def.version || 1} · ${totalItems} active${retiredItems ? ' · ' + retiredItems + ' retired' : ''} · requires ${p.requiredSigs || 2} signatures</div>`;
+    (p.categories || []).forEach((cat, ci) => {
+      html += `<div style="margin-top:10px;border-top:1px solid var(--border);padding-top:8px">
+        <div style="display:flex;gap:6px;align-items:center;margin-bottom:6px">
+          <input type="text" value="${esc(cat.name?.EN || '')}" onchange="ppEditCatLabel(${pi},${ci},'EN',this.value)" placeholder="Category (EN)" style="font-size:11px;flex:1">
+          <input type="text" value="${esc(cat.name?.IS || '')}" onchange="ppEditCatLabel(${pi},${ci},'IS',this.value)" placeholder="Category (IS)" style="font-size:11px;flex:1">
+          <span style="color:var(--muted);font-size:9px">${esc(cat.id)}</span>
+        </div>`;
+      (cat.items || []).forEach((it, ii) => {
+        const retired = !!it.retired;
+        html += `<div style="display:grid;grid-template-columns:1fr 1fr 80px 70px;gap:6px;margin:4px 0;align-items:center;${retired ? 'opacity:.5' : ''}">
+          <input type="text" value="${esc(it.name?.EN || '')}" onchange="ppEditItem(${pi},${ci},${ii},'name','EN',this.value)" placeholder="Item (EN)" style="font-size:11px">
+          <input type="text" value="${esc(it.name?.IS || '')}" onchange="ppEditItem(${pi},${ci},${ii},'name','IS',this.value)" placeholder="Item (IS)" style="font-size:11px">
+          <span style="color:var(--muted);font-size:9px;overflow:hidden;text-overflow:ellipsis">${esc(it.id)}</span>
+          <button class="btn btn-secondary" style="font-size:10px;padding:3px 6px" onclick="ppToggleRetire(${pi},${ci},${ii})">${retired ? s('passport.unretire') : s('passport.retire')}</button>
+        </div>`;
+      });
+      html += `<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px;margin-top:4px" onclick="ppAddItem(${pi},${ci})" data-s="passport.addItem">+ Add item</button>
+      </div>`;
+    });
+    html += `<div style="margin-top:10px"><button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="ppAddCategory(${pi})" data-s="passport.addCategory">+ Add category</button></div>`;
+    html += '</div>';
+  });
+  html += `<div style="margin-top:12px;display:flex;gap:8px;align-items:center">
+    <button class="btn btn-primary" style="font-size:11px" onclick="ppSaveDef()" data-s="passport.save">Save changes</button>
+    <span id="ppDirtyMark" style="font-size:10px;color:var(--brass)">${_passportDirty ? '● unsaved' : ''}</span>
+  </div>`;
+  card.innerHTML = html;
+}
+
+function _ppMarkDirty() { _passportDirty = true; const m = document.getElementById('ppDirtyMark'); if (m) m.textContent = '● unsaved'; }
+function _ppSlug(s) { return String(s || '').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') || ('item-' + Date.now().toString(36)); }
+
+function ppEditCatLabel(pi, ci, lang, val) {
+  const cat = _passportDef.passports[pi].categories[ci];
+  cat.name = cat.name || {}; cat.name[lang] = val;
+  _ppMarkDirty();
+}
+function ppEditItem(pi, ci, ii, field, lang, val) {
+  const it = _passportDef.passports[pi].categories[ci].items[ii];
+  it[field] = it[field] || {}; it[field][lang] = val;
+  _ppMarkDirty();
+}
+function ppToggleRetire(pi, ci, ii) {
+  const it = _passportDef.passports[pi].categories[ci].items[ii];
+  it.retired = !it.retired;
+  _ppMarkDirty();
+  drawPassportEditor();
+}
+function ppAddItem(pi, ci) {
+  const label = prompt('Item name (English)'); if (!label) return;
+  const id = _ppSlug(label);
+  _passportDef.passports[pi].categories[ci].items.push({ id, name: { EN: label, IS: label }, desc: { EN: '', IS: '' } });
+  _ppMarkDirty();
+  drawPassportEditor();
+}
+function ppAddCategory(pi) {
+  const label = prompt('Category name (English)'); if (!label) return;
+  const id = _ppSlug(label);
+  _passportDef.passports[pi].categories.push({ id, name: { EN: label, IS: label }, items: [] });
+  _ppMarkDirty();
+  drawPassportEditor();
+}
+async function ppSaveDef() {
+  if (!_passportDef) return;
+  // Bump version on save
+  _passportDef.version = (_passportDef.version || 0) + 1;
+  try {
+    await apiPost('saveRowingPassportDef', { definition: _passportDef });
+    _passportDirty = false;
+    toast(s('passport.saved'));
+    renderPassportAdmin();
+  } catch(e) { toast(e.message, 'err'); }
+}
+window.ppEditCatLabel = ppEditCatLabel;
+window.ppEditItem = ppEditItem;
+window.ppToggleRetire = ppToggleRetire;
+window.ppAddItem = ppAddItem;
+window.ppAddCategory = ppAddCategory;
+window.ppSaveDef = ppSaveDef;
 
 async function passportImportCsv() {
   const file = document.getElementById('passportCsvFile').files[0];

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -116,6 +116,15 @@
   <!-- ══ ROWING PASSPORT ══ -->
   <div class="cx-section" id="sectPassport">
     <div class="cx-section-hdr" data-s="passport.title">ROWING PASSPORT</div>
+    <div id="passportPicker" class="hidden" style="margin-bottom:10px;position:relative">
+      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+        <label style="font-size:10px;color:var(--muted);letter-spacing:.5px" data-s="passport.viewMember">VIEW MEMBER</label>
+        <input type="text" id="ppMemberSearch" autocomplete="off" placeholder="" oninput="ppSearchMember(this.value)" style="font-size:11px;flex:1;min-width:160px">
+        <button class="btn btn-secondary" style="font-size:10px;padding:4px 10px" onclick="ppViewSelf()" data-s="passport.viewSelf">My passport</button>
+      </div>
+      <div id="ppMemberSuggestions" class="suggest-drop hidden" style="position:absolute;left:0;right:0;top:100%;z-index:10"></div>
+      <div id="ppCurrentTarget" style="font-size:10px;color:var(--brass);margin-top:4px"></div>
+    </div>
     <div id="passportProgressBar" style="height:6px;background:var(--surface);border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-bottom:10px">
       <div id="passportProgressFill" style="height:100%;width:0%;background:var(--brass);transition:width .3s"></div>
     </div>
@@ -332,6 +341,11 @@ var _passportTargetMemberId = user.id; // own passport by default
   if (_rowingSub === 'restricted') {
     var hideIds = ['sectMaint','sectCrews','sectSlots','cxStats'];
     hideIds.forEach(function(id){ var el = document.getElementById(id); if (el) el.style.display = 'none'; });
+  }
+  // Show member picker for users who can sign for others
+  if (_isStaffSigner || _rowingSub === 'released' || _rowingSub === 'coxswain') {
+    document.getElementById('passportPicker').classList.remove('hidden');
+    ensureMembersLoaded();
   }
 
   try {
@@ -990,7 +1004,11 @@ function renderPassport() {
       var icon = st.complete ? '✔' : (st.distinctSigners > 0 ? '◐' : '○');
       var cls = 'pp-item' + (st.complete ? ' pp-item-complete' : '') + (signingSomeoneElse ? ' pp-item-signable' : '');
       var sigText = st.distinctSigners + '/' + st.required;
-      var signersList = st.signoffs.map(function(so){ return _esc(so.signerName || '?') + ' · ' + String(so.timestamp || '').slice(0,10); }).join(' · ');
+      var canRevoke = _isStaffSigner;
+      var signersList = st.signoffs.map(function(so){
+        var revokeBtn = canRevoke ? ' <a href="#" onclick="revokeSignoffClick(event,\'' + so.id + '\')" style="color:var(--red);text-decoration:none;font-weight:600">✕</a>' : '';
+        return _esc(so.signerName || '?') + ' · ' + String(so.timestamp || '').slice(0,10) + revokeBtn;
+      }).join(' · ');
       var onclick = signingSomeoneElse ? ' onclick="signPassportItemClick(\'' + it.id + '\')"' : '';
       html += '<div class="' + cls + '"' + onclick + '>'
         + '<div class="pp-item-icon">' + icon + '</div>'
@@ -1023,6 +1041,60 @@ async function signPassportItemClick(itemId) {
   }
 }
 window.signPassportItemClick = signPassportItemClick;
+
+async function reloadPassportProgress() {
+  try {
+    var res = await apiGet('getRowingPassport', { memberId: _passportTargetMemberId });
+    _passportDef = res.definition; _passportProgress = res.progress;
+    renderPassport();
+  } catch(e) { showToast(e.message, 'err'); }
+}
+
+function ppSearchMember(q) {
+  var box = document.getElementById('ppMemberSuggestions');
+  q = (q || '').trim().toLowerCase();
+  if (!q || !_members.length) { box.classList.add('hidden'); box.innerHTML = ''; return; }
+  var hits = _members.filter(function(m){
+    if (!hasRowingEndorsement(m)) return false;
+    var n = (m.name || '').toLowerCase();
+    var k = (m.kennitala || '').toLowerCase();
+    return n.indexOf(q) >= 0 || k.indexOf(q) >= 0;
+  }).slice(0, 8);
+  if (!hits.length) { box.classList.add('hidden'); box.innerHTML = ''; return; }
+  box.innerHTML = hits.map(function(m){
+    return '<div class="suggest-item" onclick="ppSelectMember(\'' + m.id + '\')">' + _esc(m.name) + ' <span style="color:var(--muted);font-size:10px">' + _esc(m.kennitala || '') + '</span></div>';
+  }).join('');
+  box.classList.remove('hidden');
+}
+async function ppSelectMember(memberId) {
+  var m = _members.find(function(x){ return String(x.id) === String(memberId); });
+  _passportTargetMemberId = memberId;
+  document.getElementById('ppMemberSuggestions').classList.add('hidden');
+  document.getElementById('ppMemberSearch').value = '';
+  document.getElementById('ppCurrentTarget').textContent = m ? ('Viewing: ' + m.name) : '';
+  await reloadPassportProgress();
+}
+function ppViewSelf() {
+  _passportTargetMemberId = user.id;
+  document.getElementById('ppCurrentTarget').textContent = '';
+  document.getElementById('ppMemberSearch').value = '';
+  document.getElementById('ppMemberSuggestions').classList.add('hidden');
+  reloadPassportProgress();
+}
+async function revokeSignoffClick(ev, signoffId) {
+  ev.preventDefault(); ev.stopPropagation();
+  var reason = prompt(s('passport.revokeReason'));
+  if (reason === null) return;
+  try {
+    await apiPost('revokePassportSignoff', { signoffId: signoffId, revokedBy: user.name || '', reason: reason || '' });
+    showToast(s('passport.revoked'), 'ok');
+    await reloadPassportProgress();
+  } catch(e) { showToast(e.message, 'err'); }
+}
+window.ppSearchMember = ppSearchMember;
+window.ppSelectMember = ppSelectMember;
+window.ppViewSelf = ppViewSelf;
+window.revokeSignoffClick = revokeSignoffClick;
 
 // ── Expose onclick handlers to global scope (they live inside DOMContentLoaded closure) ──
 window.openCrewModal = openCrewModal;

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1571,5 +1571,16 @@ var _STRINGS_FLAT = {
   "passport.adminTitle": "Rowing Passport",
   "passport.importCsv": "Import CSV",
   "passport.exportCsv": "Export CSV",
-  "passport.csvHelp": "Columns: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is"
+  "passport.csvHelp": "Columns: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is",
+  "passport.viewMember": "VIEW MEMBER",
+  "passport.viewSelf": "My passport",
+  "passport.revokeReason": "Reason for revoking this sign-off?",
+  "passport.revoked": "Sign-off revoked.",
+  "passport.addCategory": "+ Add category",
+  "passport.addItem": "+ Add item",
+  "passport.retire": "Retire",
+  "passport.unretire": "Restore",
+  "passport.save": "Save changes",
+  "passport.saved": "Passport saved.",
+  "passport.unsavedChanges": "You have unsaved changes. Discard?"
 };

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1571,5 +1571,16 @@ var _STRINGS_FLAT = {
   "passport.adminTitle": "Ræðarapassi",
   "passport.importCsv": "Flytja inn CSV",
   "passport.exportCsv": "Flytja út CSV",
-  "passport.csvHelp": "Dálkar: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is"
+  "passport.csvHelp": "Dálkar: passport_id,category_id,category_label_en,category_label_is,item_id,item_label_en,item_label_is,description_en,description_is",
+  "passport.viewMember": "SKOÐA FÉLAGA",
+  "passport.viewSelf": "Minn passi",
+  "passport.revokeReason": "Ástæða fyrir afturköllun?",
+  "passport.revoked": "Undirritun afturkölluð.",
+  "passport.addCategory": "+ Bæta við flokki",
+  "passport.addItem": "+ Bæta við atriði",
+  "passport.retire": "Hætta",
+  "passport.unretire": "Endurvirkja",
+  "passport.save": "Vista breytingar",
+  "passport.saved": "Passi vistaður.",
+  "passport.unsavedChanges": "Óvistaðar breytingar. Henda?"
 };


### PR DESCRIPTION
- Coxswain page: staff and released rowers see a member-search picker above the passport. Selecting a member loads their progress and enables sign mode. "My passport" button returns to own view.
- Sign-off lines now show a ✕ button for staff users to revoke individual signatures with a reason; recomputes progress in place.
- Admin passport tab replaces the read-only preview with an inline editor: edit EN/IS labels for categories and items, add categories, add items (auto-slugs id), retire/restore items (preserves history), and save (bumps version). CSV import/export retained.