### PR TITLE
Surface volunteer activity types on member page and admin volunteers tab

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -15,6 +15,7 @@
   <script src="../shared/weather.js" defer></script>
   <script src="../shared/ui.js"></script>
   <script src="../shared/certs.js" defer></script>
+  <script src="../shared/volunteer.js" defer></script>
   <script src="../shared/mcm.js" defer></script>
   <script src="../shared/calendar.js"></script>
   <style>
@@ -2497,25 +2498,40 @@ function renderVolunteerEvents() {
   const card = document.getElementById("volEventsCard");
   const L = getLang();
   const locale = L === 'IS' ? 'is' : 'en';
-  const sorted = volunteerEvents.slice()
-    .filter(e => e.active !== false)
-    .sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+  const today = new Date().toISOString().slice(0, 10);
+  // Expand volunteer-flagged activity types into virtual events so the admin
+  // tab reflects activity-type-defined volunteer activities.
+  const virtualEvents = (typeof expandVolunteerActivityTypes === 'function')
+    ? expandVolunteerActivityTypes(actTypes || [], today, null)
+    : [];
+  const merged = (typeof mergeVolunteerEvents === 'function')
+    ? mergeVolunteerEvents(volunteerEvents.filter(e => e.active !== false), virtualEvents)
+    : volunteerEvents.filter(e => e.active !== false).concat(virtualEvents);
+  const sorted = merged.slice().sort((a, b) => (a.date || '').localeCompare(b.date || ''));
   if (!sorted.length) {
     card.innerHTML = '<div class="empty-state">' + s('admin.noVolEvents') + '</div>';
     return;
   }
   card.innerHTML = sorted.map(ev => {
     const title = (L === 'IS' && ev.titleIS ? ev.titleIS : ev.title) || ev.title || '—';
+    const subtitle = (L === 'IS' && ev.subtitleIS ? ev.subtitleIS : ev.subtitle) || ev.subtitle || '';
     const roles = Array.isArray(ev.roles) ? ev.roles : [];
     const rolesHtml = roles.map(r => {
       const rn = (L === 'IS' && r.nameIS ? r.nameIS : r.name) || r.name || '';
-      return '<span style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px;display:block">→ ' + esc(rn) + ' (' + (r.slots || '∞') + ' ' + s('admin.volSlots').toLowerCase() + ')</span>';
+      const endorseStr = r.requiredEndorsement
+        ? ' <span style="color:var(--brass)">[' + esc((((certDefs || []).find(function(d){ return d.id === r.requiredEndorsement; }) || {}).name) || r.requiredEndorsement) + ']</span>'
+        : '';
+      return '<span style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px;display:block">→ ' + esc(rn) + ' (' + (r.slots || '∞') + ' ' + s('admin.volSlots').toLowerCase() + ')' + endorseStr + '</span>';
     }).join('');
-    return '<div class="list-row" style="flex-direction:column;align-items:stretch;gap:2px">'
+    const isVirtual = !!ev.virtual;
+    const actions = isVirtual
+      ? '<span style="font-size:9px;color:var(--brass);letter-spacing:.5px;margin-left:auto">' + s('admin.volFromActType') + '</span>'
+      : '<button class="row-edit" onclick="openVolEventModal(\'' + ev.id + '\')">Edit</button>'
+        + '<button class="row-del" onclick="deleteVolEvent(\'' + ev.id + '\')">×</button>';
+    return '<div class="list-row" style="flex-direction:column;align-items:stretch;gap:2px' + (isVirtual ? ';border-left:2px solid var(--brass);padding-left:8px' : '') + '">'
       + '<div style="display:flex;align-items:center;gap:10px">'
-      + '<span class="list-name">' + esc(title) + '<span style="color:var(--muted);font-size:11px;margin-left:8px">' + esc(ev.date || '') + (ev.startTime ? ' · ' + esc(ev.startTime) : '') + (ev.endTime ? '–' + esc(ev.endTime) : '') + '</span></span>'
-      + '<button class="row-edit" onclick="openVolEventModal(\'' + ev.id + '\')">Edit</button>'
-      + '<button class="row-del" onclick="deleteVolEvent(\'' + ev.id + '\')">×</button>'
+      + '<span class="list-name">' + esc(title) + (subtitle ? '<span style="color:var(--muted);font-size:11px;margin-left:6px">· ' + esc(subtitle) + '</span>' : '') + '<span style="color:var(--muted);font-size:11px;margin-left:8px">' + esc(ev.date || '') + (ev.startTime ? ' · ' + esc(ev.startTime) : '') + (ev.endTime ? '–' + esc(ev.endTime) : '') + '</span></span>'
+      + actions
       + '</div>'
       + (ev.leaderName ? '<div style="font-size:10px;color:var(--muted);padding-left:12px">' + s('admin.volLeader') + ': ' + esc(ev.leaderName) + (ev.leaderPhone && ev.showLeaderPhone ? ' · ' + esc(ev.leaderPhone) : '') + '</div>' : '')
       + rolesHtml

--- a/code.gs
+++ b/code.gs
@@ -5231,8 +5231,40 @@ function volunteerSignup_(b) {
       return failJ('Already signed up for this role');
     }
     // Check slot capacity
-    const events = JSON.parse(getConfigSheetValue_('volunteer_events') || '[]');
-    const evt = events.find(e => e.id === b.eventId);
+    let events = JSON.parse(getConfigSheetValue_('volunteer_events') || '[]');
+    let evt = events.find(e => e.id === b.eventId);
+    // If not found and a virtualEvent payload was provided, materialize it
+    // into volunteer_events so future signups and lookups work.
+    if (!evt && b.virtualEvent && String(b.eventId).indexOf('vae-') === 0) {
+      const ve = b.virtualEvent;
+      evt = {
+        id: ve.id,
+        activityTypeId: ve.activityTypeId || ve.sourceActivityTypeId || '',
+        sourceActivityTypeId: ve.sourceActivityTypeId || '',
+        sourceSubtypeId: ve.sourceSubtypeId || '',
+        title: ve.title || '',
+        titleIS: ve.titleIS || '',
+        subtitle: ve.subtitle || '',
+        subtitleIS: ve.subtitleIS || '',
+        date: ve.date || '',
+        startTime: ve.startTime || '',
+        endTime: ve.endTime || '',
+        leaderMemberId: '',
+        leaderName: '',
+        leaderPhone: '',
+        showLeaderPhone: false,
+        notes: '',
+        notesIS: '',
+        roles: Array.isArray(ve.roles) ? ve.roles : [],
+        active: true,
+        createdAt: now_(),
+        updatedAt: now_(),
+        materialized: true,
+      };
+      events.push(evt);
+      setConfigSheetValue_('volunteer_events', JSON.stringify(events));
+      cDel_('config');
+    }
     if (!evt) return failJ('Event not found');
     const role = (Array.isArray(evt.roles) ? evt.roles : []).find(r => r.id === b.roleId);
     if (!role) return failJ('Role not found');

--- a/member/index.html
+++ b/member/index.html
@@ -16,6 +16,7 @@
 <script src="../shared/tides.js" defer></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/certs.js" defer></script>
+<script src="../shared/volunteer.js" defer></script>
 <script src="../shared/qr.js" defer></script>
 <style>
 /* ── Quick-action header strip ── */
@@ -304,7 +305,7 @@
 const user = requireAuth();
 let _staffStatus = { onDuty: false, supportBoat: false };
 let boats=[], locations=[], checkouts=[];
-let _volunteerEvents=[], _volunteerSignups=[];
+let _volunteerEvents=[], _volunteerSignups=[], _volunteerActTypes=[];
 let currentWx=null;
 let launchBoat=null, returnCo=null;
 let _clubCalendars = [];
@@ -363,6 +364,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     _volunteerEvents = (cfgRes.volunteerEvents || []).filter(e => e.active !== false);
+    _volunteerActTypes = cfgRes.activityTypes || [];
     _clubCalendars = cfgRes.clubCalendars || [];
     if (_clubCalendars.length) document.getElementById('calendarBtn').style.display = '';
 
@@ -1533,7 +1535,12 @@ function _renderMemberStaffStatus() {
 // ══ VOLUNTEER EVENTS ═══════════════════════════════════════════════════════
 
 async function loadVolunteerSignups() {
-  if (!_volunteerEvents.length) {
+  // Check whether we have any volunteer-flagged activity types (virtual events)
+  // or saved events. If neither, skip the signup fetch entirely.
+  const hasVolActType = (_volunteerActTypes || []).some(function(a) {
+    return a && (a.volunteer === true || a.volunteer === 'true') && (a.active !== false && a.active !== 'false');
+  });
+  if (!_volunteerEvents.length && !hasVolActType) {
     renderMemberVolunteerEvents();
     return;
   }
@@ -1551,9 +1558,24 @@ function renderMemberVolunteerEvents() {
   const user = getUser();
   const kt = user ? user.kennitala : '';
   const today = new Date().toISOString().slice(0, 10);
+  // Expand volunteer-flagged activity types with bulk schedules into virtual
+  // events, then merge with saved events.
+  const virtualEvents = (typeof expandVolunteerActivityTypes === 'function')
+    ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, null)
+    : [];
+  const merged = (typeof mergeVolunteerEvents === 'function')
+    ? mergeVolunteerEvents(_volunteerEvents, virtualEvents)
+    : _volunteerEvents.concat(virtualEvents);
+  // Member's own certifications (for endorsement gating)
+  let myCerts = [];
+  try {
+    myCerts = user && user.certifications
+      ? (typeof user.certifications === 'string' ? JSON.parse(user.certifications) : user.certifications)
+      : [];
+  } catch(e) { myCerts = []; }
   // Show only future or today events, sorted by date
-  const upcoming = _volunteerEvents
-    .filter(e => e.date >= today)
+  const upcoming = merged
+    .filter(e => (e.date || '') >= today)
     .sort((a, b) => (a.date || '').localeCompare(b.date || '') || (a.startTime || '').localeCompare(b.startTime || ''));
   if (!upcoming.length) {
     container.innerHTML = '<div class="empty-note">' + s('member.noVolEvents') + '</div>';
@@ -1561,6 +1583,7 @@ function renderMemberVolunteerEvents() {
   }
   container.innerHTML = upcoming.map(function(ev) {
     const title = (L === 'IS' && ev.titleIS ? ev.titleIS : ev.title) || ev.title || '';
+    const subtitle = (L === 'IS' && ev.subtitleIS ? ev.subtitleIS : ev.subtitle) || ev.subtitle || '';
     const notes = (L === 'IS' && ev.notesIS ? ev.notesIS : ev.notes) || ev.notes || '';
     const roles = Array.isArray(ev.roles) ? ev.roles : [];
     const rolesHtml = roles.map(function(role) {
@@ -1571,9 +1594,14 @@ function renderMemberVolunteerEvents() {
       const isFull = total > 0 && filled >= total;
       const mySignup = signupsForRole.find(function(su) { return su.kennitala === kt; });
       const pct = total > 0 ? Math.min(100, Math.round(filled / total * 100)) : 0;
+      const allowed = (typeof memberCanTakeRole === 'function')
+        ? memberCanTakeRole(role, myCerts)
+        : true;
       let btnHtml = '';
       if (mySignup) {
         btnHtml = '<button class="vol-btn signed-up" onclick="memberVolWithdraw(\'' + mySignup.id + '\')">' + s('member.volWithdraw') + '</button>';
+      } else if (!allowed) {
+        btnHtml = '<span style="font-size:10px;color:var(--muted);font-style:italic">' + s('member.volNeedsEndorsement') + '</span>';
       } else if (isFull) {
         btnHtml = '<span style="font-size:10px;color:var(--red);font-weight:500">' + s('member.volFull') + '</span>';
       } else {
@@ -1592,10 +1620,11 @@ function renderMemberVolunteerEvents() {
       ? '<div class="vol-card-leader">' + s('member.volLeader') + ': ' + esc(ev.leaderName) + (ev.showLeaderPhone && ev.leaderPhone ? ' · ' + esc(ev.leaderPhone) : '') + '</div>'
       : '';
     const notesHtml = notes ? '<div style="font-size:10px;color:var(--muted);margin-top:4px">' + esc(notes) + '</div>' : '';
+    const subtitleHtml = subtitle ? '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + esc(subtitle) + '</div>' : '';
     return '<div class="vol-card">'
       + '<div class="vol-card-date">' + esc(ev.date || '') + (ev.startTime ? ' · ' + esc(ev.startTime) : '') + (ev.endTime ? '–' + esc(ev.endTime) : '') + '</div>'
       + '<div class="vol-card-title">' + esc(title) + '</div>'
-      + leaderHtml + notesHtml
+      + subtitleHtml + leaderHtml + notesHtml
       + rolesHtml
       + '</div>';
   }).join('');
@@ -1605,12 +1634,23 @@ async function memberVolSignup(eventId, roleId) {
   const user = getUser();
   if (!user) return;
   try {
-    const res = await apiPost('volunteerSignup', {
+    // If this is a virtual event (derived from an activity type), send the
+    // source event data so the backend can materialize it before signup.
+    const payload = {
       eventId: eventId,
       roleId: roleId,
       kennitala: user.kennitala,
       name: user.name || '',
-    });
+    };
+    if (String(eventId).indexOf('vae-') === 0) {
+      const today = new Date().toISOString().slice(0, 10);
+      const virt = (typeof expandVolunteerActivityTypes === 'function')
+        ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, null)
+        : [];
+      const src = virt.find(function(e) { return e.id === eventId; });
+      if (src) payload.virtualEvent = src;
+    }
+    const res = await apiPost('volunteerSignup', payload);
     _volunteerSignups.push(res.signup || { id: res.id, eventId: eventId, roleId: roleId, kennitala: user.kennitala, name: user.name });
     renderMemberVolunteerEvents();
     toast(s('toast.saved'));

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1261,6 +1261,7 @@ var _STRINGS_FLAT = {
   "admin.roleNoRestriction": "— No restriction —",
   "admin.bulkUsesDefaultTimes": "Uses default times",
   "admin.bulkSetDefaultTimes": "Set default start/end times above to use with bulk schedule.",
+  "admin.volFromActType": "FROM ACTIVITY TYPE",
 
   "member.volunteerEvents": "VOLUNTEER EVENTS",
   "member.volSignUp": "Sign up",
@@ -1269,6 +1270,7 @@ var _STRINGS_FLAT = {
   "member.volSignedUp": "Signed up",
   "member.volSlotsLeft": "{n} left",
   "member.volLeader": "In charge",
+  "member.volNeedsEndorsement": "Endorsement required",
   "member.noVolEvents": "No upcoming volunteer events.",
   "member.calendar": "📅 Calendar",
   "member.calTitle": "Club Calendars",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1261,6 +1261,7 @@ var _STRINGS_FLAT = {
   "admin.roleNoRestriction": "— Engin takmörkun —",
   "admin.bulkUsesDefaultTimes": "Notar sjálfgefna tíma",
   "admin.bulkSetDefaultTimes": "Stilltu sjálfgefinn byrjunar-/lokatíma hér að ofan til að nota við magnbókun.",
+  "admin.volFromActType": "ÚR TEGUND STARFSEMI",
 
   "member.volunteerEvents": "SJÁLFBOÐAVIÐBURÐIR",
   "member.volSignUp": "Skrá mig",
@@ -1269,6 +1270,7 @@ var _STRINGS_FLAT = {
   "member.volSignedUp": "Skráð/ur",
   "member.volSlotsLeft": "{n} eftir",
   "member.volLeader": "Ábyrgðarmaður",
+  "member.volNeedsEndorsement": "Réttindi nauðsynleg",
   "member.noVolEvents": "Engir sjálfboðaviðburðir á næstunni.",
   "member.calendar": "📅 Dagatal",
   "member.calTitle": "Dagatöl klúbbsins",

--- a/shared/volunteer.js
+++ b/shared/volunteer.js
@@ -1,0 +1,152 @@
+// ══ VOLUNTEER ACTIVITY HELPERS ═══════════════════════════════════════════════
+// Expands volunteer-flagged activity types with bulk schedules into virtual
+// volunteer event occurrences. Used by both the admin volunteers tab and the
+// member volunteer events list so that activity types marked as volunteer
+// automatically appear without requiring a hand-crafted volunteer event row.
+//
+// A "virtual" event has the same shape as a saved volunteer event (id, title,
+// date, startTime, endTime, roles, …) but with a deterministic id of the form
+// `vae-{activityTypeId}-{subtypeId}-{YYYYMMDD}` and a `virtual: true` flag.
+// On signup, the client sends the source activity type + subtype + date so
+// the backend can materialize the event on demand.
+
+(function(global) {
+  'use strict';
+
+  function _parse(v, fallback) {
+    if (Array.isArray(v)) return v;
+    if (!v) return fallback;
+    try { return JSON.parse(v); } catch (e) { return fallback; }
+  }
+
+  // Returns true if ISO date string `d` falls within [from, to] inclusive.
+  // Empty bounds are treated as unbounded.
+  function _inRange(d, from, to) {
+    if (from && d < from) return false;
+    if (to   && d > to)   return false;
+    return true;
+  }
+
+  // Iterate each day between two ISO dates (inclusive) and yield the date and
+  // its day-of-week (0=Sun..6=Sat).
+  function _eachDay(fromIso, toIso, cb) {
+    var a = new Date(fromIso + 'T00:00:00');
+    var b = new Date(toIso   + 'T00:00:00');
+    for (var d = new Date(a); d <= b; d.setDate(d.getDate() + 1)) {
+      var iso = d.toISOString().slice(0, 10);
+      cb(iso, d.getDay());
+    }
+  }
+
+  // Expand all active, volunteer-flagged activity types into virtual volunteer
+  // events within [rangeFrom, rangeTo]. Subtypes without a bulk schedule are
+  // skipped. Subtypes with bulk schedules that lack default times are also
+  // skipped (times come from subtype defaults now).
+  //
+  //   actTypes : array from config
+  //   rangeFrom: ISO date (default: today)
+  //   rangeTo  : ISO date (default: today + 90 days)
+  //   locale   : 'IS' or 'EN' (unused here; consumer handles localization)
+  //
+  // Returns an array of virtual event objects.
+  function expandVolunteerActivityTypes(actTypes, rangeFrom, rangeTo) {
+    if (!Array.isArray(actTypes) || !actTypes.length) return [];
+    var today = new Date();
+    var fromIso = rangeFrom || today.toISOString().slice(0, 10);
+    if (!rangeTo) {
+      var until = new Date(today.getTime() + 90 * 24 * 60 * 60 * 1000);
+      rangeTo = until.toISOString().slice(0, 10);
+    }
+    var out = [];
+    actTypes.forEach(function(at) {
+      if (!at || at.active === false || at.active === 'false') return;
+      var isVol = at.volunteer === true || at.volunteer === 'true';
+      if (!isVol) return;
+      var roles = _parse(at.roles, []);
+      if (!roles.length) return;
+      var subs = _parse(at.subtypes, []);
+      subs.forEach(function(st) {
+        if (!st || !st.bulkSchedule) return;
+        var bs = st.bulkSchedule;
+        var fd = bs.fromDate || '';
+        var td = bs.toDate   || '';
+        if (!fd || !td) return;
+        var startT = st.defaultStart || '';
+        var endT   = st.defaultEnd   || '';
+        if (!startT || !endT) return;
+        var days = Array.isArray(bs.daysOfWeek)
+          ? bs.daysOfWeek.map(function(n) { return parseInt(n, 10); })
+          : [];
+        if (!days.length) return;
+        // Intersect the subtype's own range with the requested range
+        var effFrom = fd > fromIso ? fd : fromIso;
+        var effTo   = td < rangeTo ? td : rangeTo;
+        if (effFrom > effTo) return;
+        _eachDay(effFrom, effTo, function(iso, dow) {
+          if (days.indexOf(dow) === -1) return;
+          var id = 'vae-' + at.id + '-' + (st.id || 'st') + '-' + iso.replace(/-/g, '');
+          out.push({
+            id: id,
+            virtual: true,
+            sourceActivityTypeId: at.id,
+            sourceSubtypeId: st.id || '',
+            title: at.name || '',
+            titleIS: at.nameIS || '',
+            subtitle: st.name || '',
+            subtitleIS: st.nameIS || '',
+            activityTypeId: at.id,
+            date: iso,
+            startTime: startT,
+            endTime: endT,
+            leaderName: '',
+            leaderPhone: '',
+            showLeaderPhone: false,
+            notes: '',
+            notesIS: '',
+            // Each virtual instance gets its own role ids so signups don't
+            // collide across days for the same activity type.
+            roles: roles.map(function(r) {
+              return {
+                id: (r.id || 'r') + '-' + iso.replace(/-/g, ''),
+                baseRoleId: r.id || '',
+                name: r.name || '',
+                nameIS: r.nameIS || '',
+                slots: r.slots || 1,
+                requiredEndorsement: r.requiredEndorsement || '',
+              };
+            }),
+            active: true,
+          });
+        });
+      });
+    });
+    return out;
+  }
+
+  // Merge virtual events with saved events. Saved events win if they share
+  // the same virtual id (i.e. they've already been materialized via signup).
+  function mergeVolunteerEvents(savedEvents, virtualEvents) {
+    var saved = Array.isArray(savedEvents)   ? savedEvents   : [];
+    var virt  = Array.isArray(virtualEvents) ? virtualEvents : [];
+    var ids = {};
+    saved.forEach(function(e) { if (e && e.id) ids[e.id] = true; });
+    var out = saved.slice();
+    virt.forEach(function(e) { if (!ids[e.id]) out.push(e); });
+    return out;
+  }
+
+  // Returns true if the given member can take the given role. `memberCerts`
+  // is the member's enriched certifications array (each item has at least
+  // .certId). A role with no requiredEndorsement is always allowed.
+  function memberCanTakeRole(role, memberCerts) {
+    if (!role || !role.requiredEndorsement) return true;
+    if (!Array.isArray(memberCerts)) return false;
+    return memberCerts.some(function(c) {
+      return c && (c.certId === role.requiredEndorsement || c.id === role.requiredEndorsement);
+    });
+  }
+
+  global.expandVolunteerActivityTypes = expandVolunteerActivityTypes;
+  global.mergeVolunteerEvents         = mergeVolunteerEvents;
+  global.memberCanTakeRole            = memberCanTakeRole;
+})(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
- New shared/volunteer.js helper expands volunteer-flagged activity types with bulk schedules into "virtual" volunteer events (one per scheduled occurrence within the next 90 days by default)
- Member page: loads activityTypes, merges virtual + saved events into the volunteer list, filters roles by endorsement (member.volNeedsEndorsement shown for restricted roles), and passes virtual event data on signup
- Admin volunteers tab: merges virtual events into the list with a brass left-border and a "FROM ACTIVITY TYPE" badge (read-only — edits happen via the activity type modal); role endorsement shown per role
- Backend (code.gs) volunteerSignup_ now materializes a virtual event into volunteer_events on first signup so validation and subsequent lookups all use the same record

https://claude.ai/code/session_01AzkXmyWNXXAfcGeSAyucf8