### PR TITLE
Fix weather flag scoring ignoring admin-saved config

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -997,6 +997,7 @@ async function loadIncidentsForDate(date) {
 
 function applyLogData(log, cfgRes) {
   const cfg = cfgRes || {};
+  if (cfg.flagConfig && typeof wxLoadFlagConfig === 'function') wxLoadFlagConfig(cfg.flagConfig);
   amItems       = cfg.dailyChecklist?.opening || DEFAULT_AM;
   pmItems       = cfg.dailyChecklist?.closing  || DEFAULT_PM;
   activityTypes = cfg.activityTypes       || DEFAULT_TYPES;

--- a/member/index.html
+++ b/member/index.html
@@ -305,6 +305,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       window._earlyCheckouts || apiGet('getActiveCheckouts'),
       window._earlyConfig || apiGet('getConfig'),
     ]);
+    if (cfgRes.flagConfig && typeof wxLoadFlagConfig === 'function') wxLoadFlagConfig(cfgRes.flagConfig);
     checkouts = coRes.checkouts || [];
     boats     = (cfgRes.boats     || []).filter(b => b.active !== false && b.active !== 'false');
     locations = (cfgRes.locations || []).filter(l => l.active !== false && l.active !== 'false');

--- a/weather/index.html
+++ b/weather/index.html
@@ -205,6 +205,7 @@ async function fetchAll() {
       wxFetch(CURRENT_LOC.lat, CURRENT_LOC.lon, { fresh: true, useBirk: CURRENT_LOC.isDefault }),
       apiGet('getConfig').catch(() => null),
     ]);
+    if (cfgRes?.flagConfig && typeof wxLoadFlagConfig === 'function') wxLoadFlagConfig(cfgRes.flagConfig);
     const staffStatus = cfgRes?.staffStatus ?? null;
     render(wx, marine, staffStatus);
     document.getElementById('updatedAt').textContent =


### PR DESCRIPTION
The weather, dailylog, and member pages all use wxScoreFlag() but never called wxLoadFlagConfig() to load admin-saved thresholds. This meant flag scoring always used the hardcoded defaults in SCORE_CONFIG, regardless of what was saved in admin → Flags tab.

https://claude.ai/code/session_019TAh2bSAJDMJPCE8mCGZNd