### PR TITLE
Dark-mode embedded calendars with CSS invert filter

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1623,20 +1623,27 @@ function renderClubCalendars() {
     el.innerHTML = '<div class="empty-note">' + (s('member.calEmpty') || '') + '</div>';
     return;
   }
-  // Resolve effective theme to a hex bgcolor for Google Calendar's embed
-  // (the URL param is fixed at iframe load time and can't read CSS vars).
+  // Google Calendar's embed runs cross-origin, so we can't style its interior
+  // directly and its &bgcolor= URL param is ignored in the new agenda view.
+  // On dark theme, apply a CSS filter to visually invert the iframe — this is
+  // a purely client-side paint effect and doesn't touch iframe content.
+  // hue-rotate(180deg) compensates so colored event markers stay close to
+  // their original hues after the invert.
   var theme = (typeof getTheme === 'function') ? getTheme() : 'dark';
   if (theme === 'auto') {
     theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
   }
-  var bgHex = theme === 'light' ? '#ffffff' : '#132d50';
+  var isDark = theme !== 'light';
+  var frameFilter = isDark ? 'filter:invert(0.92) hue-rotate(180deg);' : '';
+  // Always white — Google's default — so the invert filter lands on a dark
+  // shade on dark theme, and it stays white on light theme.
+  var frameBg = '#ffffff';
   el.innerHTML = _clubCalendars.map(function(c) {
     var cid = encodeURIComponent(c.calendarId);
     var src = 'https://calendar.google.com/calendar/embed'
       + '?src=' + cid
       + '&ctz=Atlantic/Reykjavik'
       + '&mode=AGENDA'
-      + '&bgcolor=' + encodeURIComponent(bgHex)
       + '&showTitle=0&showNav=1&showPrint=0&showTabs=0&showCalendars=0&showTz=0';
     var openUrl = 'https://calendar.google.com/calendar/u/0/r?cid=' + cid;
     return '<div style="margin-bottom:14px">'
@@ -1644,7 +1651,7 @@ function renderClubCalendars() {
       +   '<span style="font-size:11px;font-weight:500;color:var(--text)">' + esc(c.name) + '</span>'
       +   '<a href="' + openUrl + '" target="_blank" rel="noopener" style="font-size:11px;color:var(--brass);text-decoration:none">' + esc(s('member.calOpen')) + ' \u2197</a>'
       + '</div>'
-      + '<iframe src="' + src + '" style="border:1px solid var(--border);width:100%;height:380px;border-radius:var(--radius-md);background:' + bgHex + ';display:block" frameborder="0"></iframe>'
+      + '<iframe src="' + src + '" style="border:1px solid var(--border);width:100%;height:380px;border-radius:var(--radius-md);background:' + frameBg + ';display:block;' + frameFilter + '" frameborder="0"></iframe>'
       + '</div>';
   }).join('');
 }


### PR DESCRIPTION
Google Calendar's &bgcolor= URL param is ignored by the new agenda view, and we can't style inside a cross-origin iframe. Instead, on dark theme apply filter:invert(0.92) hue-rotate(180deg) to the iframe — a purely client-side paint effect that flips the white calendar to dark while keeping colored event markers roughly true to their original hues. Leave light theme alone since Google's default white is already correct there.