### PR TITLE
Fix Add calendar button on admin Club Calendars tab

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3704,7 +3704,7 @@ function addClubCalRow(name, calId) {
   var list = document.getElementById("clubCalList");
   // Remove empty-state message if present
   var empty = list.querySelector("[data-s='admin.calEmpty']");
-  if (empty) empty.parentElement.remove();
+  if (empty) empty.remove();
   var row = document.createElement("div");
   row.className = "grid2";
   row.style.cssText = "margin-bottom:8px;align-items:end";


### PR DESCRIPTION
The button silently destroyed the list container on first click because addClubCalRow removed empty.parentElement, which is #clubCalList itself (the empty-state div is a direct child). Subsequent clicks then crashed with a null reference. Remove only the empty-state element.