### PR TITLE
Fix broken member hub script — remove stale volunteer code

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1597,81 +1597,15 @@ function renderVolunteerNotifBadge() {
   merged.forEach(function(ev) {
     if ((ev.date || '') < today) return;
     const roles = Array.isArray(ev.roles) ? ev.roles : [];
-    const rolesHtml = roles.map(function(role) {
-      const rn = (L === 'IS' && role.nameIS ? role.nameIS : role.name) || role.name || '';
-      const rdesc = (L === 'IS' && role.descriptionIS ? role.descriptionIS : role.description) || role.description || '';
-      const signupsForRole = _volunteerSignups.filter(function(su) { return su.eventId === ev.id && su.roleId === role.id; });
-      const filled = signupsForRole.length;
+    roles.forEach(function(role) {
       const total = Number(role.slots) || 0;
-      const isFull = total > 0 && filled >= total;
-      const mySignup = signupsForRole.find(function(su) { return su.kennitala === kt; });
-      const pct = total > 0 ? Math.min(100, Math.round(filled / total * 100)) : 0;
-      const allowed = (typeof memberCanTakeRole === 'function')
-        ? memberCanTakeRole(role, myCerts)
-        : true;
-      let btnHtml = '';
-      if (mySignup) {
-        btnHtml = '<button class="vol-btn signed-up" onclick="memberVolWithdraw(\'' + mySignup.id + '\')">' + s('member.volWithdraw') + '</button>';
-      } else if (!allowed) {
-        btnHtml = '<span style="font-size:10px;color:var(--muted);font-style:italic">' + s('member.volNeedsEndorsement') + '</span>';
-      } else if (isFull) {
-        btnHtml = '<span style="font-size:10px;color:var(--red);font-weight:500">' + s('member.volFull') + '</span>';
-      } else {
-        btnHtml = '<button class="vol-btn" onclick="memberVolSignup(\'' + ev.id + '\',\'' + role.id + '\')">' + s('member.volSignUp') + '</button>';
-      }
-      const descHtml = rdesc ? '<div style="font-size:10px;color:var(--muted);margin-top:2px;line-height:1.35">' + esc(rdesc) + '</div>' : '';
-      return '<div class="vol-role-row">'
-        + '<div><div class="vol-role-name">' + esc(rn) + '</div>'
-        + descHtml
-        + '<div style="display:flex;align-items:center;gap:6px;margin-top:2px">'
-        + '<div class="vol-bar"><div class="vol-bar-fill" style="width:' + pct + '%"></div></div>'
-        + '<span class="vol-role-status">' + filled + '/' + total + (mySignup ? ' · ' + s('member.volSignedUp') : '') + '</span>'
-        + '</div></div>'
-        + '<div>' + btnHtml + '</div>'
-        + '</div>';
-    }).join('');
-    const leaderHtml = ev.leaderName
-      ? '<div class="vol-card-leader">' + s('member.volLeader') + ': ' + esc(ev.leaderName) + (ev.showLeaderPhone && ev.leaderPhone ? ' · ' + esc(ev.leaderPhone) : '') + '</div>'
-      : '';
-    const notesHtml = notes ? '<div style="font-size:10px;color:var(--muted);margin-top:4px">' + esc(notes) + '</div>' : '';
-    const subtitleHtml = subtitle ? '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + esc(subtitle) + '</div>' : '';
-    return '<div class="vol-card">'
-      + '<div class="vol-card-date">' + esc(ev.date || '') + (ev.startTime ? ' · ' + esc(ev.startTime) : '') + (ev.endTime ? '–' + esc(ev.endTime) : '') + '</div>'
-      + '<div class="vol-card-title">' + esc(title) + '</div>'
-      + subtitleHtml + leaderHtml + notesHtml
-      + rolesHtml
-      + '</div>';
-  }).join('');
-}
-
-async function memberVolSignup(eventId, roleId) {
-  const user = getUser();
-  if (!user) return;
-  try {
-    // If this is a virtual event (derived from an activity type), send the
-    // source event data so the backend can materialize it before signup.
-    const payload = {
-      eventId: eventId,
-      roleId: roleId,
-      kennitala: user.kennitala,
-      name: user.name || '',
-    };
-    if (String(eventId).indexOf('vae-') === 0) {
-      const today = new Date().toISOString().slice(0, 10);
-      const virt = (typeof expandVolunteerActivityTypes === 'function')
-        ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, null)
-        : [];
-      const src = virt.find(function(e) { return e.id === eventId; });
-      if (src) payload.virtualEvent = src;
-    }
-    const res = await apiPost('volunteerSignup', payload);
-    _volunteerSignups.push(res.signup || { id: res.id, eventId: eventId, roleId: roleId, kennitala: user.kennitala, name: user.name });
-    renderMemberVolunteerEvents();
-    toast(s('toast.saved'));
-  } catch(e) {
-    toast(e.message, 'err');
-  }
-}
+      if (!total) return;
+      const filled = _volunteerSignups.filter(function(su) {
+        return su.eventId === ev.id && su.roleId === role.id;
+      }).length;
+      if (filled < total) unfilled += (total - filled);
+    });
+  });
 
   if (!unfilled) return;
   const badge = document.createElement('span');


### PR DESCRIPTION
The original #519 merge commit accidentally left the old renderMemberVolunteerEvents body and the memberVolSignup function pasted into the middle of the new renderVolunteerNotifBadge, producing "Illegal return statement" at runtime (the tail of renderVolunteerNotifBadge ended up outside any function). Replace the polluted block with the clean unfilled-slot counter so the script parses again.

https://claude.ai/code/session_01HYDa5jTjR79n3yWi2k2JMQ