### PR TITLE
Re-render weather widget after loading flag config on staff/member pages

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -305,7 +305,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       window._earlyCheckouts || apiGet('getActiveCheckouts'),
       window._earlyConfig || apiGet('getConfig'),
     ]);
-    if (cfgRes.flagConfig && typeof wxLoadFlagConfig === 'function') wxLoadFlagConfig(cfgRes.flagConfig);
+    if (cfgRes.flagConfig && typeof wxLoadFlagConfig === 'function') { wxLoadFlagConfig(cfgRes.flagConfig); document.getElementById('wxWidget')?._wxRefresh?.(); }
     checkouts = coRes.checkouts || [];
     boats     = (cfgRes.boats     || []).filter(b => b.active !== false && b.active !== 'false');
     locations = (cfgRes.locations || []).filter(l => l.active !== false && l.active !== 'false');

--- a/staff/index.html
+++ b/staff/index.html
@@ -532,7 +532,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (cfgRes.boatCategories && cfgRes.boatCategories.length) {
       registerBoatCats(cfgRes.boatCategories.filter(c => c.active !== false && c.active !== 'false'));
     }
-    if (typeof wxLoadFlagConfig === 'function') wxLoadFlagConfig(cfgRes.flagConfig);
+    if (typeof wxLoadFlagConfig === 'function' && cfgRes.flagConfig) { wxLoadFlagConfig(cfgRes.flagConfig); document.getElementById('wxWidget')?._wxRefresh?.(); }
     if (cfgRes.staffStatus) { _staffStatus = cfgRes.staffStatus; renderStaffStatusStrip(); document.getElementById('wxWidget')?._wxRefreshBadges?.(); }
 
     populateSelects();


### PR DESCRIPTION
The wxWidget starts and renders before getConfig resolves, so it always scored flags using hardcoded SCORE_CONFIG defaults. After wxLoadFlagConfig updates the thresholds, call _wxRefresh() to re-render the widget with the correct admin-saved scoring.

https://claude.ai/code/session_019TAh2bSAJDMJPCE8mCGZNd