### PR TITLE
Lock lang-toggle button width to prevent nav cluster shift

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -198,6 +198,9 @@ main.wide { max-width: 1100px; }
 .hbtn:hover       { color: var(--brass); border-color: var(--brass); background: var(--brass)08; }
 .hbtn.active      { color: var(--brass); border-color: var(--brass); }
 
+/* Lang toggle: lock width so "IS"/"EN" swap doesn't shift the right-side nav cluster */
+.hbtn.lang-toggle { min-width: 2.25em; text-align: center; }
+
 .back-btn {
   background: none;
   border: 1px solid var(--border);

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -319,7 +319,7 @@ window.buildHeader = function (page) {
 
   // RIGHT: Settings · lang · sign out
   if (user && page !== 'settings') right.appendChild(link(depth + 'settings/', s('nav.settings'), 'hbtn'));
-  right.appendChild(btn(s('nav.langToggle'), () => { if (typeof toggleLang === 'function') toggleLang(); }, 'hbtn'));
+  right.appendChild(btn(s('nav.langToggle'), () => { if (typeof toggleLang === 'function') toggleLang(); }, 'hbtn lang-toggle'));
   right.appendChild(btn(s('nav.signOut'),    () => { if (typeof signOut    === 'function') signOut();    }, 'hbtn'));
 };
 


### PR DESCRIPTION
The header lang toggle alternates between "IS" and "EN" — in a proportional font "EN" is wider than "IS", so the right-side nav cluster visibly jumps leftward on small screens when switching. Tag the button with a `lang-toggle` class and set `min-width: 2.25em; text-align: center` so both labels render inside a stable, centered box.

https://claude.ai/code/session_01QsqBqHZCQJj62dsaPuYRBA