### PR TITLE
Clear saumaklubbur notifications when user views followed project

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -375,6 +375,7 @@ function route_(action, b) {
     case 'removeMaterial':          return removeMaterial_(b);
     case 'followProject':           return followProject_(b);
     case 'unfollowProject':         return unfollowProject_(b);
+    case 'markProjectSeen':         return markProjectSeen_(b);
     case 'getNotifications':        return getNotifications_(b);
     // ── PAYROLL ────────────────────────────────────────────────────────────────────
     case 'clockIn':             return clockIn_(b);
@@ -1318,6 +1319,25 @@ function unfollowProject_(b) {
   updateRow_('maintenance', 'id', b.id, { followers: JSON.stringify(followers) });
   cDel_('maintenance');
   return okJ({ unfollowed: true });
+}
+
+function markProjectSeen_(b) {
+  if (!b.id) return failJ('id required');
+  if (!b.kennitala) return failJ('kennitala required');
+  const ex = findOne_('maintenance', 'id', b.id);
+  if (!ex) return failJ('Request not found', 404);
+  ensureMaintCols_();
+  var followers = [];
+  try { followers = JSON.parse(ex.followers || '[]'); } catch(e) { followers = []; }
+  var kt = String(b.kennitala);
+  var changed = false;
+  followers.forEach(function(f) {
+    if (String(f.kt) === kt) { f.at = now_(); changed = true; }
+  });
+  if (!changed) return okJ({ notFollowing: true });
+  updateRow_('maintenance', 'id', b.id, { followers: JSON.stringify(followers) });
+  cDel_('maintenance');
+  return okJ({ seen: true });
 }
 
 function deleteMaintenance_(b) {

--- a/shared/api.js
+++ b/shared/api.js
@@ -70,7 +70,7 @@ async function apiPost(action, payload) {
   if (action === 'respondConfirmation' || action === 'dismissConfirmation' || action === 'dismissAllConfirmations' ||
       action === 'respondCrewInvite' ||
       action === 'saveMaintenance' || action === 'resolveMaintenance' || action === 'addMaintenanceComment' ||
-      action === 'followProject' || action === 'unfollowProject' ||
+      action === 'followProject' || action === 'unfollowProject' || action === 'markProjectSeen' ||
       action === 'adoptSaumaklubbur' || action === 'approveSaumaklubbur' || action === 'holdSaumaklubbur' ||
       action === 'toggleMaterial' || action === 'addMaterial' || action === 'removeMaterial') {
     try { sessionStorage.removeItem('ymir_getNotifications_'); } catch(e) {}

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -466,6 +466,21 @@ function maintOpenDetail(r, currentUser) {
 
   renderAndWire();
   openModal('maintDetailModal');
+
+  // Mark followed project as seen — clears "updated since follow" notifications
+  (function() {
+    const kt = window._maintUser?.kennitala;
+    if (!kt || !boolVal(r.saumaklubbur)) return;
+    const followers = parseJson(r.followers, []);
+    const myIdx = followers.findIndex(function(f) { return String(f.kt||f) === String(kt); });
+    if (myIdx < 0) return;
+    const myFollow = followers[myIdx];
+    if (!r.updatedAt || !myFollow.at || r.updatedAt <= myFollow.at) return;
+    // Optimistically bump local timestamp so subsequent renders don't re-trigger
+    followers[myIdx] = { kt: String(kt), at: new Date().toISOString() };
+    r.followers = JSON.stringify(followers);
+    apiPost('markProjectSeen', { id: r.id, kennitala: kt }).catch(function() {});
+  })();
 }
 
 function maintRenderCard(r) {


### PR DESCRIPTION
Adds markProjectSeen_ endpoint that bumps the user's follower entry timestamp to now. Called from maintOpenDetail when a user opens a followed project whose updatedAt is newer than their last-seen time.

This closes the gap where followed-project notifications persisted forever — they now clear the next time the user views the project. The follow relationship itself is unchanged; only the "seen" timestamp moves forward.

https://claude.ai/code/session_019Nkh6yYNM1EFUo52jYNTiW