### PR TITLE
Fix missing comma in string files that broke all translations

### DIFF
--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1264,7 +1264,7 @@ var _STRINGS_FLAT = {
   "member.volSignedUp": "Signed up",
   "member.volSlotsLeft": "{n} left",
   "member.volLeader": "In charge",
-  "member.noVolEvents": "No upcoming volunteer events."
+  "member.noVolEvents": "No upcoming volunteer events.",
   "member.calendar": "📅 Calendar",
   "member.calTitle": "Club Calendars",
   "member.calEmpty": "No calendars have been set up yet.",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1264,7 +1264,7 @@ var _STRINGS_FLAT = {
   "member.volSignedUp": "Skráð/ur",
   "member.volSlotsLeft": "{n} eftir",
   "member.volLeader": "Ábyrgðarmaður",
-  "member.noVolEvents": "Engir sjálfboðaviðburðir á næstunni."
+  "member.noVolEvents": "Engir sjálfboðaviðburðir á næstunni.",
   "member.calendar": "📅 Dagatal",
   "member.calTitle": "Dagatöl klúbbsins",
   "member.calEmpty": "Engin dagatöl hafa verið sett upp.",


### PR DESCRIPTION
A bad merge (f7625b0) dropped the comma after "member.noVolEvents" in both strings-is.js and strings-en.js. This caused a JS syntax error that prevented _STRINGS_FLAT from loading, so every s() call fell back to returning the raw key instead of the translated string.

https://claude.ai/code/session_017EJPZRpPqJoESUHHz6BXbH