### PR TITLE
passport: actually ignore expiry in hasRowingEndorsement, re-add diag

### DIFF
--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -1111,6 +1111,23 @@ async function reloadPassportProgress() {
 // shared hasRowingEndorsement, which is tolerant of legacy data shapes.
 function _ppIsRower(m) { return hasRowingEndorsement(m); }
 
+// Dump every distinct certId[/sub] the loaded members carry, with counts, so
+// a silent-empty dropdown makes the data shape visible instead of opaque.
+function _ppCertIdSummary() {
+  var seen = {};
+  _members.forEach(function(m) {
+    if (!m || !m.certifications) { seen['(no-cert-field)'] = (seen['(no-cert-field)'] || 0) + 1; return; }
+    var certs = typeof m.certifications === 'string' ? parseJson(m.certifications, []) : (m.certifications || []);
+    if (!Array.isArray(certs) || !certs.length) { seen['(empty-certs)'] = (seen['(empty-certs)'] || 0) + 1; return; }
+    certs.forEach(function(c) {
+      if (!c) return;
+      var key = (c.certId || c.id || '?') + (c.sub ? '/' + c.sub : '');
+      seen[key] = (seen[key] || 0) + 1;
+    });
+  });
+  return Object.keys(seen).sort().map(function(k) { return k + ':' + seen[k]; }).join(', ');
+}
+
 async function ppSearchMember(q) {
   var box = document.getElementById('ppMemberSuggestions');
   q = (q || '').trim().toLowerCase();
@@ -1127,14 +1144,20 @@ async function ppSearchMember(q) {
     var cur = (document.getElementById('ppMemberSearch').value || '').trim().toLowerCase();
     if (cur !== q) return;
   }
-  var hits = _members.filter(function(m) {
-    if (!_ppIsRower(m)) return false;
+  var rowers = _members.filter(_ppIsRower);
+  var hits = rowers.filter(function(m) {
     var n = String(m.name || '').toLowerCase();
     var k = String(m.kennitala || '').toLowerCase();
     return n.indexOf(q) >= 0 || k.indexOf(q) >= 0;
   }).slice(0, 20);
   if (!hits.length) {
-    box.innerHTML = '<div style="' + msgStyle + '">No matching rowers</div>';
+    var summary = _ppCertIdSummary();
+    var diag = '<div style="' + msgStyle + '">No matching rowers ('
+      + rowers.length + ' of ' + _members.length + ' members)</div>';
+    if (summary) {
+      diag += '<div style="' + msgStyle + ';font-size:10px;word-break:break-all">Certs seen: ' + _esc(summary) + '</div>';
+    }
+    box.innerHTML = diag;
     box.classList.remove('hidden');
     return;
   }

--- a/shared/api.js
+++ b/shared/api.js
@@ -120,10 +120,10 @@ function isCaptain(u) {
 }
 // Internal: walk a user's certifications once and return { hasAny, sub },
 // where hasAny means "has some rowing_division (or legacy released_rower)
-// entry of any shape" and sub is the highest-rank strictly-valid subcat
-// ('restricted' | 'released' | 'coxswain') or null. Tolerant of case,
-// missing `sub`, and stale data shapes — a bare rowing_division cert still
-// marks the user as a rower even without a recognised sub.
+// entry of any shape, regardless of expiry" and sub is the highest-rank
+// strictly-valid, non-expired subcat ('restricted' | 'released' | 'coxswain')
+// or null. Tolerant of case and missing `sub` — a bare rowing_division cert
+// still marks the user as a rower even without a recognised sub.
 function _rowingCertInfo(u) {
   var out = { hasAny: false, sub: null };
   if (!u || !u.certifications) return out;
@@ -134,7 +134,6 @@ function _rowingCertInfo(u) {
   for (var i = 0; i < certs.length; i++) {
     var c = certs[i];
     if (!c) continue;
-    if (!_certNotExpired(c)) continue;
     var id  = String(c.certId || c.id || '').toLowerCase();
     var sub = String(c.sub || '').toLowerCase();
     var isRowing = false;
@@ -147,8 +146,11 @@ function _rowingCertInfo(u) {
       resolvedSub = 'released';
     }
     if (!isRowing) continue;
+    // Membership is permanent — any rowing_division cert, expired or not,
+    // counts for gating access to the rowing division page.
     out.hasAny = true;
-    if (resolvedSub && rank[resolvedSub] > bestRank) {
+    // Feature gating (released vs restricted) uses only non-expired certs.
+    if (resolvedSub && _certNotExpired(c) && rank[resolvedSub] > bestRank) {
       out.sub = resolvedSub;
       bestRank = rank[resolvedSub];
     }


### PR DESCRIPTION
The previous pass's comment said hasRowingEndorsement is tolerant of expiry, but _rowingCertInfo still short-circuited expired certs before they could set hasAny. Restricted rowers whose certs had drifted into a past expiresAt were still getting locked out. Split the check: hasAny flips on any rowing_division entry regardless of expiry, while the resolved sub (used for feature gating) keeps the expiry check.

Also re-add the certId-summary diagnostic to the passport picker's empty-dropdown state. If rowers=0 in the count, the summary line reveals exactly what's actually in the certifications JSON, so we can tell whether the data is missing rowing_division entries entirely or storing them under an unexpected shape.