### PR TITLE
Add club calendar feature for member page

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -247,6 +247,7 @@
         <button class="tab-btn"        data-tab="alerts"     onclick="showTab('alerts')"     data-s="admin.tabAlerts"></button>
         <button class="tab-btn"        data-tab="slotCal"    onclick="showTab('slotCal')"    data-s="admin.tabReservations"></button>
         <button class="tab-btn"        data-tab="passport"   onclick="showTab('passport')"   data-s="passport.adminTitle">Rowing Passport</button>
+        <button class="tab-btn"        data-tab="clubCal"    onclick="showTab('clubCal')"    data-s="admin.tabCalendars"></button>
       </div>
       <!-- Settings tab dropdown (mobile) -->
       <select class="tab-select" id="settingsTabSelect" onchange="showTab(this.value)">
@@ -259,6 +260,7 @@
         <option value="alerts"     data-s="admin.tabAlerts"></option>
         <option value="slotCal"    data-s="admin.tabReservations"></option>
         <option value="passport"   data-s="passport.adminTitle"></option>
+        <option value="clubCal"    data-s="admin.tabCalendars"></option>
       </select>
 
     <!-- ══ BOATS ════════════════════════════════════════════════════════════ -->
@@ -591,6 +593,17 @@
       <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted)">
         <span><span style="display:inline-block;width:10px;height:10px;border:2px solid var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
         <span><span style="display:inline-block;width:10px;height:10px;background:var(--green);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendBooked">Booked</span></span>
+      </div>
+    </div>
+
+    <!-- ══ CLUB CALENDARS ════════════════════════════════════════════════ -->
+    <div id="tab-clubCal" class="hidden">
+      <div style="font-size:11px;color:var(--muted);margin-bottom:10px;line-height:1.5" data-s="admin.calDesc"></div>
+      <div id="clubCalList"></div>
+      <button class="btn btn-secondary" style="margin-top:8px" onclick="addClubCalRow('','')" data-s="admin.calAdd"></button>
+      <div style="display:flex;gap:8px;align-items:center;margin-top:12px">
+        <button class="btn btn-primary" onclick="saveClubCalendars()" data-s="btn.save"></button>
+        <span id="clubCalSaveMsg" style="font-size:11px"></span>
       </div>
     </div>
 
@@ -1160,6 +1173,7 @@ async function loadAll() {
   registerBoatCats(boatCats);
 
   try { loadCharterCalendars(cfgRes.charterCalendars || {}); } catch(e) { console.warn("loadCharterCalendars:", e.message); }
+  try { loadClubCalendars(cfgRes.clubCalendars || []); } catch(e) { console.warn("loadClubCalendars:", e.message); }
   try { loadAlertConfig(cfgRes.overdueAlerts); }   catch(e) { console.warn("loadAlertConfig:", e.message); }
   try { loadLaunchChecklists(cfgRes.launchChecklists || {}); } catch(e) { console.warn("loadLaunchChecklists:", e.message); }
   try { loadFlagConfigPanel(cfgRes.flagConfig); }  catch(e) { console.warn("loadFlagConfigPanel:", e.message); }
@@ -2990,6 +3004,58 @@ async function saveCharterCalendars() {
       keelboatCalendarId: document.getElementById("charterKeelboatCalId").value.trim(),
       keelboatCalendarSyncActive: document.getElementById("charterKeelboatCalActive").checked,
     });
+    msg.textContent = s("toast.saved") || "Saved";
+    msg.style.color = "var(--green)";
+  } catch (e) {
+    msg.textContent = (s("toast.error") || "Error") + ": " + e.message;
+    msg.style.color = "var(--red)";
+  }
+}
+
+// ── Club Calendars ────────────────────────────────────────────────────────────
+function loadClubCalendars(cals) {
+  var list = document.getElementById("clubCalList");
+  list.innerHTML = "";
+  if (!cals.length) {
+    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin:8px 0" data-s="admin.calEmpty"></div>';
+    applyStrings(list);
+    return;
+  }
+  cals.forEach(function(c) { addClubCalRow(c.name, c.calendarId); });
+}
+
+function addClubCalRow(name, calId) {
+  var list = document.getElementById("clubCalList");
+  // Remove empty-state message if present
+  var empty = list.querySelector("[data-s='admin.calEmpty']");
+  if (empty) empty.parentElement.remove();
+  var row = document.createElement("div");
+  row.className = "grid2";
+  row.style.cssText = "margin-bottom:8px;align-items:end";
+  row.innerHTML =
+    '<div class="field"><label data-s="admin.calName"></label><input type="text" class="ccName" value="' + esc(name) + '"></div>' +
+    '<div style="display:flex;gap:6px;align-items:end"><div class="field" style="flex:1"><label data-s="admin.calId"></label><input type="text" class="ccId" value="' + esc(calId) + '" placeholder="' + (s("admin.calPlaceholder") || "") + '"></div>' +
+    '<button class="btn btn-ghost btn-danger" style="margin-bottom:4px;font-size:10px" onclick="removeClubCalRow(this)" data-s="admin.calRemove"></button></div>';
+  list.appendChild(row);
+  applyStrings(row);
+}
+
+function removeClubCalRow(btn) {
+  btn.closest(".grid2").remove();
+}
+
+async function saveClubCalendars() {
+  var msg = document.getElementById("clubCalSaveMsg");
+  msg.textContent = "";
+  var rows = document.querySelectorAll("#clubCalList .grid2");
+  var cals = [];
+  rows.forEach(function(r) {
+    var name = r.querySelector(".ccName").value.trim();
+    var calId = r.querySelector(".ccId").value.trim();
+    if (name && calId) cals.push({ name: name, calendarId: calId });
+  });
+  try {
+    await apiPost("saveClubCalendars", { calendars: cals });
     msg.textContent = s("toast.saved") || "Saved";
     msg.style.color = "var(--green)";
   } catch (e) {

--- a/code.gs
+++ b/code.gs
@@ -387,6 +387,7 @@ function route_(action, b) {
     case 'getConfig': return getConfig_();
     case 'saveConfig': return saveConfig_(b);
     case 'saveCharterCalendars': return saveCharterCalendars_(b);
+    case 'saveClubCalendars': return saveClubCalendars_(b);
     case 'saveActivityType': return saveActivityType_(b);
     case 'deleteActivityType': return deleteActivityType_(b.id);
     case 'saveChecklistItem': return saveChecklistItem_(b);
@@ -1352,7 +1353,12 @@ function getConfig_() {
     const rpRaw = getConfigValue_('rowingPassport', cfgMap);
     if (rpRaw) rowingPassport = JSON.parse(rpRaw);
   } catch (e) {}
-  const config = { activityTypes, dailyChecklist, overdueAlerts, flagConfig, certDefs, certCategories, boats, locations, launchChecklists, boatCategories, staffStatus, allowBreaks, charterCalendars, rowingPassport };
+  let clubCalendars = [];
+  try {
+    const ccRaw = getConfigValue_('clubCalendars', cfgMap);
+    if (ccRaw) clubCalendars = JSON.parse(ccRaw);
+  } catch (e) {}
+  const config = { activityTypes, dailyChecklist, overdueAlerts, flagConfig, certDefs, certCategories, boats, locations, launchChecklists, boatCategories, staffStatus, allowBreaks, charterCalendars, rowingPassport, clubCalendars };
   cPut_('config', config);
   return okJ(config);
 }
@@ -2020,6 +2026,17 @@ function saveCharterCalendars_(b) {
     cDel_('config');
     return okJ({ saved: true });
   } catch (e) { return failJ('saveCharterCalendars failed: ' + e.message); }
+}
+
+function saveClubCalendars_(b) {
+  try {
+    var cals = (b.calendars || []).map(function(c) {
+      return { name: String(c.name || '').trim(), calendarId: String(c.calendarId || '').trim() };
+    }).filter(function(c) { return c.name && c.calendarId; });
+    setConfigSheetValue_('clubCalendars', JSON.stringify(cals));
+    cDel_('config');
+    return okJ({ saved: true });
+  } catch (e) { return failJ('saveClubCalendars failed: ' + e.message); }
 }
 
 function gcalParseDateTime_(dateStr, timeStr) {

--- a/member/index.html
+++ b/member/index.html
@@ -169,6 +169,7 @@
     <a class="act-btn" href="../saumaklubbur/"             data-s="nav.saumaklubbur"></a>
     <a class="act-btn" id="captainQBtn" href="../captain/" data-s="nav.captainQuarters" style="display:none"></a>
     <a class="act-btn" id="coxswainBtn" href="../coxswain/" data-s="nav.coxswainSeat" style="display:none"></a>
+    <button class="act-btn" id="calendarBtn" onclick="openClubCalendar()" data-s="member.calendar" style="display:none"></button>
   </div>
 
   <!-- ══ ACTIVE CHECKOUTS ══ -->
@@ -185,6 +186,17 @@
   </div>
 
 
+</div>
+
+<!-- ══ CLUB CALENDAR MODAL ══ -->
+<div class="modal-overlay hidden" id="calendarModal" onclick="if(event.target===this)closeModal('calendarModal')">
+  <div class="modal" style="max-width:900px;width:95vw;max-height:92vh;overflow-y:auto">
+    <div class="modal-header">
+      <h3 data-s="member.calTitle"></h3>
+      <button class="modal-close-x" onclick="closeModal('calendarModal')">×</button>
+    </div>
+    <div id="calendarContent"></div>
+  </div>
 </div>
 
 <!-- ══ MANUAL TRIP MODAL ══ -->
@@ -271,6 +283,7 @@ let _staffStatus = { onDuty: false, supportBoat: false };
 let boats=[], locations=[], checkouts=[];
 let currentWx=null;
 let launchBoat=null, returnCo=null;
+let _clubCalendars = [];
 const L = getLang();
 
 // ══ INIT ═════════════════════════════════════════════════════════════════════
@@ -324,6 +337,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       _boatCategories = cfgRes.boatCategories.filter(c => c.active !== false && c.active !== 'false');
       registerBoatCats(_boatCategories);
     }
+
+    _clubCalendars = cfgRes.clubCalendars || [];
+    if (_clubCalendars.length) document.getElementById('calendarBtn').style.display = '';
 
     populateFormSelects();
     renderActiveCheckouts();
@@ -1488,7 +1504,22 @@ function _renderMemberStaffStatus() {
   document.getElementById('wxWidget')?._wxRefreshBadges?.();
 }
 
-
+// ══ CLUB CALENDAR ════════════════════════════════════════════════════════════
+function openClubCalendar() {
+  var el = document.getElementById('calendarContent');
+  if (!_clubCalendars.length) {
+    el.innerHTML = '<div style="font-size:12px;color:var(--muted);padding:16px 0">' + (s('member.calEmpty') || '') + '</div>';
+  } else {
+    el.innerHTML = _clubCalendars.map(function(c) {
+      var src = 'https://calendar.google.com/calendar/embed?src=' + encodeURIComponent(c.calendarId) + '&ctz=Atlantic/Reykjavik';
+      return '<div style="margin-bottom:14px">'
+        + '<div style="font-size:12px;font-weight:600;margin-bottom:6px">' + esc(c.name) + '</div>'
+        + '<iframe src="' + src + '" style="border:0;width:100%;height:400px;border-radius:6px" frameborder="0" scrolling="no"></iframe>'
+        + '</div>';
+    }).join('');
+  }
+  openModal('calendarModal');
+}
 
 </script>
 </body>

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1229,5 +1229,16 @@ var _STRINGS_FLAT = {
   "passport.unretire": "Restore",
   "passport.save": "Save changes",
   "passport.saved": "Passport saved.",
-  "passport.unsavedChanges": "You have unsaved changes. Discard?"
+  "passport.unsavedChanges": "You have unsaved changes. Discard?",
+  "member.calendar": "📅 Calendar",
+  "member.calTitle": "Club Calendars",
+  "member.calEmpty": "No calendars have been set up yet.",
+  "admin.tabCalendars": "Calendars",
+  "admin.calDesc": "Add Google Calendar IDs that members can view from the member hub. Each calendar appears as an embedded view.",
+  "admin.calName": "Name",
+  "admin.calId": "Calendar ID",
+  "admin.calPlaceholder": "e.g. abc123@group.calendar.google.com",
+  "admin.calAdd": "+ Add calendar",
+  "admin.calEmpty": "No calendars added.",
+  "admin.calRemove": "Remove"
 };

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1229,5 +1229,16 @@ var _STRINGS_FLAT = {
   "passport.unretire": "Endurvirkja",
   "passport.save": "Vista breytingar",
   "passport.saved": "Passi vistaður.",
-  "passport.unsavedChanges": "Óvistaðar breytingar. Henda?"
+  "passport.unsavedChanges": "Óvistaðar breytingar. Henda?",
+  "member.calendar": "📅 Dagatal",
+  "member.calTitle": "Dagatöl klúbbsins",
+  "member.calEmpty": "Engin dagatöl hafa verið sett upp.",
+  "admin.tabCalendars": "Dagatöl",
+  "admin.calDesc": "Bættu við Google Calendar auðkennum sem félagar geta skoðað á félagssvæðinu. Hvert dagatal birtist sem innfellt yfirlit.",
+  "admin.calName": "Nafn",
+  "admin.calId": "Dagatal ID",
+  "admin.calPlaceholder": "t.d. abc123@group.calendar.google.com",
+  "admin.calAdd": "+ Bæta við dagatali",
+  "admin.calEmpty": "Engin dagatöl skráð.",
+  "admin.calRemove": "Fjarlægja"
 };


### PR DESCRIPTION
Add a calendar button on the member hub that opens a modal with embedded Google Calendar views. Admins can manage calendar IDs from a new "Calendars" tab in admin settings. Calendars are stored in the config sheet as a JSON array of {name, calendarId} objects. The button is hidden when no calendars are configured.

Closes #474

https://claude.ai/code/session_01LQPj9i1h7AnDsbLBCwStBA