### PR TITLE
Replace native confirm/prompt with ymConfirm/ymPrompt (#491)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1902,7 +1902,8 @@ async function saveResFromModal() {
 
 async function removeResFromModal(resId) {
   var boatId = editingId;
-  if (!boatId || !confirm(s('boat.removeReservation') + '?')) return;
+  if (!boatId) return;
+  if (!(await ymConfirm(s('boat.removeReservation') + '?'))) return;
   try {
     var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
     var b = _allBoats.find(function(x) { return x.id === boatId; });
@@ -3613,7 +3614,7 @@ async function saveCurrentSlot() {
 
 async function deleteCurrentSlot() {
   if (!_editingSlot || !_editingSlot.slotId) return;
-  if (!confirm(s('slot.confirmDelete'))) return;
+  if (!(await ymConfirm(s('slot.confirmDelete')))) return;
   try {
     await apiPost("deleteSlot", { slotId: _editingSlot.slotId });
     closeModal("slotModal");
@@ -3765,15 +3766,15 @@ function ppToggleRetire(pi, ci, ii) {
   _ppMarkDirty();
   drawPassportEditor();
 }
-function ppAddItem(pi, ci) {
-  const label = prompt('Item name (English)'); if (!label) return;
+async function ppAddItem(pi, ci) {
+  const label = await ymPrompt('Item name (English)'); if (!label) return;
   const id = _ppSlug(label);
   _passportDef.passports[pi].categories[ci].items.push({ id, assessment: 'practical', name: { EN: label, IS: label }, desc: { EN: '', IS: '' } });
   _ppMarkDirty();
   drawPassportEditor();
 }
-function ppAddCategory(pi) {
-  const label = prompt('Category name (English)'); if (!label) return;
+async function ppAddCategory(pi) {
+  const label = await ymPrompt('Category name (English)'); if (!label) return;
   const id = _ppSlug(label);
   _passportDef.passports[pi].categories.push({ id, name: { EN: label, IS: label }, items: [] });
   _ppMarkDirty();
@@ -3802,7 +3803,7 @@ async function passportImportCsv() {
   const file = document.getElementById('passportCsvFile').files[0];
   if (!file) { toast('Choose a CSV file first', 'err'); return; }
   const text = await file.text();
-  if (!confirm('Import this CSV? Items missing from the CSV will be marked retired (not deleted).')) return;
+  if (!(await ymConfirm('Import this CSV? Items missing from the CSV will be marked retired (not deleted).'))) return;
   try {
     await apiPost('importRowingPassportCsv', { csv: text });
     toast('Passport imported.');

--- a/captain/index.html
+++ b/captain/index.html
@@ -915,7 +915,7 @@ async function saveCqReservation() {
 }
 
 async function removeCqReservation(boatId, resId) {
-  if (!confirm(s('boat.removeReservation') + '?')) return;
+  if (!(await ymConfirm(s('boat.removeReservation') + '?'))) return;
   try {
     var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
     var b = _boats.find(x => x.id === boatId);
@@ -1131,7 +1131,7 @@ async function bookCqSlot(slotId) {
 }
 
 async function unbookCqSlot(slotId) {
-  if (!confirm(s('slot.confirmUnbook'))) return;
+  if (!(await ymConfirm(s('slot.confirmUnbook')))) return;
   var slot = _cqSlots.find(function(sl) { return sl.id === slotId; });
   var prevSlot = slot ? Object.assign({}, slot) : null;
   if (slot) {
@@ -1438,7 +1438,8 @@ async function saveBmResFromModal() {
 
 async function removeBmResFromModal(resId) {
   var boatId = _editingBoatId;
-  if (!boatId || !confirm(s('boat.removeReservation') + '?')) return;
+  if (!boatId) return;
+  if (!(await ymConfirm(s('boat.removeReservation') + '?'))) return;
   try {
     var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
     var b = _boats.find(function(x) { return x.id === boatId; });
@@ -1542,7 +1543,8 @@ async function saveCqBoat() {
 
 async function deleteCqBoat() {
   var id = _editingBoatId;
-  if (!id || !confirm(s('admin.confirmDeleteBoat'))) return;
+  if (!id) return;
+  if (!(await ymConfirm(s('admin.confirmDeleteBoat')))) return;
   _boats = _boats.map(function(b) { return b.id === id ? Object.assign({}, b, { active: false }) : b; });
   try {
     await apiPost('saveConfig', { boats: _boats });

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -704,7 +704,7 @@ async function joinSeat(crewId, pairId, seatIndex) {
 }
 
 async function leaveCrewConfirm(crewId) {
-  if (!confirm(s('cox.confirmLeave'))) return;
+  if (!(await ymConfirm(s('cox.confirmLeave')))) return;
   try {
     await apiPost('leaveCrew', { crewId: crewId, kennitala: user.kennitala });
     showToast(s('cox.left'), 'ok');
@@ -803,7 +803,7 @@ async function respondInvite(inviteId, response) {
 }
 
 async function disbandCrewConfirm(crewId) {
-  if (!confirm(s('cox.confirmDisband'))) return;
+  if (!(await ymConfirm(s('cox.confirmDisband')))) return;
   try {
     await apiPost('disbandCrew', { crewId: crewId });
     showToast(s('cox.crewDisbanded'), 'ok');
@@ -923,7 +923,7 @@ async function bookCxSlot(slotId) {
 }
 
 async function unbookCxSlot(slotId) {
-  if (!confirm(s('slot.confirmUnbook'))) return;
+  if (!(await ymConfirm(s('slot.confirmUnbook')))) return;
   var slot = _cxSlots.find(function(sl) { return sl.id === slotId; });
   var prevSlot = slot ? Object.assign({}, slot) : null;
   if (slot) {
@@ -1081,7 +1081,7 @@ function renderPassport() {
 function _esc(s) { return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
 async function signPassportItemClick(itemId) {
-  if (!confirm(s('passport.confirmSign'))) return;
+  if (!(await ymConfirm(s('passport.confirmSign')))) return;
   try {
     var res = await apiPost('signPassportItem', {
       memberId: _passportTargetMemberId,
@@ -1162,7 +1162,7 @@ function ppViewSelf() {
 }
 async function revokeSignoffClick(ev, signoffId) {
   ev.preventDefault(); ev.stopPropagation();
-  var reason = prompt(s('passport.revokeReason'));
+  var reason = await ymPrompt(s('passport.revokeReason'));
   if (reason === null) return;
   try {
     await apiPost('revokePassportSignoff', { signoffId: signoffId, revokedBy: user.name || '', reason: reason || '' });


### PR DESCRIPTION
The remaining native confirm() and prompt() calls in admin/captain/ coxswain showed the browser's "skarfur.github.io says..." dialog instead of the site-styled modal. Migrate them to the existing ymConfirm / ymPrompt helpers in shared/ui.js, which reuse the .modal-overlay + .modal classes from shared/style.css.