### PR TITLE
Use hbtn class for lang toggle and sign out in header

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -319,8 +319,8 @@ window.buildHeader = function (page) {
 
   // RIGHT: Settings · lang · sign out
   if (user && page !== 'settings') right.appendChild(link(depth + 'settings/', s('nav.settings'), 'hbtn'));
-  right.appendChild(btn(s('nav.langToggle'), () => { if (typeof toggleLang === 'function') toggleLang(); }));
-  right.appendChild(btn(s('nav.signOut'),    () => { if (typeof signOut    === 'function') signOut();    }));
+  right.appendChild(btn(s('nav.langToggle'), () => { if (typeof toggleLang === 'function') toggleLang(); }, 'hbtn'));
+  right.appendChild(btn(s('nav.signOut'),    () => { if (typeof signOut    === 'function') signOut();    }, 'hbtn'));
 };
 
 // ── APPLY THEME ON LOAD ────────────────────────────────────────────────────────


### PR DESCRIPTION
On small screens, .btn-ghost has min-height: 36px while .hbtn shrinks padding/font, causing the language toggle and sign out buttons to be taller than the other nav header buttons. Use .hbtn to match.

Closes #508