### PR TITLE
Tint embedded calendars to site dark navy via screen blend overlay

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1624,20 +1624,20 @@ function renderClubCalendars() {
     return;
   }
   // Google Calendar's embed runs cross-origin, so we can't style its interior
-  // directly and its &bgcolor= URL param is ignored in the new agenda view.
-  // On dark theme, apply a CSS filter to visually invert the iframe — this is
-  // a purely client-side paint effect and doesn't touch iframe content.
-  // hue-rotate(180deg) compensates so colored event markers stay close to
-  // their original hues after the invert.
-  var theme = (typeof getTheme === 'function') ? getTheme() : 'dark';
-  if (theme === 'auto') {
-    theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-  }
-  var isDark = theme !== 'light';
-  var frameFilter = isDark ? 'filter:invert(0.92) hue-rotate(180deg);' : '';
-  // Always white — Google's default — so the invert filter lands on a dark
-  // shade on dark theme, and it stays white on light theme.
-  var frameBg = '#ffffff';
+  // directly and its &bgcolor= URL param is ignored in the agenda view.
+  //
+  // Dark-mode hack (hardcoded for now — see issue ERHQ5):
+  //   1. filter:invert(1) hue-rotate(180deg) on the iframe flips it so the
+  //      white bg becomes black and the dark text becomes white, while
+  //      colored event markers roughly keep their original hues.
+  //   2. A mix-blend-mode:screen overlay with our dark-card color (#132d50)
+  //      tints the now-black bg to navy — screen math: result = 255 - (255-a)(255-b)/255,
+  //      so black (0) + #132d50 = #132d50, and white (255) + anything = white.
+  //      Text stays fully white, bg hits the site color exactly.
+  //   3. pointer-events:none on the overlay so clicks still reach the iframe.
+  //   4. isolation:isolate on the wrapper keeps the blend scoped to these
+  //      two elements.
+  var CARD_DARK = '#132d50';
   el.innerHTML = _clubCalendars.map(function(c) {
     var cid = encodeURIComponent(c.calendarId);
     var src = 'https://calendar.google.com/calendar/embed'
@@ -1651,7 +1651,10 @@ function renderClubCalendars() {
       +   '<span style="font-size:11px;font-weight:500;color:var(--text)">' + esc(c.name) + '</span>'
       +   '<a href="' + openUrl + '" target="_blank" rel="noopener" style="font-size:11px;color:var(--brass);text-decoration:none">' + esc(s('member.calOpen')) + ' \u2197</a>'
       + '</div>'
-      + '<iframe src="' + src + '" style="border:1px solid var(--border);width:100%;height:380px;border-radius:var(--radius-md);background:' + frameBg + ';display:block;' + frameFilter + '" frameborder="0"></iframe>'
+      + '<div style="position:relative;isolation:isolate;border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;background:' + CARD_DARK + '">'
+      +   '<iframe src="' + src + '" style="border:0;width:100%;height:380px;display:block;background:#ffffff;filter:invert(1) hue-rotate(180deg)" frameborder="0"></iframe>'
+      +   '<div style="position:absolute;inset:0;background:' + CARD_DARK + ';mix-blend-mode:screen;pointer-events:none"></div>'
+      + '</div>'
       + '</div>';
   }).join('');
 }


### PR DESCRIPTION
Pure invert+hue-rotate on a white iframe can only produce grayscale darks — hue-rotate has no effect on achromatic colors — so the previous filter hack bottomed out at near-black and couldn't match the site's #132d50 card color.

Combine filter:invert(1) hue-rotate(180deg) on the iframe with a mix-blend-mode:screen overlay using #132d50 on top. Screen blending math (255 - (255-a)(255-b)/255) means the inverted black bg tints exactly to #132d50, while inverted white text stays white. Colored event markers get lightened slightly by the screen but stay roughly true to their hues.

isolation:isolate on the wrapper scopes the blend; pointer-events: none on the overlay keeps the iframe clickable. Hardcoded to dark for now — theme-aware handling can be re-added later.