### PR TITLE
Fix nav button heights on small screens and remove Captain's Quarters…

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -135,7 +135,7 @@ header {
   z-index: 100;
 }
 
-.header-left  { display: flex; align-items: center; gap: 12px; }
+.header-left  { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
 .header-right { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
 .logo {
@@ -176,6 +176,8 @@ main.wide { max-width: 1100px; }
   cursor: pointer;
   text-decoration: none;
   display: inline-block;
+  white-space: nowrap;
+  line-height: 1.4;
   transition: color .15s, border-color .15s;
 }
 .hbtn:hover       { color: var(--brass); border-color: var(--brass); }
@@ -193,6 +195,8 @@ main.wide { max-width: 1100px; }
   text-decoration: none;
   display: inline-block;
   font-weight: 500;
+  white-space: nowrap;
+  line-height: 1.4;
   transition: color .15s, border-color .15s;
 }
 .back-btn:hover { color: var(--brass); border-color: var(--brass); }

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -295,7 +295,6 @@ window.buildHeader = function (page) {
     if (canStaff && currentHub !== 'staff')  left.appendChild(link(depth + 'staff/',  s('nav.staffHub'),  'hbtn'));
     if (canStaff && currentHub !== 'member') left.appendChild(link(depth + 'member/', s('nav.memberHub'), 'hbtn'));
     if (canAdmin && currentHub !== 'admin')  left.appendChild(link(depth + 'admin/',  s('nav.admin'),     'hbtn'));
-    if (isCaptainUser && page !== 'captain') left.appendChild(link(depth + 'captain/', s('nav.captainQuarters'), 'hbtn'));
   }
 
   // RIGHT: guardian-acting-as-ward badge (if applicable)


### PR DESCRIPTION
… from nav

- Add white-space: nowrap and line-height: 1.4 to .hbtn and .back-btn so buttons maintain consistent heights instead of growing when text wraps
- Add flex-wrap: wrap to .header-left so buttons wrap to a new row on narrow screens rather than getting squished
- Remove Captain's Quarters link from the header nav bar

https://claude.ai/code/session_01TqVHMMBNUY9rFMAB7NK3HW