### PR TITLE
tide widget: show full month name in non-today date label

### DIFF
--- a/shared/tides.js
+++ b/shared/tides.js
@@ -279,7 +279,7 @@ function tideWidget(targetEl, { onData } = {}) {
     // Day label
     const dd = new Date(dateStr + 'T12:00:00Z');
     const dayLabel = isToday ? (IS?'Í dag':'Today')
-      : String(dd.getDate()).padStart(2,'0') + '-' + String(dd.getMonth()+1).padStart(2,'0');
+      : String(dd.getDate()).padStart(2,'0') + '-' + dd.toLocaleDateString(IS?'is-IS':'en-GB', { month:'long' });
 
     // Today button now lives in status area (see above)
 


### PR DESCRIPTION
Display the date as 'dd-month' with the month written out, respecting the active language (Icelandic or English) instead of the previous numeric 'dd-mm' format.

Closes #430