### PR TITLE
Center scan QR button and honor custom category emoji

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -542,10 +542,12 @@ function renderLaunchPicker(preselectedBoatId) {
   const avail=boats.filter(b=>!active.find(c=>c.boatId===b.id)&&!boolVal(b.oos));
   if(!avail.length){
     document.getElementById('launchModalBody').innerHTML=
-      '<div class="mb-12">'+
-        '<button class="btn btn-secondary mb-6" style="width:100%;text-align:left" onclick="scanBoatQR()">'+
+      '<div class="mb-12" style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px">'+
+        '<button class="btn btn-secondary" style="grid-column:2;text-align:center" onclick="scanBoatQR()">'+
           s('qr.scanBtn')+
         '</button>'+
+      '</div>'+
+      '<div class="mb-12">'+
         '<button class="btn btn-secondary mb-6" style="width:100%;text-align:left" onclick="renderNonClubLaunchForm()">'+
           '🚣 '+s('member.nonClubBoat')+
           ' <span class="text-muted" style="font-size:9px;font-weight:400;margin-left:4px">'+s('member.nonClubHint')+'</span>'+
@@ -560,8 +562,8 @@ function renderLaunchPicker(preselectedBoatId) {
   const grouped={};
   avail.forEach(b=>{const cat=(b.category||'other').toLowerCase();if(!grouped[cat])grouped[cat]=[];grouped[cat].push(b);});
   document.getElementById('launchModalBody').innerHTML=
-    '<div class="mb-12">'+
-      '<button class="btn btn-secondary mb-6" style="width:100%;text-align:left" onclick="scanBoatQR()">'+
+    '<div class="mb-12" style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px">'+
+      '<button class="btn btn-secondary" style="grid-column:2;text-align:center" onclick="scanBoatQR()">'+
         s('qr.scanBtn')+
       '</button>'+
     '</div>'+

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -79,7 +79,10 @@ const BOAT_CAT_COLORS = {
 };
 
 function boatEmoji(cat) {
-  return BOAT_EMOJI[(cat||"").toLowerCase()] || "⛵";
+  const key = (cat||"").toLowerCase();
+  const c = _boatCatRegistry.find(x => x.key === key);
+  if (c && c.emoji) return c.emoji;
+  return BOAT_EMOJI[key] || "⛵";
 }
 
 // ── Ownership / charter helpers ───────────────────────────────────────────────


### PR DESCRIPTION
In the member check-out modal, the Scan QR button spanned the full modal width. Place it in the center column of the 3-column boat grid so it matches the visual width of a single boat tile.

boatEmoji() only consulted the hardcoded BOAT_EMOJI map, so custom boat categories configured in admin (e.g. a support-boat category with its own emoji) fell back to the generic sailboat. Look up the registered category first and use its configured emoji when set.

Fixes #509

https://claude.ai/code/session_019e7hbYyUCg4mokS4yVmwfy