### PR TITLE
public dashboard: add active members count and 'become a member' CTA

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -4582,6 +4582,8 @@ function publicDashboard_() {
 
   // ── Captains ──
   var members = readAll_('members').filter(function(m) { return m.active === true || m.active === 'TRUE' || m.active === 'true'; });
+  // Active members count excludes guest entries
+  var activeMembersCount = members.filter(function(m) { return m.role !== 'guest'; }).length;
   var captains = [];
   var scriptUrl = ScriptApp.getService().getUrl();
 
@@ -4682,6 +4684,7 @@ function publicDashboard_() {
     ytd: { totalTrips: totalTrips, totalHours: Math.round(totalHours * 10) / 10, byCategory: byCategory },
     locations: locData,
     onWater: { boatCount: boatCount, peopleCount: peopleCount, boats: onWaterBoats },
+    activeMembers: activeMembersCount,
     captains: captains,
     boatCategories: boatCategories.map(function(c) { return { key: c.key, labelEN: c.labelEN || c.key, labelIS: c.labelIS || '', emoji: c.emoji || '' }; }),
     staffStatus: staffStatus,

--- a/public/index.html
+++ b/public/index.html
@@ -84,6 +84,16 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .live-badge{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--green);margin-right:6px;animation:pulse 2s infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
 
+/* ── Membership row (active members + CTA) ─────────────────────── */
+.membership-row{display:grid;grid-template-columns:minmax(160px,1fr) 2fr;gap:12px;align-items:stretch;margin-bottom:20px}
+.membership-row .stat-box{padding:16px 20px}
+.become-member-btn{display:flex;align-items:center;justify-content:center;text-align:center;background:var(--brass);color:#0b1f38;border:1px solid var(--brass);border-radius:8px;padding:16px 20px;font-family:inherit;font-size:14px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;text-decoration:none;transition:opacity .15s ease,transform .15s ease}
+.become-member-btn:hover{opacity:.9;text-decoration:none;transform:translateY(-1px)}
+@media(max-width:600px){
+  .membership-row{grid-template-columns:1fr}
+  .become-member-btn{padding:14px 16px;font-size:13px}
+}
+
 /* ── Two-column section ─────────────────────────────────────────── */
 .two-col{display:grid;grid-template-columns:1fr 1fr;gap:20px;align-items:start}
 
@@ -247,6 +257,16 @@ function renderDashboard(data) {
   if (data.flagConfig && typeof wxLoadFlagConfig === 'function') {
     wxLoadFlagConfig(data.flagConfig);
   }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // 0) MEMBERSHIP — active members count + become-a-member CTA
+  // ═══════════════════════════════════════════════════════════════════
+  html += '<section>';
+  html += '<div class="membership-row">';
+  html += '<div class="stat-box"><div class="stat-val">' + esc(data.activeMembers || 0) + '</div><div class="stat-lbl">' + esc(s('pub.dash.activeMembers')) + '</div></div>';
+  html += '<a class="become-member-btn" href="https://www.abler.io/shop/siglingafelagid/1" target="_blank" rel="noopener">' + esc(s('pub.dash.becomeMember')) + '</a>';
+  html += '</div>';
+  html += '</section>';
 
   // ═══════════════════════════════════════════════════════════════════
   // 1) ON THE WATER — stat strip at the very top

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1010,6 +1010,8 @@ var _STRINGS_FLAT = {
   "pub.dash.trips": "trips",
   "pub.dash.viewProfile": "View full profile",
   "pub.dash.comingSoon": "More information coming soon.",
+  "pub.dash.activeMembers": "Active Members",
+  "pub.dash.becomeMember": "Become a Member",
   "admin.expectedColumns": "EXPECTED COLUMNS",
   "admin.colName": "Full name (required)",
   "admin.colKt": "10-digit ID (required)",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1010,6 +1010,8 @@ var _STRINGS_FLAT = {
   "pub.dash.trips": "siglingar",
   "pub.dash.viewProfile": "Sjá fulla prófíl",
   "pub.dash.comingSoon": "Frekari upplýsingar birtast fljótlega.",
+  "pub.dash.activeMembers": "Virkir félagsmenn",
+  "pub.dash.becomeMember": "Gerast félagi",
   "admin.expectedColumns": "VÆNTIR DÁLKAR",
   "admin.colName": "Fullt nafn (áskilið)",
   "admin.colKt": "10 stafa kennitala (áskilið)",


### PR DESCRIPTION
Adds an active-member count (excluding guest role entries) to the public dashboard's top section, paired with a 'Become a member' / 'Gerast félagi' call-to-action button linking to the club's Abler signup page.

Closes #381