### PR TITLE
Extend CSS refresh to page-specific styles across all HTML files

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -21,29 +21,29 @@
     /* ── Tab bar ── */
     .tab-bar { display:flex; gap:0; border-bottom:1px solid var(--border); margin-bottom:20px; overflow-x:auto; }
     .tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
-      font-family:inherit; font-size:11px; letter-spacing:.8px; padding:10px 16px; cursor:pointer;
-      margin-bottom:-1px; transition:color .15s,border-color .15s; white-space:nowrap; }
+      font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
+      margin-bottom:-1px; transition:color .2s,border-color .2s; white-space:nowrap; }
     .tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
     .tab-btn:hover:not(.active) { color:var(--text); }
 
     /* ── Tab dropdown (mobile) ── */
     .tab-select { display:none; width:100%; padding:10px 12px; margin-bottom:20px;
       font-family:inherit; font-size:13px; color:var(--text); background:var(--surface);
-      border:1px solid var(--border); border-radius:6px; cursor:pointer; }
+      border:1px solid var(--border); border-radius:var(--radius-sm); cursor:pointer; }
 
     /* ── Collapsible section ── */
     .col-section { margin-bottom:16px; }
     .col-head { display:flex; align-items:center; justify-content:space-between;
       padding:10px 14px; background:var(--surface); border:1px solid var(--border);
-      border-radius:8px; cursor:pointer; user-select:none; transition:border-color .15s; }
+      border-radius:var(--radius-md); cursor:pointer; user-select:none; transition:border-color .2s,box-shadow .2s; box-shadow:var(--shadow-sm); }
     .col-head:hover { border-color:var(--brass)55; }
-    .col-head.open { border-radius:8px 8px 0 0; border-bottom-color:transparent; }
-    .col-title { font-size:11px; letter-spacing:1.2px; color:var(--muted); display:flex; align-items:center; gap:10px; }
+    .col-head.open { border-radius:var(--radius-md) var(--radius-md) 0 0; border-bottom-color:transparent; box-shadow:none; }
+    .col-title { font-size:11px; letter-spacing:.8px; color:var(--muted); display:flex; align-items:center; gap:10px; }
     .col-title strong { color:var(--text); font-size:13px; letter-spacing:0; }
     .col-toggle { font-size:11px; color:var(--muted); transition:transform .2s; }
     .col-toggle.open { transform:rotate(180deg); }
-    .col-body { border:1px solid var(--border); border-top:none; border-radius:0 0 8px 8px;
-      padding:14px 16px; background:var(--card); }
+    .col-body { border:1px solid var(--border); border-top:none; border-radius:0 0 var(--radius-md) var(--radius-md);
+      padding:14px 16px; background:var(--card); box-shadow:var(--shadow-sm); }
 
     /* ── Member rows ── */
     .member-row { display:flex; align-items:center; gap:10px; padding:9px 0;
@@ -54,7 +54,7 @@
 
     /* ── Boat cards ── */
     .boat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:10px; }
-    .boat-card { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:12px 14px; }
+    .boat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 14px; box-shadow:var(--shadow-sm); }
     .boat-card.oos { opacity:.55; }
     .boat-card-name { font-size:13px; font-weight:500; color:var(--text); margin-bottom:6px; }
     .boat-card-actions { display:flex; gap:6px; margin-top:10px; }
@@ -80,10 +80,10 @@
 
     /* ── Action buttons ── */
     .row-edit { background:none; border:1px solid transparent; color:var(--muted); cursor:pointer;
-      font-size:11px; font-family:inherit; padding:3px 8px; border-radius:4px; transition:all .15s; }
+      font-size:11px; font-family:inherit; padding:3px 8px; border-radius:var(--radius-sm); transition:all .2s; }
     .row-edit:hover { color:var(--brass); border-color:var(--brass)55; }
     .row-del  { background:none; border:none; color:var(--border); cursor:pointer;
-      font-size:16px; padding:2px 4px; line-height:1; transition:color .15s; }
+      font-size:16px; padding:2px 4px; line-height:1; transition:color .2s; }
     .row-del:hover { color:var(--red); }
 
     /* ── Search ── */
@@ -93,12 +93,12 @@
       transform:translateY(-50%); color:var(--muted); font-size:15px; pointer-events:none; }
 
     /* ── Import ── */
-    .import-card { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:20px; }
-    .upload-zone { border:2px dashed var(--border); border-radius:8px; padding:28px;
+    .import-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:20px; box-shadow:var(--shadow-sm); }
+    .upload-zone { border:2px dashed var(--border); border-radius:var(--radius-md); padding:28px;
       text-align:center; cursor:pointer; transition:border-color .2s;
       display:flex; flex-direction:column; align-items:center; gap:8px; }
     .upload-zone:hover { border-color:var(--brass); }
-    .col-hint { background:var(--surface); border:1px solid var(--border); border-radius:6px; padding:12px 16px; margin-bottom:16px; }
+    .col-hint { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px 16px; margin-bottom:16px; }
     .col-hint-row { display:flex; gap:8px; margin-bottom:4px; font-size:11px; align-items:flex-start; }
     .col-hint-field { color:var(--brass); width:120px; flex-shrink:0; }
     .col-hint-vals  { color:var(--muted); }
@@ -109,13 +109,13 @@
     .chip-orange { background:#e67e2222; color:#e67e22; border:1px solid #e67e2244; }
     .chip-muted  { background:var(--surface); color:var(--muted); border:1px solid var(--border); }
     .chip-red    { background:#e74c3c22; color:#e74c3c; border:1px solid #e74c3c44; }
-    .import-list { max-height:220px; overflow-y:auto; border:1px solid var(--border); border-radius:6px; margin-top:6px; }
+    .import-list { max-height:220px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm); margin-top:6px; }
     .import-row  { display:flex; gap:10px; padding:6px 12px; border-bottom:1px solid var(--border)33;
       font-size:11px; align-items:center; }
     .import-row:last-child { border-bottom:none; }
     .import-row label { display:flex; align-items:center; gap:6px; cursor:pointer; }
     .import-row input[type=checkbox] { accent-color:var(--brass); }
-    .import-ambig { background:#9b59b622; border:1px solid #9b59b644; border-radius:6px; padding:8px 12px;
+    .import-ambig { background:#9b59b622; border:1px solid #9b59b644; border-radius:var(--radius-sm); padding:8px 12px;
       font-size:11px; margin-bottom:6px; display:flex; gap:10px; align-items:center; }
     .import-ambig-btns button { font-size:10px; padding:3px 8px; border-radius:4px; border:1px solid var(--border);
       background:var(--surface); color:var(--text); cursor:pointer; margin-left:4px; }

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -8,8 +8,8 @@
   <style>
     .tab-bar { display:flex; gap:0; border-bottom:1px solid var(--border); margin-bottom:20px; overflow-x:auto; }
     .tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
-      font-family:inherit; font-size:11px; letter-spacing:.8px; padding:10px 16px; cursor:pointer;
-      margin-bottom:-1px; transition:color .15s,border-color .15s; white-space:nowrap; }
+      font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
+      margin-bottom:-1px; transition:color .2s,border-color .2s; white-space:nowrap; }
     .tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
     .tab-btn:hover:not(.active) { color:var(--text); }
     @media(max-width:600px){ .tab-btn{padding:8px 10px;font-size:10px;letter-spacing:.5px} }
@@ -35,7 +35,7 @@
 
     <!-- EMPLOYEES -->
     <div id="pr-employees">
-      <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:14px">
+      <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:14px;box-shadow:var(--shadow-sm)">
         <label class="toggle-wrap" style="display:flex;align-items:center;gap:8px;cursor:pointer;margin:0">
           <input type="checkbox" id="cfgAllowBreaks" onchange="cfgSaveAllowBreaks()" style="width:16px;height:16px;accent-color:var(--brass)">
           <span style="font-size:12px" data-s="payroll.allowBreaks"></span>
@@ -62,7 +62,7 @@
         </div>
       </div>
       <!-- EXPORT PANEL -->
-      <div id="prExportPanel" class="hidden" style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px 16px;margin-bottom:14px">
+      <div id="prExportPanel" class="hidden" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;margin-bottom:14px;box-shadow:var(--shadow-sm)">
         <div class="sec-lbl" data-s="payroll.export"></div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
           <label style="font-size:10px;color:var(--muted)" data-s="payroll.periodFrom"></label>

--- a/alert-action/index.html
+++ b/alert-action/index.html
@@ -6,12 +6,13 @@
 <title>Ýmir — Alert Action</title>
 <style>
 body{margin:0;padding:40px 20px;background:#071526;font-family:system-ui,sans-serif;color:#fff;display:flex;align-items:center;justify-content:center;min-height:100vh;box-sizing:border-box}
-.card{background:#0b1f38;border:1px solid #1e3a5a;border-radius:8px;padding:32px;max-width:440px;width:100%;text-align:center}
+.card{background:#0b1f38;border:1px solid #1e3a5a;border-radius:10px;padding:32px;max-width:440px;width:100%;text-align:center;box-shadow:0 8px 30px rgba(0,0,0,.35)}
 .logo{color:#c8a84b;font-size:22px;font-weight:bold;margin-bottom:24px;letter-spacing:1px}
 .icon{font-size:48px;margin-bottom:16px}
 h2{margin:0 0 12px;font-size:20px}
 p{margin:0 0 24px;color:#7a9cbe;font-size:14px;line-height:1.6}
-.btn{display:inline-block;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:bold;font-size:14px}
+.btn{display:inline-block;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:bold;font-size:14px;transition:all .2s}
+.btn:hover{transform:translateY(-1px);box-shadow:0 4px 12px rgba(39,174,96,.35)}
 .btn-primary{background:#27ae60;color:#fff}
 .spinner{width:36px;height:36px;border:3px solid #1e3a5a;border-top-color:#c8a84b;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 20px}
 @keyframes spin{to{transform:rotate(360deg)}}

--- a/captain/index.html
+++ b/captain/index.html
@@ -22,7 +22,7 @@
 <style>
 /* ── Stats ── */
 .cq-stats { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }
-.cq-stat { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px 12px; text-align:center; }
+.cq-stat { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 12px; text-align:center; box-shadow:var(--shadow-sm); }
 .cq-stat .sn { font-size:24px; color:var(--brass); font-weight:500; }
 .cq-stat .sl { font-size:9px; color:var(--muted); margin-top:4px; letter-spacing:.5px; }
 
@@ -34,27 +34,27 @@
 /* ── Filter pills ── */
 .cq-pills { display:flex; gap:6px; margin-bottom:10px; flex-wrap:wrap; }
 .cq-pill { padding:5px 12px; border-radius:16px; border:1px solid var(--border); background:var(--surface);
-  font-size:10px; font-family:inherit; color:var(--muted); cursor:pointer; transition:all .15s; }
+  font-size:10px; font-family:inherit; color:var(--muted); cursor:pointer; transition:all .2s; }
 .cq-pill.active { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
 
 /* ── Compact filter bar ── */
 .cq-filter-bar { display:grid; grid-template-columns:repeat(auto-fill,minmax(110px,1fr)); gap:6px; margin-bottom:10px; align-items:center; }
-.cq-filter-bar select, .cq-filter-bar input[type="text"] { background:var(--surface); border:1px solid var(--border); border-radius:6px;
+.cq-filter-bar select, .cq-filter-bar input[type="text"] { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
   color:var(--text); font-family:inherit; font-size:10px; padding:4px 8px; height:26px; outline:none;
-  transition:border-color .15s; min-width:0; width:100%; box-sizing:border-box; }
-.cq-filter-bar select:focus, .cq-filter-bar input:focus { border-color:var(--brass); }
+  transition:border-color .2s,box-shadow .2s; min-width:0; width:100%; box-sizing:border-box; }
+.cq-filter-bar select:focus, .cq-filter-bar input:focus { border-color:var(--brass); box-shadow:0 0 0 3px rgba(212,175,55,.15); }
 .cq-filter-search { display:flex; gap:6px; align-items:center; grid-column:1/-1; }
 .cq-filter-search input { flex:1; min-width:0; }
 .cq-filter-count { font-size:9px; color:var(--muted); white-space:nowrap; }
 
 /* ── Cards ── */
-.cq-card { background:var(--card); border:1px solid var(--border); border-radius:8px;
-  padding:12px 14px; margin-bottom:8px; }
+.cq-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:12px 14px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
 .cq-card-title { font-size:12px; font-weight:500; color:var(--text); }
 .cq-card-sub { font-size:11px; color:var(--muted); margin-top:3px; }
 .cq-card-meta { font-size:10px; color:var(--brass); margin-top:2px; }
 .cq-card .conf-actions { display:flex; gap:6px; margin-top:8px; }
-.cq-card .conf-actions button { font-size:11px; font-family:inherit; padding:5px 12px; border-radius:6px; cursor:pointer; border:1px solid; }
+.cq-card .conf-actions button { font-size:11px; font-family:inherit; padding:5px 12px; border-radius:var(--radius-sm); cursor:pointer; border:1px solid; }
 .cq-card .btn-confirm { background:var(--green)18; color:var(--green); border-color:var(--green)55; }
 .cq-card .btn-confirm:hover { background:var(--green)33; }
 .cq-card .btn-reject { background:var(--red)18; color:var(--red); border-color:var(--red)55; }
@@ -69,38 +69,39 @@
 
 
 /* ── Show-more button ── */
-.cq-show-more { width:100%; background:var(--surface); border:1px solid var(--border); border-radius:8px;
-  padding:8px; font-size:10px; color:var(--muted); cursor:pointer; font-family:inherit; margin-top:4px; text-align:center; }
+.cq-show-more { width:100%; background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:8px; font-size:10px; color:var(--muted); cursor:pointer; font-family:inherit; margin-top:4px; text-align:center; transition:border-color .2s,color .2s; }
 .cq-show-more:hover { border-color:var(--brass); color:var(--text); }
 
 /* ── Filter bar (logbook) ── */
 .filter-bar { display:grid; grid-template-columns:repeat(4,1fr); gap:6px; margin-bottom:12px; align-items:center; }
-.filter-bar select, .filter-bar input { background:var(--surface); border:1px solid var(--border); border-radius:6px;
+.filter-bar select, .filter-bar input { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
   color:var(--text); font-family:inherit; font-size:11px; padding:5px 9px; height:30px; outline:none;
-  transition:border-color .15s; width:100%; box-sizing:border-box; }
-.filter-bar select:focus, .filter-bar input:focus { border-color:var(--brass); }
+  transition:border-color .2s,box-shadow .2s; width:100%; box-sizing:border-box; }
+.filter-bar select:focus, .filter-bar input:focus { border-color:var(--brass); box-shadow:0 0 0 3px rgba(212,175,55,.15); }
 .filter-bar .filter-search-row { grid-column:1/-1; display:flex; gap:6px; align-items:center; }
 .filter-bar .filter-search-row input { flex:1; min-width:0; }
 .filter-count { font-size:10px; color:var(--muted); white-space:nowrap; }
 
 /* ── Bio section ── */
 .cq-bio-area { width:100%; min-height:80px; background:var(--surface); border:1px solid var(--border);
-  border-radius:8px; color:var(--text); font-family:inherit; font-size:12px; padding:10px 12px;
-  resize:vertical; box-sizing:border-box; }
+  border-radius:var(--radius-md); color:var(--text); font-family:inherit; font-size:12px; padding:10px 12px;
+  resize:vertical; box-sizing:border-box; transition:border-color .2s,box-shadow .2s; outline:none; }
+.cq-bio-area:focus { border-color:var(--brass); box-shadow:0 0 0 3px rgba(212,175,55,.15); }
 .cq-headshot-preview { width:80px; height:80px; border-radius:50%; object-fit:cover; border:2px solid var(--brass); }
 .cq-headshot-placeholder { width:80px; height:80px; border-radius:50%; background:var(--surface);
   border:2px dashed var(--border); display:flex; align-items:center; justify-content:center;
   font-size:24px; color:var(--muted); }
 
 /* ── Boat cards ── */
-.cq-boat { background:var(--card); border:1px solid var(--border); border-radius:8px;
-  padding:12px 14px; margin-bottom:8px; display:flex; align-items:center; gap:12px; }
+.cq-boat { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:12px 14px; margin-bottom:8px; display:flex; align-items:center; gap:12px; box-shadow:var(--shadow-sm); }
 .cq-boat-name { font-size:13px; font-weight:500; }
 .cq-boat-sub { font-size:11px; color:var(--muted); margin-top:2px; }
 .cq-boat-actions { margin-left:auto; display:flex; gap:6px; }
-.cq-boat-actions button { font-size:10px; font-family:inherit; padding:4px 10px; border-radius:6px;
-  cursor:pointer; border:1px solid var(--border); background:var(--surface); color:var(--muted); }
-.cq-boat-actions button:hover { border-color:var(--brass); color:var(--brass); }
+.cq-boat-actions button { font-size:10px; font-family:inherit; padding:4px 10px; border-radius:var(--radius-sm);
+  cursor:pointer; border:1px solid var(--border); background:var(--surface); color:var(--muted); transition:color .2s,border-color .2s,background .2s; }
+.cq-boat-actions button:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)08; }
 
 /* ── Responsive ── */
 @media(max-width:600px){

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -18,15 +18,15 @@
 <style>
 /* ── Stats ── */
 .cx-stats { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }
-.cx-stat { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px 12px; text-align:center; }
+.cx-stat { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 12px; text-align:center; box-shadow:var(--shadow-sm); }
 .cx-stat .sn { font-size:24px; color:var(--brass); font-weight:500; }
 .cx-stat .sl { font-size:9px; color:var(--muted); margin-top:4px; letter-spacing:.5px; }
 
 /* ── Tab bar ── */
 .cx-tab-bar { display:flex; gap:0; border-bottom:1px solid var(--border); margin-bottom:16px; overflow-x:auto; }
 .cx-tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
-  font-family:inherit; font-size:11px; letter-spacing:.8px; padding:10px 16px; cursor:pointer;
-  white-space:nowrap; transition:color .15s; text-transform:uppercase; }
+  font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
+  white-space:nowrap; transition:color .2s,border-color .2s; text-transform:uppercase; margin-bottom:-1px; }
 .cx-tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
 .cx-tab-btn:hover:not(.active) { color:var(--text); }
 
@@ -35,28 +35,28 @@
 .cx-section-hdr { font-size:9px; color:var(--muted); letter-spacing:1.5px; margin-bottom:10px; display:flex; align-items:center; gap:8px; }
 
 /* ── Cards ── */
-.cx-card { background:var(--card); border:1px solid var(--border); border-radius:8px;
-  padding:12px 14px; margin-bottom:8px; }
+.cx-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:12px 14px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
 
 /* ── Boats ── */
 .cx-boat { display:flex; justify-content:space-between; align-items:flex-start;
-  background:var(--card); border:1px solid var(--border); border-radius:8px;
-  padding:12px 14px; margin-bottom:8px; flex-wrap:wrap; gap:8px; }
+  background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:12px 14px; margin-bottom:8px; flex-wrap:wrap; gap:8px; box-shadow:var(--shadow-sm); }
 .cx-boat-name { font-size:13px; font-weight:500; color:var(--text); }
 .cx-boat-sub  { font-size:11px; color:var(--muted); margin-top:3px; }
 .cx-boat-actions { margin-left:auto; display:flex; gap:6px; }
-.cx-boat-actions button { font-size:10px; font-family:inherit; padding:4px 10px; border-radius:6px;
-  cursor:pointer; border:1px solid var(--border); background:var(--surface); color:var(--muted); }
-.cx-boat-actions button:hover { border-color:var(--brass); color:var(--brass); }
+.cx-boat-actions button { font-size:10px; font-family:inherit; padding:4px 10px; border-radius:var(--radius-sm);
+  cursor:pointer; border:1px solid var(--border); background:var(--surface); color:var(--muted); transition:color .2s,border-color .2s,background .2s; }
+.cx-boat-actions button:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)08; }
 
 /* ── Read-only banner ── */
 .cx-readonly { font-size:11px; color:var(--muted); background:var(--surface); border:1px solid var(--border);
-  border-radius:6px; padding:8px 12px; margin-bottom:12px; text-align:center; }
+  border-radius:var(--radius-sm); padding:8px 12px; margin-bottom:12px; text-align:center; }
 
 /* ── Crew board ── */
 .cb-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
-.cb-card { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px;
-  border-left:3px solid var(--border); }
+.cb-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px;
+  border-left:3px solid var(--border); box-shadow:var(--shadow-sm); }
 .cb-header { display:flex; align-items:center; gap:8px; margin-bottom:6px; flex-wrap:wrap; }
 .cb-name { font-size:13px; font-weight:500; color:var(--text); }
 .cb-count { font-size:10px; color:var(--muted); }
@@ -85,8 +85,8 @@
 .pp-cat { margin-bottom:14px; }
 .pp-cat-hdr { font-size:10px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; margin-bottom:6px; display:flex; align-items:center; gap:8px; }
 .pp-cat-count { font-size:9px; color:var(--brass); }
-.pp-item { display:flex; align-items:flex-start; gap:10px; background:var(--card); border:1px solid var(--border); border-radius:6px; padding:8px 12px; margin-bottom:4px; font-size:11px; }
-.pp-item-signable { cursor:pointer; transition:border-color .15s; }
+.pp-item { display:flex; align-items:flex-start; gap:10px; background:var(--card); border:1px solid var(--border); border-radius:var(--radius-sm); padding:8px 12px; margin-bottom:4px; font-size:11px; }
+.pp-item-signable { cursor:pointer; transition:border-color .2s; }
 .pp-item-signable:hover { border-color:var(--brass); }
 .pp-item-complete { border-left:3px solid var(--green); }
 .pp-item-icon { font-size:14px; color:var(--brass); width:18px; text-align:center; flex-shrink:0; }

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -18,24 +18,24 @@
 <style>
 /* ── Date nav ── */
 .date-nav { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
-.date-nav button { background:none; border:1px solid var(--border); border-radius:6px;
-  color:var(--text); font-family:inherit; font-size:12px; padding:5px 12px; cursor:pointer; }
-.date-nav button:hover { border-color:var(--brass); }
+.date-nav button { background:none; border:1px solid var(--border); border-radius:var(--radius-sm);
+  color:var(--text); font-family:inherit; font-size:12px; padding:5px 12px; cursor:pointer; transition:border-color .2s,color .2s; }
+.date-nav button:hover { border-color:var(--brass); color:var(--brass); }
 .date-big { font-size:13px; font-weight:400; color:var(--muted); letter-spacing:.5px; flex:1; text-align:center; }
 .date-hero { font-size:28px; font-weight:500; color:var(--text); text-align:center; margin:4px 0 12px; line-height:1.1; }
 .signoff-badge { display:inline-flex; align-items:center; gap:6px;
   background:var(--green)18; border:1px solid var(--green)44; color:var(--green);
-  border-radius:6px; padding:4px 10px; font-size:11px; }
+  border-radius:var(--radius-sm); padding:4px 10px; font-size:11px; }
 .readonly-badge { display:inline-flex; align-items:center;
   background:var(--surface); border:1px solid var(--border); color:var(--muted);
-  border-radius:6px; padding:4px 10px; font-size:11px; }
+  border-radius:var(--radius-sm); padding:4px 10px; font-size:11px; }
 
 /* ── Section headings ── */
-.section-heading { font-size:9px; color:var(--muted); letter-spacing:1.5px;
+.section-heading { font-size:9px; color:var(--muted); letter-spacing:1px;
   margin:20px 0 8px; display:flex; align-items:center; justify-content:space-between; }
 
 /* ── Cards ── */
-.content-card { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:14px 16px; margin-bottom:4px; }
+.content-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 16px; margin-bottom:4px; box-shadow:var(--shadow-sm); }
 
 /* ── Checklists ── */
 .cl-progress-line { font-size:11px; color:var(--muted); margin-bottom:8px; }
@@ -68,15 +68,15 @@
 
 /* ── Incident button ── */
 .incident-btn { display:flex; align-items:center; gap:12px; padding:12px 16px;
-  background:var(--surface); border:1px solid var(--border); border-radius:8px;
-  text-decoration:none; color:var(--text); transition:border-color .15s; margin-bottom:4px; cursor:pointer; }
-.incident-btn:hover { border-color:var(--brass); }
+  background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
+  text-decoration:none; color:var(--text); transition:border-color .2s,box-shadow .2s; margin-bottom:4px; cursor:pointer; box-shadow:var(--shadow-sm); }
+.incident-btn:hover { border-color:var(--brass); box-shadow:var(--shadow-md); }
 .incident-icon { font-size:22px; flex-shrink:0; }
 .incident-label { font-size:13px; font-weight:500; }
 .incident-sub { font-size:11px; color:var(--muted); margin-top:2px; }
 
 /* ── Weather log ── */
-.wx-snap-card { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:10px 12px; margin-bottom:8px; }
+.wx-snap-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:10px 12px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
 .wx-snap-header { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
 .wx-snap-time { color:var(--brass); font-weight:500; font-size:14px; flex:1; }
 .wx-snap-flag { font-size:16px; }
@@ -96,8 +96,8 @@
 /* ── Activity type buttons ── */
 .type-btns { display:flex; flex-wrap:wrap; gap:6px; margin-top:4px; }
 .type-btn { padding:5px 12px; background:var(--surface); border:1px solid var(--border);
-  border-radius:4px; font-size:12px; font-family:inherit; color:var(--text);
-  cursor:pointer; transition:all .15s; }
+  border-radius:var(--radius-sm); font-size:12px; font-family:inherit; color:var(--text);
+  cursor:pointer; transition:all .2s; }
 .type-btn.selected { background:var(--brass)22; border-color:var(--brass); color:var(--brass); }
 
 /* ── Trip detail modal ── */

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -15,20 +15,20 @@
   <style>
     .mode-btns { display:flex; gap:8px; margin-bottom:20px; }
     .mode-btn { flex:1; padding:12px; background:var(--card); border:1px solid var(--border);
-      border-radius:8px; font-family:inherit; font-size:13px; color:var(--muted); cursor:pointer;
-      transition:all .15s; text-align:center; }
+      border-radius:var(--radius-md); font-family:inherit; font-size:13px; color:var(--muted); cursor:pointer;
+      transition:all .2s; text-align:center; box-shadow:var(--shadow-sm); }
     .mode-btn.active { background:var(--brass)18; border-color:var(--brass); color:var(--text); }
     .mode-btn .icon { font-size:22px; display:block; margin-bottom:4px; }
 
     .type-grid { display:flex; flex-wrap:wrap; gap:8px; margin-top:6px; }
     .type-toggle { padding:6px 12px; background:var(--faint); border:1px solid var(--border);
-      border-radius:4px; font-size:12px; font-family:inherit; color:var(--text); cursor:pointer; transition:all .15s; }
+      border-radius:var(--radius-sm); font-size:12px; font-family:inherit; color:var(--text); cursor:pointer; transition:all .2s; }
     .type-toggle.on { background:var(--red)22; border-color:var(--red)88; color:var(--red); }
 
     .sev-btns { display:flex; gap:6px; margin-top:6px; flex-wrap:wrap; }
     .sev-btn { flex:1; min-width:60px; padding:7px 4px; background:var(--surface);
-      border-radius:6px; border:1px solid; font-size:11px; font-family:inherit;
-      cursor:pointer; text-align:center; font-weight:600; letter-spacing:.4px; transition:all .15s; }
+      border-radius:var(--radius-sm); border:1px solid; font-size:11px; font-family:inherit;
+      cursor:pointer; text-align:center; font-weight:600; letter-spacing:.4px; transition:all .2s; }
     .sev-btn[data-v="low"]      { color:var(--green);  border-color:#27ae6055; background:#27ae6011; }
     .sev-btn[data-v="medium"]   { color:#c9a800;       border-color:#f1c40f55; background:#f1c40f11; }
     .sev-btn[data-v="high"]     { color:var(--orange); border-color:#e67e2255; background:#e67e2211; }
@@ -43,7 +43,7 @@
     .incident-meta { font-size:11px; color:var(--muted); margin-top:3px; }
 
     .notes-list { margin-top:8px; }
-    .note-item { background:var(--faint); border-radius:6px; padding:8px 12px; margin-bottom:6px; font-size:12px; }
+    .note-item { background:var(--faint); border-radius:var(--radius-sm); padding:8px 12px; margin-bottom:6px; font-size:12px; }
     .note-meta  { color:var(--muted); font-size:11px; margin-top:3px; }
 
     .page { max-width:720px; margin:0 auto; padding:16px 16px 60px; }
@@ -74,7 +74,7 @@
     </div>
 
     <!-- Needs-review alert -->
-    <div id="reviewAlert" class="hidden" style="background:#e67e2218;border:1px solid #e67e2255;color:var(--orange);border-radius:8px;padding:10px 14px;margin-bottom:14px;font-size:13px;display:flex;align-items:center;gap:8px">
+    <div id="reviewAlert" class="hidden" style="background:#e67e2218;border:1px solid #e67e2255;color:var(--orange);border-radius:var(--radius-md);padding:10px 14px;margin-bottom:14px;font-size:13px;display:flex;align-items:center;gap:8px;box-shadow:var(--shadow-sm)">
       <span style="font-size:16px">⚠️</span>
       <span id="reviewAlertText"></span>
     </div>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -19,11 +19,11 @@
 <style>
 .page{max-width:640px;margin:0 auto;padding:20px 16px 60px}
 .stat-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:12px}
-.stat-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 12px;text-align:center}
+.stat-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;text-align:center;box-shadow:var(--shadow-sm)}
 .stat-val{font-size:22px;font-weight:500;color:var(--text);line-height:1}
 .stat-val.stat-val-text{font-size:13px;font-weight:500;line-height:1.15;padding:4px 0 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .stat-lbl{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;margin-top:4px}
-.cat-hours{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:12px}
+.cat-hours{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 14px;margin-bottom:12px;box-shadow:var(--shadow-sm)}
 .cat-hours-title{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:10px}
 .cat-hour-row{display:flex;align-items:center;gap:10px;margin-bottom:6px;font-size:12px}
 .cat-hour-bar-wrap{flex:1;height:5px;background:var(--border);border-radius:3px;overflow:hidden}
@@ -32,35 +32,36 @@
 .section-hdr{font-size:9px;color:var(--muted);letter-spacing:1.2px;text-transform:uppercase;margin:20px 0 8px;display:flex;align-items:center;justify-content:space-between}
 .cert-grid{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:4px}
 .filter-bar{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin-bottom:12px;align-items:center}
-.filter-bar select,.filter-bar input{background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 9px;height:30px;outline:none;transition:border-color .15s;width:100%;box-sizing:border-box}
+.filter-bar select,.filter-bar input{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:11px;padding:5px 9px;height:30px;outline:none;transition:border-color .2s,box-shadow .2s;width:100%;box-sizing:border-box}
+.filter-bar select:focus,.filter-bar input:focus{box-shadow:0 0 0 3px rgba(212,175,55,.15)}
 .filter-bar select:focus,.filter-bar input:focus{border-color:var(--brass)}
 .filter-bar .filter-search-row{grid-column:1/-1;display:flex;gap:6px;align-items:center}
 .filter-bar .filter-search-row input{flex:1;min-width:0}
 .filter-count{font-size:10px;color:var(--muted);white-space:nowrap}
 .empty-note{font-size:12px;color:var(--muted);padding:20px;text-align:center}
-.load-more{width:100%;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px;font-size:11px;color:var(--muted);cursor:pointer;font-family:inherit;margin-top:4px}
+.load-more{width:100%;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px;font-size:11px;color:var(--muted);cursor:pointer;font-family:inherit;margin-top:4px;transition:border-color .2s,color .2s}
 .load-more:hover{border-color:var(--brass);color:var(--text)}
 
 /* Log manually modal */
-.modal-overlay{position:fixed;inset:0;background:#00000088;display:flex;align-items:flex-end;justify-content:center;z-index:500;padding:0}
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);display:flex;align-items:flex-end;justify-content:center;z-index:500;padding:0}
 .modal-overlay.hidden{display:none}
-.modal-sheet{background:var(--bg);border-radius:16px 16px 0 0;padding:20px 20px 40px;width:100%;max-width:640px;max-height:90vh;overflow-y:auto}
+.modal-sheet{background:var(--bg);border-radius:var(--radius-lg) var(--radius-lg) 0 0;padding:20px 20px 40px;width:100%;max-width:640px;max-height:90vh;overflow-y:auto;box-shadow:var(--shadow-lg)}
 .modal-title{font-size:14px;font-weight:500;margin-bottom:16px;display:flex;align-items:center;justify-content:space-between}
 .modal-close{background:none;border:none;color:var(--muted);font-size:18px;cursor:pointer;padding:0}
 .form-field{margin-bottom:12px}
 .form-field label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:4px}
-.form-field input,.form-field select,.form-field textarea{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:12px;padding:8px 10px;outline:none;transition:border-color .15s}
-.form-field input:focus,.form-field select:focus,.form-field textarea:focus{border-color:var(--brass)}
+.form-field input,.form-field select,.form-field textarea{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:12px;padding:8px 10px;outline:none;transition:border-color .2s,box-shadow .2s}
+.form-field input:focus,.form-field select:focus,.form-field textarea:focus{border-color:var(--brass);box-shadow:0 0 0 3px rgba(212,175,55,.15)}
 .form-row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-.btn-primary{background:var(--brass);color:#000;border:none;border-radius:8px;padding:11px 20px;font-family:inherit;font-size:12px;font-weight:500;cursor:pointer;width:100%}
-.btn-primary:hover{opacity:.9}
-.btn-secondary{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 20px;font-family:inherit;font-size:12px;color:var(--text);cursor:pointer;width:100%}
-.trip-pick-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 12px;margin-bottom:6px;cursor:pointer;font-size:12px;transition:border-color .15s}
+.btn-primary{background:var(--brass);color:#000;border:none;border-radius:var(--radius-sm);padding:11px 20px;font-family:inherit;font-size:12px;font-weight:500;cursor:pointer;width:100%;transition:all .2s}
+.btn-primary:hover{opacity:.9;box-shadow:0 2px 8px rgba(212,175,55,.35);transform:translateY(-1px)}
+.btn-secondary{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:10px 20px;font-family:inherit;font-size:12px;color:var(--text);cursor:pointer;width:100%;transition:all .2s}
+.trip-pick-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;margin-bottom:6px;cursor:pointer;font-size:12px;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
 .trip-pick-card:hover,.trip-pick-card.selected{border-color:var(--brass);background:var(--card)}
 .trip-pick-card .tpc-boat{font-weight:500;margin-bottom:3px}
 .trip-pick-card .tpc-sub{color:var(--muted);font-size:11px}
 .wx-row{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
-.manual-member-drop{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 6px 6px;z-index:200;max-height:180px;overflow-y:auto;display:none}
+.manual-member-drop{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 var(--radius-sm) var(--radius-sm);z-index:200;max-height:180px;overflow-y:auto;display:none;box-shadow:var(--shadow-md)}
 .manual-member-drop .mm-item{padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border)}
 .manual-member-drop .mm-item:hover{background:var(--card)}
 .manual-member-drop .mm-guest{font-size:10px;color:var(--brass);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
@@ -74,14 +75,14 @@ details#portDetails summary::-webkit-details-marker{display:none}
 details#portDetails[open] #portSummaryLabel::after{content:' ▴';font-size:8px}
 details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-size:8px}
 /* ── Member heatmap ── */
-.member-heatmap{background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:12px;overflow:hidden}
+.member-heatmap{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:12px;overflow:hidden;box-shadow:var(--shadow-sm)}
 .member-heatmap-header{display:flex;align-items:center;justify-content:space-between;padding:10px 14px 0}
 .member-heatmap-title{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase}
-.heatmap-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden}
-.heatmap-toggle button{background:var(--surface);border:none;color:var(--muted);font-family:inherit;font-size:10px;padding:4px 10px;cursor:pointer;transition:background .15s,color .15s;border-right:1px solid var(--border)}
+.heatmap-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden}
+.heatmap-toggle button{background:var(--surface);border:none;color:var(--muted);font-family:inherit;font-size:10px;padding:4px 10px;cursor:pointer;transition:background .2s,color .2s;border-right:1px solid var(--border)}
 .heatmap-toggle button:last-child{border-right:none}
 .heatmap-toggle button.active{background:var(--brass);color:#000;font-weight:500}
-#memberHeatmap{height:260px;border-radius:0 0 8px 8px}
+#memberHeatmap{height:260px;border-radius:0 0 var(--radius-md) var(--radius-md)}
 /* Logbook-only: detailed toggle */
 .trip-detailed{display:none;margin-top:6px}
 .trip-detailed.open{display:block}
@@ -104,14 +105,14 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .lightbox-nav.next{right:12px}
 
 /* ── Confirmations ── */
-.conf-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:8px 12px;margin-bottom:6px}
+.conf-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:8px 12px;margin-bottom:6px;box-shadow:var(--shadow-sm)}
 .conf-card .conf-line{font-size:11px;color:var(--text);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
 .conf-card .conf-line .conf-name{font-weight:500}
 .conf-card .conf-line .conf-type{color:var(--muted)}
 .conf-card .conf-line .conf-boat-info{color:var(--brass)}
 .conf-card .conf-line .conf-date-info{color:var(--muted);font-size:10px}
 .conf-card .conf-actions{display:flex;gap:6px;margin-top:6px}
-.conf-card .conf-actions button{font-size:10px;font-family:inherit;padding:4px 10px;border-radius:6px;cursor:pointer;border:1px solid}
+.conf-card .conf-actions button{font-size:10px;font-family:inherit;padding:4px 10px;border-radius:var(--radius-sm);cursor:pointer;border:1px solid}
 .conf-card .btn-confirm{background:var(--green)18;color:var(--green);border-color:var(--green)55}
 .conf-card .btn-confirm:hover{background:var(--green)33}
 .conf-card .btn-reject{background:var(--red)18;color:var(--red);border-color:var(--red)55}
@@ -132,7 +133,7 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
   .filter-bar{grid-template-columns:1fr 1fr}
   .form-row{grid-template-columns:1fr}
   .wx-row{grid-template-columns:1fr 1fr}
-  .modal-sheet{border-radius:14px 14px 0 0;padding:16px 14px 32px;max-height:95vh}
+  .modal-sheet{border-radius:var(--radius-lg) var(--radius-lg) 0 0;padding:16px 14px 32px;max-height:95vh}
   .gm-row{grid-template-columns:1fr}
   .trip-body{padding:8px 10px}
   .lightbox-nav{padding:6px 10px;font-size:20px}

--- a/login/index.html
+++ b/login/index.html
@@ -22,12 +22,12 @@
     #roleScreen, #accountScreen { display:none; }
     .role-greeting { color:var(--brass); font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; }
     .role-btn {
-      width:100%; padding:18px 20px; margin-bottom:10px; border-radius:8px;
+      width:100%; padding:18px 20px; margin-bottom:10px; border-radius:var(--radius-md);
       border:1px solid var(--border); background:var(--surface); cursor:pointer;
-      display:flex; align-items:center; gap:14px; transition:border-color .15s, background .15s;
-      text-align:left;
+      display:flex; align-items:center; gap:14px; transition:all .2s;
+      text-align:left; box-shadow:var(--shadow-sm);
     }
-    .role-btn:hover { border-color:var(--brass); background:var(--card); }
+    .role-btn:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
     .role-btn .role-icon { font-size:22px; flex-shrink:0; }
     .role-btn .role-label { color:var(--text); font-size:13px; font-weight:500; letter-spacing:.5px; }
     .role-btn .role-desc { color:var(--muted); font-size:11px; margin-top:2px; }

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -23,22 +23,22 @@
     .filter-group-label { font-size:9px; color:var(--muted); letter-spacing:1px; min-width:68px; flex-shrink:0; }
     .filter-btn { background:var(--surface); border:1px solid var(--border); color:var(--muted);
       border-radius:20px; padding:5px 14px; font-size:11px; font-family:inherit; cursor:pointer;
-      letter-spacing:.5px; transition:all .15s; }
+      letter-spacing:.5px; transition:all .2s; }
     .filter-btn.active { background:var(--brass); color:#0b1f38; border-color:var(--brass); }
     .filter-btn:hover:not(.active):not(.muted) { border-color:var(--brass); color:var(--brass); }
     .filter-btn.muted { opacity:0.3; pointer-events:none; border-style:dashed; }
 
     /* ── Stat strip ── */
     .stat-strip { display:grid; grid-template-columns:repeat(5,1fr); gap:8px; margin-bottom:20px; }
-    .stat-card { background:var(--surface); border:1px solid var(--border); border-radius:8px;
-      padding:12px; text-align:center; }
+    .stat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
+      padding:12px; text-align:center; box-shadow:var(--shadow-sm); }
     .stat-num { font-size:24px; color:var(--brass); font-weight:500; }
     .stat-label { font-size:10px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
     @media(max-width:580px){ .stat-strip { grid-template-columns:repeat(2,1fr); } }
 
     /* ── Request card ── */
-    .req-card { background:var(--card); border:1px solid var(--border); border-radius:8px;
-      padding:14px 16px; margin-bottom:10px; transition:border-color .15s; }
+    .req-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+      padding:14px 16px; margin-bottom:10px; transition:border-color .2s,box-shadow .2s; box-shadow:var(--shadow-sm); }
     .req-card.resolved { opacity:.45; }
     .req-card.sev-critical { border-left:3px solid var(--red); }
     .req-card.sev-high     { border-left:3px solid var(--orange); }
@@ -50,8 +50,8 @@
     .req-meta  { display:flex; flex-wrap:wrap; gap:6px; align-items:center; font-size:11px; color:var(--muted); }
     .req-desc  { font-size:12px; color:var(--muted); margin-top:8px; line-height:1.5; }
     .req-actions { display:flex; gap:8px; align-items:center; margin-top:10px; flex-wrap:wrap; }
-    .req-photo { width:80px; height:60px; object-fit:cover; border-radius:6px; border:1px solid var(--border);
-      margin-top:8px; cursor:pointer; transition:opacity .15s; }
+    .req-photo { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm); border:1px solid var(--border);
+      margin-top:8px; cursor:pointer; transition:opacity .2s; }
     .req-photo:hover { opacity:.8; }
 
     /* ── Comments ── */
@@ -77,25 +77,26 @@
       border:1px solid var(--red)44; border-radius:3px; padding:2px 6px; font-weight:500; }
 
     /* ── Modal ── */
-    .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:200;
+    .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.6); backdrop-filter:blur(4px); -webkit-backdrop-filter:blur(4px); z-index:200;
       display:flex; align-items:center; justify-content:center; padding:16px; }
     .modal-overlay.hidden { display:none; }
-    .modal { background:var(--card); border:1px solid var(--border); border-radius:10px;
-      padding:22px; width:100%; max-width:500px; max-height:90vh; overflow-y:auto; }
+    .modal { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-lg);
+      padding:22px; width:100%; max-width:500px; max-height:90vh; overflow-y:auto; box-shadow:var(--shadow-lg); }
     .modal h3 { color:var(--brass); margin-bottom:16px; font-size:15px; }
     .field { margin-bottom:14px; }
     .field label { display:block; font-size:10px; color:var(--muted); letter-spacing:.8px; margin-bottom:6px; }
     .field input, .field select, .field textarea {
-      width:100%; background:var(--surface); border:1px solid var(--border); border-radius:6px;
-      color:var(--text); padding:9px 10px; font-size:13px; font-family:inherit; box-sizing:border-box; }
+      width:100%; background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
+      color:var(--text); padding:9px 10px; font-size:13px; font-family:inherit; box-sizing:border-box; transition:border-color .2s,box-shadow .2s; outline:none; }
+    .field input:focus, .field select:focus, .field textarea:focus { border-color:var(--brass); box-shadow:0 0 0 3px rgba(212,175,55,.15); }
     .field textarea { resize:vertical; min-height:72px; }
     .btn-row { display:flex; gap:8px; justify-content:flex-end; margin-top:4px; }
 
     /* Severity selector */
     .sev-btns { display:flex; gap:6px; flex-wrap:wrap; }
-    .sev-btn { flex:1; min-width:70px; padding:8px 4px; border-radius:6px; border:1px solid;
+    .sev-btn { flex:1; min-width:70px; padding:8px 4px; border-radius:var(--radius-sm); border:1px solid;
       font-size:11px; font-family:inherit; cursor:pointer; text-align:center; font-weight:bold;
-      letter-spacing:.5px; transition:all .15s; }
+      letter-spacing:.5px; transition:all .2s; }
     .sev-btn[data-sev="low"]      { color:var(--green);  border-color:var(--green)55;  background:var(--green)11; }
     .sev-btn[data-sev="medium"]   { color:var(--yellow); border-color:var(--yellow)55; background:var(--yellow)11; }
     .sev-btn[data-sev="high"]     { color:var(--orange); border-color:var(--orange)55; background:var(--orange)11; }
@@ -104,13 +105,13 @@
 
     /* Category selector */
     .cat-btns { display:flex; gap:6px; flex-wrap:wrap; }
-    .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:6px; border:1px solid var(--border);
+    .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border);
       background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit;
-      cursor:pointer; text-align:center; transition:all .15s; }
+      cursor:pointer; text-align:center; transition:all .2s; }
     .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
 
     /* Photo preview */
-    .photo-preview { width:80px; height:60px; object-fit:cover; border-radius:6px;
+    .photo-preview { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm);
       border:1px solid var(--border); margin-top:6px; display:none; }
     .photo-preview.show { display:block; }
 
@@ -118,7 +119,7 @@
     .photo-overlay { position:fixed; inset:0; background:rgba(0,0,0,.9); z-index:300;
       display:flex; align-items:center; justify-content:center; cursor:pointer; }
     .photo-overlay.hidden { display:none; }
-    .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:8px; }
+    .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:var(--radius-md); }
 
     /* ── Responsive ── */
     @media(max-width:600px){

--- a/member/index.html
+++ b/member/index.html
@@ -22,17 +22,18 @@
 .member-actions { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
 .member-actions .act-btn {
   flex:1; min-width:100px; background:var(--surface); border:1px solid var(--border);
-  border-radius:8px; padding:10px 12px; cursor:pointer; font-family:inherit;
+  border-radius:var(--radius-md); padding:10px 12px; cursor:pointer; font-family:inherit;
   font-size:11px; color:var(--text); text-align:center; text-decoration:none;
-  transition:border-color .15s,background .15s; display:block;
+  transition:all .2s; display:block; box-shadow:var(--shadow-sm);
 }
-.member-actions .act-btn:hover { border-color:var(--brass); background:var(--card); }
+.member-actions .act-btn:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
 
 /* ── Tabs ── */
 .hub-tabs { display:flex; gap:0; border-bottom:1px solid var(--border); margin-bottom:14px; overflow-x:auto; }
 .hub-tab  { padding:10px 16px; border:none; background:none; color:var(--muted);
-  font-family:inherit; font-size:11px; letter-spacing:.8px; cursor:pointer;
-  border-bottom:2px solid transparent; white-space:nowrap; transition:color .15s; }
+  font-family:inherit; font-size:11px; letter-spacing:.6px; cursor:pointer;
+  border-bottom:2px solid transparent; white-space:nowrap; transition:color .2s,border-color .2s; margin-bottom:-1px; }
+.hub-tab:hover:not(.active) { color:var(--text); }
 .hub-tab.active { color:var(--brass); border-bottom-color:var(--brass); }
 
 /* ── Boat category section ── */
@@ -53,8 +54,8 @@
 .co-sub   { font-size:10px; color:var(--muted); margin-top:2px; }
 
 /* ── Recent trips ── */
-.pub-trip { background:var(--card); border:1px solid var(--border); border-radius:8px;
-  padding:12px 14px; margin-bottom:8px; cursor:pointer; transition:border-color .15s; }
+.pub-trip { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:12px 14px; margin-bottom:8px; cursor:pointer; transition:border-color .2s,box-shadow .2s; box-shadow:var(--shadow-sm); }
 .pub-trip:hover { border-color:var(--brass); }
 .pub-trip-head { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; }
 .pub-trip-date  { font-size:10px; color:var(--brass); margin-bottom:2px; }
@@ -70,19 +71,19 @@
 
 /* ── Stats card ── */
 .stats-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:8px; margin-bottom:14px; }
-.stat-box { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px 12px; text-align:center; }
+.stat-box { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 12px; text-align:center; box-shadow:var(--shadow-sm); }
 .stat-box .sn { font-size:24px; color:var(--brass); font-weight:500; }
 .stat-box .sl { font-size:9px; color:var(--muted); margin-top:4px; letter-spacing:.5px; }
 
 /* ── Cert badges ── */
-.cert-section { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:14px 16px; margin-bottom:12px; }
+.cert-section { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 16px; margin-bottom:12px; box-shadow:var(--shadow-sm); }
 .cert-section-title { font-size:9px; color:var(--muted); letter-spacing:1.2px; margin-bottom:10px; }
 /* ── Inline report form styles ── */
 .cat-btns { display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
-.cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:6px; border:1px solid var(--border); background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit; cursor:pointer; text-align:center; transition:all .15s; }
+.cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border); background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit; cursor:pointer; text-align:center; transition:all .2s; }
 .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
 .sev-btns { display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
-.sev-btn { flex:1; min-width:60px; padding:7px 4px; border-radius:6px; border:1px solid; font-size:11px; font-family:inherit; cursor:pointer; text-align:center; font-weight:600; letter-spacing:.4px; transition:all .15s; }
+.sev-btn { flex:1; min-width:60px; padding:7px 4px; border-radius:var(--radius-sm); border:1px solid; font-size:11px; font-family:inherit; cursor:pointer; text-align:center; font-weight:600; letter-spacing:.4px; transition:all .2s; }
 .sev-btn[data-sev="low"]      { color:var(--green);  border-color:var(--green)55;  background:var(--green)11;  }
 .sev-btn[data-sev="medium"]   { color:var(--yellow); border-color:var(--yellow)55; background:var(--yellow)11; }
 .sev-btn[data-sev="high"]     { color:var(--orange); border-color:var(--orange)55; background:var(--orange)11; }
@@ -91,7 +92,7 @@
 .ir-type-grid { display:grid; grid-template-columns:1fr 1fr; gap:4px; margin-top:4px; }
 /* ── Fleet status ─────────────────────────── */
 .fleet-status-block { margin-bottom:4px; }
-.fsb-header { display:flex;align-items:center;gap:10px;padding:8px 12px;cursor:pointer;border-radius:6px;background:var(--surface);transition:background .15s;border-left:3px solid transparent; }
+.fsb-header { display:flex;align-items:center;gap:10px;padding:8px 12px;cursor:pointer;border-radius:var(--radius-sm);background:var(--surface);transition:background .2s;border-left:3px solid transparent; }
 .fsb-header:hover { background:var(--surface2,#132233); }
 .fsb-emoji { font-size:14px;flex-shrink:0; }
 .fsb-label { font-size:12px;color:var(--muted);flex:1;text-transform:uppercase;letter-spacing:.04em; }
@@ -103,7 +104,7 @@
 .fsb-arrow { font-size:11px;color:var(--muted); }
 .fsb-body { padding:4px 0; }
 .fleet-cat-grid { display:flex;flex-wrap:wrap;gap:6px;padding:4px; }
-.bc-card { background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 12px;font-size:12px; }
+.bc-card { background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;font-size:12px; }
 .bc-avail { border-left:3px solid #2ecc71;cursor:pointer; }
 .bc-avail:hover { background:var(--surface2,#132233); }
 .bc-out { border-left:3px solid var(--brass); }
@@ -111,13 +112,13 @@
 .bc-oos { opacity:.5; }
 
 /* ── Pending confirmations ── */
-.conf-card { background:var(--card); border:1px solid var(--border); border-radius:8px;
+.conf-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); box-shadow:var(--shadow-sm);
   padding:12px 14px; margin-bottom:8px; }
 .conf-card .conf-from { font-size:12px; font-weight:500; color:var(--text); }
 .conf-card .conf-detail { font-size:11px; color:var(--muted); margin-top:3px; }
 .conf-card .conf-boat { font-size:11px; color:var(--brass); margin-top:2px; }
 .conf-card .conf-actions { display:flex; gap:6px; margin-top:8px; }
-.conf-card .conf-actions button { font-size:11px; font-family:inherit; padding:5px 12px; border-radius:6px; cursor:pointer; border:1px solid; }
+.conf-card .conf-actions button { font-size:11px; font-family:inherit; padding:5px 12px; border-radius:var(--radius-sm); cursor:pointer; border:1px solid; }
 .conf-card .btn-confirm { background:var(--green)18; color:var(--green); border-color:var(--green)55; }
 .conf-card .btn-confirm:hover { background:var(--green)33; }
 .conf-card .btn-reject { background:var(--red)18; color:var(--red); border-color:var(--red)55; }
@@ -138,7 +139,7 @@
   pointer-events:none; }
 
 /* ── Volunteer event cards ── */
-.vol-card { background:var(--card); border:1px solid var(--border); border-radius:8px;
+.vol-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); box-shadow:var(--shadow-sm);
   padding:12px 14px; margin-bottom:8px; }
 .vol-card-head { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; }
 .vol-card-title { font-size:13px; font-weight:500; color:var(--text); }

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,14 @@
   --orange:  #e67e22;
   --blue:    #2980b9;
   --faint:   #6b92b844;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'DM Mono', 'Courier New', monospace;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.18);
+  --shadow-md: 0 2px 8px rgba(0,0,0,.22);
+  --shadow-lg: 0 8px 30px rgba(0,0,0,.35);
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
 }
 /* ── Tide chart (shared SVG classes) ───────────────────────────── */
 .c-brass  { fill: var(--brass);  stroke: var(--brass);  }
@@ -41,21 +49,21 @@
 .chart-line   { fill: none; stroke-width: 1; opacity: 0.7; }
 .chart-dot    { opacity: 0.8; }
 .chart-now    { stroke: var(--faint); stroke-width: 1; stroke-dasharray: 3,3; }
-.chart-now-t  { font: 8px 'DM Mono', monospace; fill: var(--brass); }
-.chart-axis-t { font: 8px 'DM Mono', monospace; fill: var(--muted); }
-.chart-lbl    { font: 9px 'DM Mono', monospace; }
+.chart-now-t  { font: 8px var(--font-mono); fill: var(--brass); }
+.chart-axis-t { font: 8px var(--font-mono); fill: var(--muted); }
+.chart-lbl    { font: 9px var(--font-mono); }
 .chart-lbl-bg { fill: var(--card); opacity: 0.85; }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-body{background:var(--bg);color:var(--text);font-family:'DM Mono',monospace;font-size:14px;line-height:1.6;min-height:100vh}
+body{background:var(--bg);color:var(--text);font-family:var(--font-sans);font-size:14px;line-height:1.6;min-height:100vh;-webkit-font-smoothing:antialiased}
 a{color:var(--brass);text-decoration:none}
 a:hover{text-decoration:underline}
 
 /* ── Header ─────────────────────────────────────────────────────── */
-header{background:var(--surface);border-bottom:1px solid var(--border);padding:12px 24px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100}
+header{background:var(--surface);border-bottom:1px solid var(--border);box-shadow:var(--shadow-md);padding:12px 24px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100}
 .logo{font-size:18px;font-weight:500;color:var(--brass);letter-spacing:1px}
 .subtitle{font-size:11px;color:var(--muted);letter-spacing:.5px;margin-left:12px}
-.lang-btn{background:none;border:1px solid var(--border);color:var(--muted);font-family:inherit;font-size:11px;padding:4px 10px;border-radius:4px;cursor:pointer;letter-spacing:.5px}
-.lang-btn:hover{color:var(--brass);border-color:var(--brass)}
+.lang-btn{background:none;border:1px solid var(--border);color:var(--muted);font-family:inherit;font-size:11px;padding:4px 10px;border-radius:var(--radius-sm);cursor:pointer;letter-spacing:.5px;transition:color .2s,border-color .2s,background .2s}
+.lang-btn:hover{color:var(--brass);border-color:var(--brass);background:rgba(212,175,55,.06)}
 
 /* ── Main layout ────────────────────────────────────────────────── */
 main{max-width:1100px;margin:0 auto;padding:24px 20px 48px}
@@ -64,13 +72,13 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 
 /* ── Stat boxes ─────────────────────────────────────────────────── */
 .stats-row{display:flex;gap:16px;flex-wrap:wrap;margin-bottom:20px}
-.stat-box{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:20px 24px;flex:1;min-width:140px;text-align:center}
+.stat-box{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 24px;flex:1;min-width:140px;text-align:center;box-shadow:var(--shadow-sm)}
 .stat-val{font-size:32px;font-weight:500;color:var(--brass);line-height:1.2}
 .stat-lbl{font-size:11px;color:var(--muted);letter-spacing:.5px;margin-top:4px}
 
 /* ── Category breakdown ─────────────────────────────────────────── */
 .cat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:10px}
-.cat-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:14px 16px;display:flex;align-items:center;gap:12px}
+.cat-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;display:flex;align-items:center;gap:12px;box-shadow:var(--shadow-sm)}
 .cat-emoji{font-size:22px;flex-shrink:0}
 .cat-info{flex:1;min-width:0}
 .cat-name{font-size:12px;color:var(--text);font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
@@ -78,7 +86,7 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 
 /* ── On the water strip ─────────────────────────────────────────── */
 .stat-strip{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-bottom:14px}
-.strip-cell{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:12px 10px;text-align:center}
+.strip-cell{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 10px;text-align:center;box-shadow:var(--shadow-sm)}
 .strip-n{font-size:22px;color:var(--brass);font-weight:500}
 .strip-l{font-size:10px;color:var(--muted);letter-spacing:1px;margin-top:2px}
 .live-badge{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--green);margin-right:6px;animation:pulse 2s infinite}
@@ -87,8 +95,8 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 /* ── Membership row (active members + CTA) ─────────────────────── */
 .membership-row{display:grid;grid-template-columns:minmax(160px,1fr) 2fr;gap:12px;align-items:stretch;margin-bottom:20px}
 .membership-row .stat-box{padding:16px 20px}
-.become-member-btn{display:flex;align-items:center;justify-content:center;text-align:center;background:var(--brass);color:#0b1f38;border:1px solid var(--brass);border-radius:8px;padding:16px 20px;font-family:inherit;font-size:14px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;text-decoration:none;transition:opacity .15s ease,transform .15s ease}
-.become-member-btn:hover{opacity:.9;text-decoration:none;transform:translateY(-1px)}
+.become-member-btn{display:flex;align-items:center;justify-content:center;text-align:center;background:var(--brass);color:#0b1f38;border:1px solid var(--brass);border-radius:var(--radius-md);padding:16px 20px;font-family:inherit;font-size:14px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;text-decoration:none;transition:all .2s ease;box-shadow:var(--shadow-sm)}
+.become-member-btn:hover{opacity:.9;text-decoration:none;transform:translateY(-1px);box-shadow:0 4px 12px rgba(212,175,55,.35)}
 @media(max-width:600px){
   .membership-row{grid-template-columns:1fr}
   .become-member-btn{padding:14px 16px;font-size:13px}
@@ -101,21 +109,21 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .flag-banner-wrap{margin-bottom:14px}
 .duty-pills{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:14px}
 .water-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;margin-top:12px}
-.water-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:14px 16px;display:flex;align-items:center;gap:12px}
+.water-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;display:flex;align-items:center;gap:12px;box-shadow:var(--shadow-sm)}
 .water-emoji{font-size:20px;flex-shrink:0}
 .water-name{font-size:13px;color:var(--text);font-weight:500}
 .water-loc{font-size:11px;color:var(--muted)}
 .empty-msg{color:var(--muted);font-size:12px;font-style:italic;padding:12px 0}
 
 /* ── Right column: weather widget + tide ────────────────────────── */
-.wx-widget{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:14px 16px;margin-bottom:14px}
+.wx-widget{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;margin-bottom:14px;box-shadow:var(--shadow-sm)}
 .wx-widget .flag-pill{display:none!important}
 .wx-widget .wx-status-badges{display:none!important}
 .wx-cell{padding:4px 0}
 
 /* ── Map + Stats combo ──────────────────────────────────────────── */
 .map-stats{display:grid;grid-template-columns:3fr 1fr 280px;gap:16px;align-items:start}
-#map-container{height:520px;border-radius:8px;overflow:hidden;border:1px solid var(--border);background:var(--surface)}
+#map-container{height:520px;border-radius:var(--radius-md);overflow:hidden;border:1px solid var(--border);background:var(--surface);box-shadow:var(--shadow-sm)}
 #map-container .leaflet-control-attribution{font-size:9px;background:rgba(11,31,56,.8)!important;color:var(--muted)!important}
 #map-container .leaflet-control-attribution a{color:var(--muted)!important}
 .ytd-sidebar{display:flex;flex-direction:column;gap:10px}
@@ -124,12 +132,12 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .ytd-sidebar h3{font-size:11px;font-weight:500;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin:6px 0 4px}
 
 /* ── Future text placeholder ────────────────────────────────────── */
-.future-text{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:20px 24px;text-align:center}
+.future-text{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 24px;text-align:center;box-shadow:var(--shadow-sm)}
 .future-text p{color:var(--muted);font-size:12px;font-style:italic}
 
 /* ── Captains ───────────────────────────────────────────────────── */
 .captain-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(540px,1fr));gap:20px}
-.captain-card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:20px;display:flex;flex-direction:column;gap:12px}
+.captain-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px;display:flex;flex-direction:column;gap:12px;box-shadow:var(--shadow-sm)}
 .captain-header{display:flex;align-items:center;gap:16px}
 .captain-headshot{width:72px;height:72px;border-radius:50%;object-fit:cover;border:2px solid var(--brass);flex-shrink:0}
 .captain-headshot-ph{width:72px;height:72px;border-radius:50%;background:var(--surface);border:2px dashed var(--border);display:flex;align-items:center;justify-content:center;font-size:24px;color:var(--muted);flex-shrink:0}
@@ -137,10 +145,10 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .captain-stats{display:flex;gap:16px;font-size:11px;color:var(--muted);flex-wrap:wrap}
 .captain-stats span{display:flex;align-items:center;gap:4px}
 .captain-certs{display:flex;flex-wrap:wrap;gap:4px}
-.cert-badge{display:inline-flex;align-items:center;gap:5px;background:var(--surface);border:1px solid var(--border);border-radius:5px;padding:4px 8px;font-size:10px;color:var(--text)}
+.cert-badge{display:inline-flex;align-items:center;gap:5px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:4px 8px;font-size:10px;color:var(--text)}
 .cert-badge::before{content:'\2713';color:var(--green);font-weight:bold;font-size:9px}
 .captain-bio{font-size:12px;color:var(--muted);font-style:italic;line-height:1.5;max-width:600px}
-.captain-placeholder{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:24px;text-align:center}
+.captain-placeholder{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:24px;text-align:center;box-shadow:var(--shadow-sm)}
 .captain-placeholder p{color:var(--muted);font-size:12px;font-style:italic}
 /* ── Captain trip table ── */
 .cap-trip-table{width:100%;border-collapse:collapse;font-size:11px}
@@ -148,11 +156,11 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .cap-trip-table td{padding:6px 8px;border-bottom:1px solid var(--border);color:var(--text);white-space:nowrap}
 .cap-trip-table tr:last-child td{border-bottom:none}
 .cap-trip-table td.loc-col{white-space:normal;max-width:140px;overflow:hidden;text-overflow:ellipsis}
-.cap-show-more{width:100%;background:var(--surface);border:1px solid var(--border);border-radius:0 0 8px 8px;padding:6px;font-size:10px;color:var(--muted);cursor:pointer;font-family:inherit;text-align:center}
+.cap-show-more{width:100%;background:var(--surface);border:1px solid var(--border);border-radius:0 0 var(--radius-md) var(--radius-md);padding:6px;font-size:10px;color:var(--muted);cursor:pointer;font-family:inherit;text-align:center}
 .cap-show-more:hover{border-color:var(--brass);color:var(--text)}
 /* ── Captain heatmap ── */
-.cap-heatmap{height:240px;border-radius:8px;border:1px solid var(--border);overflow:hidden;margin-top:8px}
-.cap-hm-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden;margin-bottom:8px}
+.cap-heatmap{height:240px;border-radius:var(--radius-md);border:1px solid var(--border);overflow:hidden;margin-top:8px}
+.cap-hm-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden;margin-bottom:8px}
 .cap-hm-btn{background:var(--surface);border:none;color:var(--muted);font-family:inherit;font-size:10px;padding:4px 10px;cursor:pointer;border-right:1px solid var(--border)}
 .cap-hm-btn:last-child{border-right:none}
 .cap-hm-btn.active{background:var(--brass);color:#000;font-weight:500}
@@ -164,9 +172,9 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 .error-msg{text-align:center;padding:40px 20px;color:var(--red);font-size:13px}
 
 /* ── Modal (for flag detail) ────────────────────────────────────── */
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);display:flex;align-items:center;justify-content:center;z-index:200;padding:20px}
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);display:flex;align-items:center;justify-content:center;z-index:200;padding:20px}
 .modal-overlay.hidden{display:none}
-.modal{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:24px;width:100%;max-width:520px;max-height:85vh;overflow-y:auto}
+.modal{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:100%;max-width:520px;max-height:85vh;overflow-y:auto;box-shadow:var(--shadow-lg)}
 
 /* ── Footer ─────────────────────────────────────────────────────── */
 footer{text-align:center;padding:16px 20px;font-size:10px;color:var(--muted);border-top:1px solid var(--border)}
@@ -188,7 +196,7 @@ footer{text-align:center;padding:16px 20px;font-size:10px;color:var(--muted);bor
   .subtitle{display:none}
   .water-grid{grid-template-columns:1fr}
   .modal-overlay{padding:10px;align-items:flex-end}
-  .modal{max-width:100%;border-radius:14px 14px 0 0;padding:20px 16px;max-height:90vh}
+  .modal{max-width:100%;border-radius:var(--radius-lg) var(--radius-lg) 0 0;padding:20px 16px;max-height:90vh}
 }
 </style>
 </head>

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -22,13 +22,13 @@
     .filter-bar { display:flex; gap:8px; flex-wrap:wrap; margin-bottom:18px; align-items:center; }
     .filter-btn { background:var(--surface); border:1px solid var(--border); color:var(--muted);
       border-radius:20px; padding:5px 14px; font-size:11px; font-family:inherit; cursor:pointer;
-      letter-spacing:.5px; transition:all .15s; }
+      letter-spacing:.5px; transition:all .2s; }
     .filter-btn.active { background:var(--brass); color:#0b1f38; border-color:var(--brass); }
     .filter-btn:hover:not(.active) { border-color:var(--brass); color:var(--brass); }
 
     /* ── Project card ── */
-    .req-card { background:var(--card); border:1px solid var(--border); border-radius:8px;
-      padding:14px 16px; margin-bottom:10px; transition:border-color .15s; cursor:pointer; }
+    .req-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+      padding:14px 16px; margin-bottom:10px; transition:border-color .2s,box-shadow .2s; cursor:pointer; box-shadow:var(--shadow-sm); }
     .req-card:hover { border-color:var(--brass)88; }
     .req-card.resolved { opacity:.45; }
     .req-card.sev-high     { border-left:3px solid var(--orange); }
@@ -38,8 +38,8 @@
     .req-title { font-size:13px; font-weight:500; color:var(--text); margin-bottom:4px; }
     .req-meta  { display:flex; flex-wrap:wrap; gap:6px; align-items:center; font-size:11px; color:var(--muted); }
     .req-desc  { font-size:12px; color:var(--muted); margin-top:8px; line-height:1.5; }
-    .req-photo { width:80px; height:60px; object-fit:cover; border-radius:6px; border:1px solid var(--border);
-      margin-top:8px; cursor:pointer; transition:opacity .15s; }
+    .req-photo { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm); border:1px solid var(--border);
+      margin-top:8px; cursor:pointer; transition:opacity .2s; }
     .req-photo:hover { opacity:.8; }
     .comment-thread { margin-top:8px; border-top:1px solid var(--border)44; padding-top:8px; }
     .comment-item { margin-bottom:8px; }
@@ -60,25 +60,26 @@
     .empty-icon { font-size:32px; margin-bottom:12px; }
 
     /* ── Modal ── */
-    .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:200;
+    .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.6); backdrop-filter:blur(4px); -webkit-backdrop-filter:blur(4px); z-index:200;
       display:flex; align-items:center; justify-content:center; padding:16px; }
     .modal-overlay.hidden { display:none; }
-    .modal { background:var(--card); border:1px solid var(--border); border-radius:10px;
-      padding:22px; width:100%; max-width:500px; max-height:90vh; overflow-y:auto; }
+    .modal { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-lg);
+      padding:22px; width:100%; max-width:500px; max-height:90vh; overflow-y:auto; box-shadow:var(--shadow-lg); }
     .modal h3 { color:var(--brass); margin-bottom:16px; font-size:15px; }
     .field { margin-bottom:14px; }
     .field label { display:block; font-size:10px; color:var(--muted); letter-spacing:.8px; margin-bottom:6px; }
     .field input, .field select, .field textarea {
-      width:100%; background:var(--surface); border:1px solid var(--border); border-radius:6px;
-      color:var(--text); padding:9px 10px; font-size:13px; font-family:inherit; box-sizing:border-box; }
+      width:100%; background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
+      color:var(--text); padding:9px 10px; font-size:13px; font-family:inherit; box-sizing:border-box; transition:border-color .2s,box-shadow .2s; outline:none; }
+    .field input:focus, .field select:focus, .field textarea:focus { border-color:var(--brass); box-shadow:0 0 0 3px rgba(212,175,55,.15); }
     .field textarea { resize:vertical; min-height:72px; }
     .btn-row { display:flex; gap:8px; justify-content:flex-end; margin-top:4px; }
 
     /* Priority selector */
     .prio-btns { display:flex; gap:6px; flex-wrap:wrap; }
-    .prio-btn { flex:1; min-width:70px; padding:8px 4px; border-radius:6px; border:1px solid;
+    .prio-btn { flex:1; min-width:70px; padding:8px 4px; border-radius:var(--radius-sm); border:1px solid;
       font-size:11px; font-family:inherit; cursor:pointer; text-align:center; font-weight:bold;
-      letter-spacing:.5px; transition:all .15s; }
+      letter-spacing:.5px; transition:all .2s; }
     .prio-btn[data-sev="low"]    { color:var(--green);  border-color:var(--green)55;  background:var(--green)11; }
     .prio-btn[data-sev="medium"] { color:var(--yellow); border-color:var(--yellow)55; background:var(--yellow)11; }
     .prio-btn[data-sev="high"]   { color:var(--orange); border-color:var(--orange)55; background:var(--orange)11; }
@@ -86,19 +87,19 @@
 
     /* Category selector */
     .cat-btns { display:flex; gap:6px; flex-wrap:wrap; }
-    .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:6px; border:1px solid var(--border);
+    .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border);
       background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit;
-      cursor:pointer; text-align:center; transition:all .15s; }
+      cursor:pointer; text-align:center; transition:all .2s; }
     .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
 
-    .photo-preview { width:80px; height:60px; object-fit:cover; border-radius:6px;
+    .photo-preview { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm);
       border:1px solid var(--border); margin-top:6px; display:none; }
     .photo-preview.show { display:block; }
 
     .photo-overlay { position:fixed; inset:0; background:rgba(0,0,0,.9); z-index:300;
       display:flex; align-items:center; justify-content:center; cursor:pointer; }
     .photo-overlay.hidden { display:none; }
-    .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:8px; }
+    .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:var(--radius-md); }
 
     /* ── Kanban board ── */
     .kanban-board { display:flex; gap:12px; overflow-x:auto; padding-bottom:12px;
@@ -112,8 +113,8 @@
     .kanban-col-header .col-count { font-size:10px; color:var(--faint);
       background:var(--surface); padding:1px 7px; border-radius:10px; }
     .kanban-col-body { flex:1; overflow-y:auto; padding-right:4px; }
-    .kanban-card { background:var(--card); border:1px solid var(--border); border-radius:6px;
-      padding:10px 12px; margin-bottom:8px; cursor:pointer; transition:border-color .15s; }
+    .kanban-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-sm);
+      padding:10px 12px; margin-bottom:8px; cursor:pointer; transition:border-color .2s,box-shadow .2s; box-shadow:var(--shadow-sm); }
     .kanban-card:hover { border-color:var(--brass)88; }
     .kanban-card.sev-high   { border-left:3px solid var(--orange); }
     .kanban-card.sev-medium { border-left:3px solid var(--yellow); }

--- a/settings/index.html
+++ b/settings/index.html
@@ -12,9 +12,9 @@
 <script>document.write('<script src="../shared/strings-'+(localStorage.getItem('ymirLang')||'IS').toLowerCase()+'.js"><\/script>');</script>
 <script src="../shared/strings.js"></script>
 <style>
-.settings-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);display:flex;align-items:center;justify-content:center;z-index:200;padding:20px}
-.settings-page{max-width:560px;width:100%;background:var(--card);border:1px solid var(--border-l);border-radius:10px;padding:24px 20px 20px;max-height:88vh;overflow-y:auto;position:relative}
-.settings-section{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:16px 18px;margin-bottom:12px}
+.settings-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);display:flex;align-items:center;justify-content:center;z-index:200;padding:20px}
+.settings-page{max-width:560px;width:100%;background:var(--card);border:1px solid var(--border-l);border-radius:var(--radius-lg);padding:24px 20px 20px;max-height:88vh;overflow-y:auto;position:relative;box-shadow:var(--shadow-lg)}
+.settings-section{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:16px 18px;margin-bottom:12px;box-shadow:var(--shadow-sm)}
 .settings-section-title{font-size:9px;color:var(--muted);letter-spacing:1.2px;text-transform:uppercase;margin-bottom:12px;font-weight:600}
 .settings-hint{font-size:11px;color:var(--muted);margin-top:4px}
 .settings-row{display:flex;align-items:center;gap:12px;margin-bottom:10px}
@@ -22,21 +22,21 @@
 .settings-row label{font-size:12px;color:var(--text);flex:1;display:flex;align-items:center;gap:6px;text-transform:none;letter-spacing:0;margin:0}
 .settings-row input[type="text"]{width:80px;font-size:14px;font-weight:500;text-align:center;letter-spacing:2px;padding:8px;text-transform:uppercase}
 .settings-row select{width:auto;min-width:140px;font-size:12px;padding:7px 10px}
-.toggle-group{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden}
-.toggle-group button{background:none;border:none;border-right:1px solid var(--border);padding:7px 14px;font-size:11px;font-family:inherit;cursor:pointer;color:var(--muted);transition:all .15s;white-space:nowrap}
+.toggle-group{display:flex;gap:0;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden}
+.toggle-group button{background:none;border:none;border-right:1px solid var(--border);padding:7px 14px;font-size:11px;font-family:inherit;cursor:pointer;color:var(--muted);transition:all .2s;white-space:nowrap}
 .toggle-group button:last-child{border-right:none}
 .toggle-group button.active{background:var(--brass);color:#0b1f38;font-weight:600}
 .toggle-group button:hover:not(.active){color:var(--text);background:var(--faint)}
 .stat-group-label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;margin:14px 0 6px;font-weight:600}
 .stat-group-label:first-child{margin-top:0}
 .pill-grid{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:4px}
-.pill-toggle{display:inline-flex;align-items:center;padding:5px 12px;border-radius:99px;border:1px solid var(--border);font-size:11px;color:var(--muted);cursor:pointer;transition:all .15s;user-select:none;background:none}
+.pill-toggle{display:inline-flex;align-items:center;padding:5px 12px;border-radius:99px;border:1px solid var(--border);font-size:11px;color:var(--muted);cursor:pointer;transition:all .2s;user-select:none;background:none}
 .pill-toggle:hover{border-color:var(--text);color:var(--text)}
 .pill-toggle.active{background:var(--brass);color:#0b1f38;border-color:var(--brass);font-weight:500}
 .pill-toggle input{display:none}
 .save-bar{position:sticky;bottom:-20px;background:var(--card);border-top:1px solid var(--border);padding:12px 0;margin-top:16px;display:flex;gap:8px;justify-content:flex-end}
 .save-bar .btn{min-width:120px}
-@media(max-width:600px){.settings-overlay{padding:0;align-items:flex-end}.settings-page{max-height:95vh;border-radius:14px 14px 0 0}}
+@media(max-width:600px){.settings-overlay{padding:0;align-items:flex-end}.settings-page{max-height:95vh;border-radius:var(--radius-lg) var(--radius-lg) 0 0}}
 </style>
 </head>
 <body>

--- a/shared/alerts.js
+++ b/shared/alerts.js
@@ -54,7 +54,7 @@
 #ym-alert-banner {
   background: #1a0a05;
   border-bottom: 2px solid var(--red,#e74c3c);
-  font-family: 'DM Mono', monospace;
+  font-family: inherit;
   font-size: 12px;
 }
 #ym-alert-inner {

--- a/shared/style.css
+++ b/shared/style.css
@@ -708,7 +708,7 @@ textarea { min-height: 70px; }
 /* ── PAYROLL PAGE ──────────────────────────────────────────────────────────────────────────── */
 
 .pr-tabs{display:flex;gap:4px;margin-bottom:16px;border-bottom:1px solid var(--border);padding-bottom:10px;flex-wrap:wrap}
-.pr-tab{padding:6px 16px;border:1px solid var(--border);border-radius:16px;background:none;cursor:pointer;font-size:12px;font-weight:600;color:var(--muted);font-family:inherit;transition:all .15s}
+.pr-tab{padding:6px 16px;border:1px solid var(--border);border-radius:16px;background:none;cursor:pointer;font-size:12px;font-weight:600;color:var(--muted);font-family:inherit;transition:all .2s}
 .pr-tab.active{background:var(--brass);color:#fff;border-color:var(--brass)}
 .pr-tab:hover:not(.active){border-color:var(--brass);color:var(--brass)}
 .emp-row{display:flex;align-items:center;gap:12px;padding:10px 0;border-bottom:1px solid var(--border)44;flex-wrap:wrap}
@@ -721,13 +721,13 @@ textarea { min-height: 70px; }
 .emp-fields .field{margin:0}
 .emp-fields label{font-size:10px}
 .cal-nav{display:flex;align-items:center;gap:12px;margin-bottom:12px}
-.cal-nav button{background:none;border:1px solid var(--border);border-radius:6px;padding:4px 12px;cursor:pointer;font-size:16px;color:var(--text);line-height:1.2;font-family:inherit}
+.cal-nav button{background:none;border:1px solid var(--border);border-radius:var(--radius-sm);padding:4px 12px;cursor:pointer;font-size:16px;color:var(--text);line-height:1.2;font-family:inherit;transition:color .2s,border-color .2s}
 .cal-nav button:hover{border-color:var(--brass);color:var(--brass)}
 .cal-month{font-weight:700;font-size:15px;min-width:160px;text-align:center}
 .cal-dows{display:grid;grid-template-columns:repeat(7,1fr);gap:2px;margin-bottom:2px}
 .cal-dow{text-align:center;font-size:10px;font-weight:700;color:var(--muted);padding:4px 0;letter-spacing:.5px}
 .cal-days{display:grid;grid-template-columns:repeat(7,1fr);gap:2px}
-.cal-cell{min-height:80px;border:1px solid var(--border)44;border-radius:6px;padding:5px;background:var(--surface)44;cursor:pointer;transition:background .1s}
+.cal-cell{min-height:80px;border:1px solid var(--border)44;border-radius:var(--radius-sm);padding:5px;background:var(--surface)44;cursor:pointer;transition:background .15s,border-color .15s}
 .cal-cell:hover{background:var(--surface);border-color:var(--brass)66}
 .cal-cell.other-month{opacity:.3}
 .cal-cell.today{border-color:var(--brass);background:var(--brass)11}
@@ -736,15 +736,15 @@ textarea { min-height: 70px; }
 .cal-pill{font-size:10px;padding:2px 6px;border-radius:4px;margin-bottom:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer;display:block;line-height:1.5;border:1px solid transparent}
 .cal-pill:hover{filter:brightness(1.1)}
 .cal-more{font-size:9px;color:var(--muted);margin-top:1px;padding-left:2px}
-.view-toggle{display:flex;border:1px solid var(--border);border-radius:8px;overflow:hidden}
-.view-toggle button{background:none;border:none;padding:5px 14px;cursor:pointer;font-size:12px;font-weight:600;color:var(--muted);font-family:inherit;transition:all .1s}
+.view-toggle{display:flex;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden}
+.view-toggle button{background:none;border:none;padding:5px 14px;cursor:pointer;font-size:12px;font-weight:600;color:var(--muted);font-family:inherit;transition:all .2s}
 .view-toggle button.active{background:var(--brass);color:#fff}
 .ts-table{width:100%;border-collapse:collapse;font-size:12px;margin-bottom:22px}
 .ts-table th{text-align:left;padding:5px 8px;font-size:10px;color:var(--muted);border-bottom:2px solid var(--border);font-weight:600;letter-spacing:.4px}
 .ts-table td{padding:5px 8px;border-bottom:1px solid var(--border)44;vertical-align:middle}
 .ts-table tr:last-child td{border-bottom:none}
 .src-admin{color:var(--brass)}
-.modal-bg{position:fixed;inset:0;background:#00000077;z-index:200;display:flex;align-items:center;justify-content:center}
+.modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:200;display:flex;align-items:center;justify-content:center}
 .modal-box{background:var(--card);border-radius:var(--radius-lg);padding:22px 26px;min-width:320px;max-width:460px;width:90vw;box-shadow:var(--shadow-lg)}
 .modal-title{margin:0 0 16px;font-size:15px;font-weight:700}
 .modal-err{font-size:11px;color:var(--red);min-height:14px;margin-bottom:2px}
@@ -757,7 +757,7 @@ textarea { min-height: 70px; }
 .sec-lbl{font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px;margin:14px 0 6px}
 .pill-ok{font-size:10px;padding:2px 8px;border-radius:10px;background:var(--green);color:#fff}
 .pill-open{font-size:10px;padding:2px 8px;border-radius:10px;background:var(--surface);color:var(--muted);border:1px solid var(--border)}
-.confirm-row{background:var(--surface);border-radius:6px;padding:10px 12px;margin-bottom:6px;display:flex;align-items:flex-start;gap:12px;flex-wrap:wrap}
+.confirm-row{background:var(--surface);border-radius:var(--radius-sm);padding:10px 12px;margin-bottom:6px;display:flex;align-items:flex-start;gap:12px;flex-wrap:wrap}
 .confirm-emp{font-weight:600;font-size:13px;min-width:160px;padding-top:2px}
 .confirm-emp-title{font-size:10px;color:var(--muted)}
 .hrs-group{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
@@ -773,7 +773,7 @@ textarea { min-height: 70px; }
 .lm-table td{padding:5px 10px;border-bottom:1px solid var(--border)44;text-align:right}
 .lm-table td:first-child{text-align:left;font-weight:500}
 .lm-table tr.lm-total td{font-weight:700;border-top:2px solid var(--border);border-bottom:none;background:var(--surface)}
-.btn-del{font-size:10px;padding:2px 8px;background:var(--red)22;color:var(--red);border:1px solid var(--red)44;border-radius:6px;cursor:pointer}
+.btn-del{font-size:10px;padding:2px 8px;background:var(--red)22;color:var(--red);border:1px solid var(--red)44;border-radius:var(--radius-sm);cursor:pointer}
 .edited-badge{font-size:9px;color:var(--muted);margin-left:3px}
 /* Payslip cards */
 .payslip-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:16px;overflow:hidden;box-shadow:var(--shadow-sm)}
@@ -974,14 +974,14 @@ textarea { min-height: 70px; }
   min-width: 42px;
   padding: 6px 2px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
   color: var(--muted);
   font-family: inherit;
   font-size: 9px;
   text-align: center;
   cursor: pointer;
-  transition: all .15s;
+  transition: all .2s;
 }
 .sc-mpick-btn.active { border-color: var(--brass); color: var(--brass); background: var(--brass)11; }
 .sc-mpick-btn.today .sc-mpick-num { color: var(--brass); }

--- a/shared/tides.js
+++ b/shared/tides.js
@@ -271,7 +271,7 @@ function tideWidget(targetEl, { onData } = {}) {
       const lbl = up ? (IS?'Hækkandi':'Rising') : (IS?'Lækkandi':'Falling');
       statusHtml = `<span style="color:${col};font-weight:700;font-size:12px">${up?'↑':'↓'}</span>`
         + `<span style="color:${col};font-size:10px;font-weight:500">${lbl}</span>`
-        + `<span style="font-size:11px;font-weight:500;color:var(--text);font-family:'DM Mono',monospace">${curH.toFixed(1)}m</span>`;
+        + `<span style="font-size:11px;font-weight:500;color:var(--text);font-family:var(--font-mono)">${curH.toFixed(1)}m</span>`;
     } else {
       statusHtml = `<button class="tide-today-btn" style="background:none;border:1px solid var(--border);color:var(--brass);border-radius:4px;padding:0 6px;font-size:9px;cursor:pointer;font-family:inherit;line-height:1.6;letter-spacing:.3px">${IS?'Fara á í dag':'Go to today'}</button>`;
     }

--- a/staff/index.html
+++ b/staff/index.html
@@ -21,30 +21,30 @@
 <style>
 /* ── Tool nav cards ── */
 .nav-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:10px; margin-bottom:20px; }
-.nav-card { background:var(--surface); border:1px solid var(--border); border-radius:10px;
-  padding:16px 14px; cursor:pointer; transition:border-color .15s,background .15s;
-  text-decoration:none; display:flex; flex-direction:column; gap:6px; }
-.nav-card:hover { border-color:var(--brass); background:var(--card); }
+.nav-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:16px 14px; cursor:pointer; transition:all .2s;
+  text-decoration:none; display:flex; flex-direction:column; gap:6px; box-shadow:var(--shadow-sm); }
+.nav-card:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
 .nc-icon  { font-size:22px; }
 .nc-label { font-size:12px; font-weight:500; color:var(--text); letter-spacing:.3px; }
 .nc-desc  { font-size:10px; color:var(--muted); line-height:1.4; }
 
 /* ── Stat strip ── */
 .stat-row  { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }
-.stat-cell { background:var(--card); border:1px solid var(--border); border-radius:8px;
-  padding:12px 10px; text-align:center; }
+.stat-cell { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:12px 10px; text-align:center; box-shadow:var(--shadow-sm); }
 .stat-n { font-size:22px; color:var(--brass); font-weight:500; }
 .stat-l { font-size:9px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
 
 /* ── Section card ── */
-.section { background:var(--surface); border:1px solid var(--border); border-radius:8px;
-  padding:14px 16px; margin-bottom:12px; }
+.section { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:14px 16px; margin-bottom:12px; box-shadow:var(--shadow-sm); }
 .section-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
-.section-head h3 { font-size:9px; letter-spacing:1.5px; color:var(--muted); margin:0; }
+.section-head h3 { font-size:9px; letter-spacing:1px; color:var(--muted); margin:0; }
 
 /* ── Checkout form ── */
-.checkout-form { background:var(--surface); border:1px solid var(--border); border-radius:8px;
-  padding:18px; margin-top:12px; }
+.checkout-form { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
+  padding:18px; margin-top:12px; box-shadow:var(--shadow-sm); }
 .checkout-form h4 { color:var(--brass); font-size:10px; letter-spacing:1px; margin-bottom:14px; }
 .inline-fields { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
 .crew-field { display:flex; align-items:center; gap:10px; }
@@ -53,8 +53,8 @@
   display:flex; align-items:center; justify-content:center; }
 .crew-btn:hover { border-color:var(--brass); }
 .crew-num { width:36px; text-align:center; font-size:16px; }
-.ret-btn  { background:var(--surface); border:1px solid var(--border); border-radius:4px;
-  color:var(--text); font-family:inherit; font-size:11px; padding:4px 8px; cursor:pointer; }
+.ret-btn  { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
+  color:var(--text); font-family:inherit; font-size:11px; padding:4px 8px; cursor:pointer; transition:color .2s,border-color .2s; }
 .ret-btn:hover { border-color:var(--brass); color:var(--brass); }
 
 /* ── Available by category ── */
@@ -115,7 +115,7 @@
 .ob-meta  { font-size:12px; color:#f5a9a9; line-height:1.5; }
 .ob-actions { display:flex; gap:8px; margin-top:10px; flex-wrap:wrap; }
 .ob-btn {
-  padding:6px 14px; border:none; border-radius:4px; font-size:12px;
+  padding:6px 14px; border:none; border-radius:var(--radius-sm); font-size:12px;
   font-weight:bold; cursor:pointer; font-family:inherit;
 }
 .ob-btn-checkin  { background:#27ae60; color:#fff; }
@@ -127,8 +127,8 @@
 .fleet-status-block { margin-bottom:6px; }
 .fsb-header {
   display:flex; align-items:center; gap:10px;
-  padding:8px 12px; cursor:pointer; border-radius:6px;
-  background:var(--surface); transition:background .15s;
+  padding:8px 12px; cursor:pointer; border-radius:var(--radius-sm);
+  background:var(--surface); transition:background .2s;
 }
 .fsb-header:hover { background:var(--surface2,#132233); }
 .fsb-label { font-size:12px; color:var(--muted); min-width:80px; text-transform:uppercase; letter-spacing:.04em; }
@@ -143,8 +143,8 @@
 /* Compact boat cards in fleet status */
 .fleet-cat-grid { display:flex; flex-wrap:wrap; gap:6px; padding:4px 4px; }
 .bc-boat-card {
-  border-radius:5px; padding:7px 10px; min-width:90px; border:1px solid transparent;
-  font-size:12px; transition:all .15s;
+  border-radius:var(--radius-sm); padding:7px 10px; min-width:90px; border:1px solid transparent;
+  font-size:12px; transition:all .2s;
 }
 .bc-boat-card.status-avail { background:#0d2e1a; border-color:var(--green); }
 .bc-boat-card.status-avail:hover { background:#143d22; transform:translateY(-1px); }
@@ -175,31 +175,31 @@
 /* Fleet status bar — emoji pip */
 .fsb-emoji { font-size:14px; flex-shrink:0; }
 /* ── Group checkout modal ────────────────────────────────────────── */
-.group-modal-overlay{position:fixed;inset:0;background:#00000099;z-index:400;display:flex;align-items:flex-end;justify-content:center}
+.group-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:400;display:flex;align-items:flex-end;justify-content:center}
 .group-modal-overlay.hidden{display:none}
-.group-modal-sheet{background:var(--bg);border-radius:16px 16px 0 0;padding:20px 20px 36px;width:100%;max-width:680px;max-height:92vh;overflow-y:auto}
+.group-modal-sheet{background:var(--bg);border-radius:var(--radius-lg) var(--radius-lg) 0 0;padding:20px 20px 36px;width:100%;max-width:680px;max-height:92vh;overflow-y:auto;box-shadow:var(--shadow-lg)}
 .group-modal-title{font-size:14px;font-weight:500;margin-bottom:16px;display:flex;align-items:center;justify-content:space-between}
 .gm-close{background:none;border:none;color:var(--muted);font-size:18px;cursor:pointer}
 .gm-section{margin-bottom:16px}
 .gm-section-label{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:8px}
 .gm-boat-grid{display:flex;flex-wrap:wrap;gap:6px}
-.gm-boat-btn{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:8px 12px;font-size:12px;cursor:pointer;font-family:inherit;color:var(--text);transition:all .15s;display:flex;align-items:center;gap:6px}
+.gm-boat-btn{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:8px 12px;font-size:12px;cursor:pointer;font-family:inherit;color:var(--text);transition:all .2s;display:flex;align-items:center;gap:6px}
 .gm-boat-btn.selected{border-color:var(--brass);background:var(--brass)18;color:var(--text)}
 .gm-boat-btn:disabled{opacity:.4;cursor:not-allowed}
 .gm-stepper{display:flex;align-items:center;gap:14px}
 .gm-stepper-btn{width:32px;height:32px;border-radius:50%;border:1px solid var(--border);background:var(--surface);font-size:18px;cursor:pointer;color:var(--text);display:flex;align-items:center;justify-content:center}
 .gm-stepper-val{font-size:20px;font-weight:500;min-width:32px;text-align:center}
 .gm-staff-wrap{position:relative;margin-bottom:6px}
-.gm-staff-input{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:6px 8px}
-.gm-drop{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 6px 6px;z-index:500;max-height:160px;overflow-y:auto;display:none}
+.gm-staff-input{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:11px;padding:6px 8px}
+.gm-drop{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 var(--radius-sm) var(--radius-sm);z-index:500;max-height:160px;overflow-y:auto;display:none}
 .gm-drop-item{padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border)}
 .gm-field label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:4px}
-.gm-field input,.gm-field select{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
+.gm-field input,.gm-field select{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
 .gm-row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-.gm-activity-link{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:10px 12px;margin-bottom:10px}
+.gm-activity-link{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;margin-bottom:10px}
 .gm-activity-link .link-label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;margin-bottom:6px}
 /* Group card in active checkouts */
-.bc-group-card{background:#0a1e2e;border:1px solid var(--border);border-left:4px solid #2e86c1;border-radius:8px;padding:12px 14px;margin-bottom:8px;cursor:pointer}
+.bc-group-card{background:#0a1e2e;border:1px solid var(--border);border-left:4px solid #2e86c1;border-radius:var(--radius-md);padding:12px 14px;margin-bottom:8px;cursor:pointer;box-shadow:var(--shadow-sm)}
 .bc-group-card.overdue{border-color:var(--red);border-left-color:var(--red)}
 .gc-header{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:6px}
 .gc-boats{font-size:13px;font-weight:500;color:var(--text)}
@@ -209,13 +209,13 @@
 .gc-staff{font-size:11px;color:var(--muted)}
 
 /* ── Guest prompt modal ── */
-.guest-modal-overlay{position:fixed;inset:0;background:#00000099;z-index:600;display:flex;align-items:center;justify-content:center}
+.guest-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:600;display:flex;align-items:center;justify-content:center}
 .guest-modal-overlay.hidden{display:none}
-.guest-modal{background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:20px;width:90%;max-width:360px}
+.guest-modal{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-lg);padding:20px;width:90%;max-width:360px;box-shadow:var(--shadow-lg)}
 .guest-modal h4{font-size:12px;color:var(--brass);letter-spacing:.5px;margin:0 0 14px}
 .guest-modal .gm-field{margin-bottom:10px}
 .guest-modal .gm-field label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:4px}
-.guest-modal .gm-field input{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
+.guest-modal .gm-field input{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
 .guest-modal .btn-row{display:flex;gap:8px;margin-top:14px;justify-content:flex-end}
 .guest-add-hint{font-size:10px;color:var(--brass);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
 .guest-add-hint:hover{background:var(--card)}

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -16,7 +16,7 @@
   <style>
     .filter-bar { display:flex; gap:8px; margin-bottom:16px; flex-wrap:wrap; align-items:center; }
     .filter-bar input, .filter-bar select { flex:1; min-width:140px; }
-    .trip-card { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px 16px; margin-bottom:8px; }
+    .trip-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 16px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
     .trip-card.verified { border-left:3px solid var(--green); }
     .trip-head { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; margin-bottom:8px; }
     .trip-date { font-size:10px; color:var(--brass); margin-bottom:3px; }
@@ -29,10 +29,10 @@
     .badge-linked   { color:var(--brass); border-color:var(--brass)55; background:var(--brass)11; }
     .verify-row { display:flex; align-items:center; gap:8px; margin-top:10px; padding-top:10px; border-top:1px solid var(--border)44; flex-wrap:wrap; }
     .verify-row input[type="text"] { flex:1; min-width:160px; }
-    .staff-comment { margin-top:8px; padding:8px 10px; background:var(--surface); border-radius:6px; font-size:11px; }
+    .staff-comment { margin-top:8px; padding:8px 10px; background:var(--surface); border-radius:var(--radius-sm); font-size:11px; }
     .staff-comment-label { font-size:9px; color:var(--muted); letter-spacing:1px; margin-bottom:3px; }
     .stat-strip { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:20px; }
-    .stat-cell { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:12px 10px; text-align:center; }
+    .stat-cell { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 10px; text-align:center; box-shadow:var(--shadow-sm); }
     .stat-n { font-size:22px; color:var(--brass); font-weight:500; }
     .stat-l { font-size:9px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
     .cert-row { display:flex; align-items:flex-start; justify-content:space-between; padding:10px 0; border-bottom:1px solid var(--border); gap:10px; }
@@ -103,13 +103,13 @@
     <div class="section-label mb-14">CERTIFICATIONS</div>
 
     <!-- Mode toggle -->
-    <div class="mb-16" style="display:flex;gap:0;border:1px solid var(--border);border-radius:8px;overflow:hidden;width:fit-content">
+    <div class="mb-16" style="display:flex;gap:0;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden;width:fit-content">
       <button id="certModeByMember" onclick="setCertMode('member')"
-        class="text-md" style="padding:7px 16px;font-family:inherit;border:none;cursor:pointer;transition:all .15s;background:var(--brass);color:#fff">
+        class="text-md" style="padding:7px 16px;font-family:inherit;border:none;cursor:pointer;transition:all .2s;background:var(--brass);color:#fff">
         By member
       </button>
       <button id="certModeByType" onclick="setCertMode('type')"
-        class="text-md" style="padding:7px 16px;font-family:inherit;border:none;cursor:pointer;transition:all .15s;background:var(--surface);color:var(--muted)">
+        class="text-md" style="padding:7px 16px;font-family:inherit;border:none;cursor:pointer;transition:all .2s;background:var(--surface);color:var(--muted)">
         By credential
       </button>
     </div>
@@ -118,10 +118,10 @@
     <div id="certPanelModeA">
       <div class="mb-14" style="position:relative">
         <input type="text" id="certMemberSearch"
-          class="text-md" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:8px;color:var(--text);font-family:inherit;padding:9px 12px"
+          class="text-md" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;padding:9px 12px"
           oninput="searchCertMember(this.value)">
         <div id="certMemberDrop"
-          style="position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 8px 8px;z-index:100;display:none;max-height:200px;overflow-y:auto">
+          style="position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 var(--radius-sm) var(--radius-sm);z-index:100;display:none;max-height:200px;overflow-y:auto;box-shadow:var(--shadow-md)">
         </div>
       </div>
 
@@ -145,7 +145,7 @@
     <div id="certPanelModeB" style="display:none">
       <div class="flex-center flex-wrap gap-8 mb-12">
         <select id="certFilterType" onchange="applyCertFilter()"
-          class="flex-1 text-md" style="min-width:200px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;padding:7px 10px">
+          class="flex-1 text-md" style="min-width:200px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;padding:7px 10px">
           <option value="">— Select credential —</option>
         </select>
       </div>

--- a/weather/index.html
+++ b/weather/index.html
@@ -21,7 +21,7 @@
 .top-bar-left { display:flex; flex-direction:column; gap:3px; }
 .loc-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
 .loc-name { font-size:16px; color:var(--text); font-weight:500; }
-.loc-coords { font-size:10px; color:var(--muted); font-family:'DM Mono',monospace; }
+.loc-coords { font-size:10px; color:var(--muted); font-family:var(--font-mono); }
 .loc-default-badge { font-size:9px; padding:2px 6px; border-radius:8px; background:var(--surface); border:1px solid var(--border); color:var(--muted); letter-spacing:.5px; }
 .top-bar-right { display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
 
@@ -29,7 +29,7 @@
 
 
 /* ── Flag banner ── */
-.flag-banner { border-radius:10px; padding:14px 18px; margin-bottom:16px; border:1px solid; display:flex; align-items:flex-start; gap:14px; }
+.flag-banner { border-radius:var(--radius-md); padding:14px 18px; margin-bottom:16px; border:1px solid; display:flex; align-items:flex-start; gap:14px; box-shadow:var(--shadow-sm); }
 .flag-advice { font-size:14px; font-weight:500; }
 .flag-reasons { margin-top:8px; display:flex; flex-wrap:wrap; gap:6px; }
 .flag-chip { font-size:10px; padding:2px 8px; border-radius:10px; border:1px solid; opacity:.85; }


### PR DESCRIPTION
Apply the new design tokens (--radius-sm/md/lg, --shadow-sm/md/lg, --font-sans/mono) to inline styles in every page. Cards across admin, member, staff, captain, coxswain, logbook, maintenance, dailylog, saumaklubbur, incidents, settings, and public now have consistent shadows and rounded corners. Modal overlays gain backdrop blur. Form inputs share the brass focus glow. Tabs use tighter letter-spacing and smoother transitions. Login role buttons get a hover lift effect. Hardcoded DM Mono references in alerts.js and tides.js updated to inherit/font-mono.

https://claude.ai/code/session_017qwXxLqLa6i6GNzYbNfNmG