### PR TITLE
Shorten IS nav.memberHub to "⛵ Forsíða"

### DIFF
--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1,6 +1,6 @@
 var _STRINGS_FLAT = {
   "nav.staffHub": "⚓️ Starfsmaenn",
-  "nav.memberHub": "⛵ Félagssvæði",
+  "nav.memberHub": "⛵ Forsíða",
   "nav.admin": "⚙️ Stjórnborð",
   "nav.logbook": "Siglingabók",
   "nav.signOut": "Skrá út",


### PR DESCRIPTION
"Félagssvæði" (14 chars) was much wider than the English "Home" (4 chars), which pushed the right-side nav cluster into a reflow on narrow iPhone screens when Icelandic was active. "Forsíða" is the standard Icelandic web nav word for a home/front page and is close in width to the English.

https://claude.ai/code/session_01QsqBqHZCQJj62dsaPuYRBA