### PR TITLE
Fix sort input width override from global style.css

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -65,7 +65,7 @@
       border-bottom:1px solid var(--border)44; font-size:12px; }
     .cl-row:last-child { border-bottom:none; }
     .cl-phase { width:50px; font-size:10px; color:var(--brass); font-weight:bold; letter-spacing:.5px; flex-shrink:0; }
-    .cl-sort-input { width:34px; text-align:center; font-size:11px; padding:2px 2px; border:1px solid var(--border);
+    .cl-sort-input { width:34px!important; max-width:34px; min-width:34px; text-align:center; font-size:11px; padding:2px 2px; border:1px solid var(--border);
       border-radius:4px; background:var(--surface); color:var(--text); font-family:inherit; flex-shrink:0;
       -moz-appearance:textfield; appearance:textfield; }
     .cl-sort-input::-webkit-inner-spin-button,


### PR DESCRIPTION
The global input[type=number] rule sets width:100%, overriding the component width. Use !important and min/max-width to lock it at 34px.

https://claude.ai/code/session_01GBdM2PnpAr8eSwLXkFRkKs