### PR TITLE
Stretch saumaklubbur board columns to fill wide-board width

### DIFF
--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -104,7 +104,7 @@
     /* ── Kanban board ── */
     .kanban-board { display:flex; gap:12px; overflow-x:auto; padding-bottom:12px;
       -webkit-overflow-scrolling:touch; scroll-snap-type:x proximity; }
-    .kanban-col { flex:0 0 220px; min-width:220px; max-height:calc(100vh - 200px);
+    .kanban-col { flex:1 0 220px; min-width:220px; max-height:calc(100vh - 200px);
       display:flex; flex-direction:column; scroll-snap-align:start; }
     .kanban-col-header { font-size:10px; text-transform:uppercase; letter-spacing:1px;
       color:var(--muted); padding:8px 10px; display:flex; align-items:center;


### PR DESCRIPTION
The 4 kanban columns were fixed at 220px (flex:0 0 220px), which left ~252px of empty space on the right of the 1200px wide-board container, visually reading as an empty 5th column slot. Changing flex-grow from 0 to 1 lets the 4 columns grow equally to fill the available width, while flex-shrink:0 + min-width:220px still trigger horizontal scroll on narrower screens and the mobile media query keeps the vertical stack below 600px.

Fixes #485