### PR TITLE
Fix launch checklist save: move launchChecklists write outside locati…

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1398,9 +1398,9 @@ function saveConfig_(b) {
 
   if (b.locations !== undefined) {
     setConfigSheetValue_('locations', JSON.stringify(b.locations));
-  if (b.launchChecklists)  { setConfigSheetValue_('launchChecklists',  JSON.stringify(b.launchChecklists));  }
     saved.locations = true;
   }
+  if (b.launchChecklists)  { setConfigSheetValue_('launchChecklists',  JSON.stringify(b.launchChecklists));  }
   if (b.boatCategories)    { setConfigSheetValue_('boatCategories',    JSON.stringify(b.boatCategories));    }
 
   if (b.rowingPassport !== undefined) {


### PR DESCRIPTION
…ons block

The `if (b.launchChecklists)` save was accidentally nested inside `if (b.locations !== undefined)`, so checklist saves without a concurrent locations payload were silently dropped.

https://claude.ai/code/session_01DS8rhs7WzVTXq3CfGyqbfP