### PR TITLE
Warn before discarding unsaved edits in admin modals

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1333,6 +1333,16 @@ document.addEventListener("DOMContentLoaded", () => {
   buildHeader('admin');
   applyStrings();
   _adminWireStrings();
+  // Enable unsaved-changes guard on all editable admin modals. The guard
+  // snapshots input state when a modal opens and confirms before closing
+  // if any field changed (bypassed when closeModal is called with force=true).
+  [
+    'memberModal', 'boatCatModal', 'boatModal', 'locationModal',
+    'clModal', 'launchCLModal', 'actTypeModal', 'volEventModal',
+    'certCatModal', 'certDefModal', 'recurSlotModal', 'slotModal',
+    'passportSettingsModal', 'passportItemModal', 'passportCategoryModal',
+    'memberCertModal',
+  ].forEach(id => { if (typeof guardUnsavedChanges === 'function') guardUnsavedChanges(id); });
   loadAll().then(() => {
     const p = new URLSearchParams(window.location.search);
     const top = p.get('top') || 'members';
@@ -1489,7 +1499,7 @@ async function saveEntity({ apiAction, getArray, setArray, payload, modalId, ren
       setArray(arr.map(x => x.id === payload.id ? { ...x, ...payload } : x));
       if (!arr.find(x => x.id === payload.id)) setArray([...arr, payload]);
     }
-    if (modalId) closeModal(modalId);
+    if (modalId) closeModal(modalId, true);
     if (renderFn) renderFn();
     toast(s("toast.saved"));
   } catch(e) {
@@ -1642,7 +1652,7 @@ async function saveMember() {
     const idx = members.findIndex(x => x.id === id);
     if (idx >= 0) members[idx] = { ...members[idx], ...payload };
     else          members.push(payload);
-    closeModal("memberModal");
+    closeModal("memberModal", true);
     renderMembers();
     toast(s("toast.saved"));
   } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
@@ -1656,7 +1666,7 @@ async function deactivateMember(id) {
     renderMembers();
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
-async function deleteMember() { await deactivateMember(editingId); closeModal("memberModal"); }
+async function deleteMember() { await deactivateMember(editingId); closeModal("memberModal", true); }
 
 // ══ BOAT CATEGORIES ══════════════════════════════════════════════════════════
 
@@ -1718,7 +1728,7 @@ async function saveBoatCat() {
     await apiPost("saveConfig", { boatCategories: _allBoatCats });
     boatCats = _allBoatCats.filter(c => c.active !== false && c.active !== 'false');
     registerBoatCats(boatCats);
-    closeModal("boatCatModal");
+    closeModal("boatCatModal", true);
     renderBoatCats();
     renderBoats();
     populateCategorySelects();
@@ -1734,7 +1744,7 @@ async function deleteBoatCat() {
     await apiPost("saveConfig", { boatCategories: _allBoatCats });
     boatCats = _allBoatCats.filter(c => c.active !== false && c.active !== 'false');
     registerBoatCats(boatCats);
-    closeModal("boatCatModal");
+    closeModal("boatCatModal", true);
     renderBoatCats();
     renderBoats();
     populateCategorySelects();
@@ -2026,8 +2036,17 @@ async function saveResFromModal() {
     var res = await apiPost('saveReservation', { boatId: boatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end, note: note });
     var b = _allBoats.find(function(x) { return x.id === boatId; });
     if (b && res.boat) { b.reservations = res.boat.reservations; }
+    // Clear sub-form fields so the boat modal's dirty check doesn't flag
+    // the stale reservation inputs after a successful save.
+    document.getElementById("bResMemberKt").value = '';
+    document.getElementById("bResMemberSearch").value = '';
+    document.getElementById("bResMemberName").textContent = '';
+    document.getElementById("bResStart").value = '';
+    document.getElementById("bResEnd").value = '';
+    document.getElementById("bResNote").value = '';
     cancelResForm();
     renderReservationList(b);
+    if (typeof resnapshotModal === 'function') resnapshotModal('boatModal');
     toast(s('boat.reservationSaved'));
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
@@ -2090,7 +2109,7 @@ async function saveBoat() {
   try {
     await apiPost("saveConfig", { boats: _allBoats });
     boats = _allBoats.filter(b => b.active !== false && b.active !== 'false');
-    closeModal("boatModal");
+    closeModal("boatModal", true);
     renderBoats();
     toast(s("toast.saved"));
   } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
@@ -2104,7 +2123,7 @@ async function deleteBoat(id) {
     await apiPost("saveConfig", { boats: _allBoats });
     boats = _allBoats.filter(b => b.active !== false && b.active !== 'false');
     renderBoats();
-    closeModal("boatModal");
+    closeModal("boatModal", true);
     toast(s("toast.deleted"));
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
@@ -2180,7 +2199,7 @@ async function saveLocation() {
   try {
     await apiPost("saveConfig", { locations: _allLocations });
     locations = _allLocations.filter(l => l.active !== false && l.active !== 'false');
-    closeModal("locationModal");
+    closeModal("locationModal", true);
     renderLocations();
     toast(s("toast.saved"));
   } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
@@ -2194,7 +2213,7 @@ async function deleteLocation(id) {
     await apiPost("saveConfig", { locations: _allLocations });
     locations = _allLocations.filter(l => l.active !== false && l.active !== 'false');
     renderLocations();
-    closeModal("locationModal");
+    closeModal("locationModal", true);
     toast(s("toast.deleted"));
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
@@ -2267,7 +2286,7 @@ async function deleteCLItem(id) {
     await apiPost("deleteChecklistItem", { id: _id });
     clItems = clItems.filter(i => i.id !== _id);
     renderChecklists();
-    closeModal("clModal");
+    closeModal("clModal", true);
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
 
@@ -2362,7 +2381,7 @@ async function saveLaunchCLItem() {
 
   try {
     await apiPost("saveConfig", { launchChecklists: _launchCLs });
-    closeModal("launchCLModal");
+    closeModal("launchCLModal", true);
     renderLaunchCLSections();
     toast(s("toast.saved"));
   } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
@@ -2399,7 +2418,7 @@ async function deleteLaunchCLItem(cat, phase, id) {
   }
   try {
     await apiPost("saveConfig", { launchChecklists: _launchCLs });
-    closeModal("launchCLModal");
+    closeModal("launchCLModal", true);
     renderLaunchCLSections();
     toast(s("toast.deleted"));
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
@@ -2496,7 +2515,7 @@ async function deleteActType(id) {
     await apiPost("deleteActivityType", { id: _id });
     actTypes = actTypes.filter(a => a.id !== _id);
     renderActTypes();
-    closeModal("actTypeModal");
+    closeModal("actTypeModal", true);
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
 
@@ -2872,7 +2891,7 @@ async function deleteVolEvent(id) {
     await apiPost("deleteVolunteerEvent", { id: _id });
     volunteerEvents = volunteerEvents.filter(a => a.id !== _id);
     renderVolunteerEvents();
-    closeModal("volEventModal");
+    closeModal("volEventModal", true);
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
 
@@ -3095,7 +3114,7 @@ async function saveCertCat() {
   });
   try {
     await apiPost("saveCertCategories", { categories: certCategories });
-    closeModal("certCatModal");
+    closeModal("certCatModal", true);
     renderCertCategories();
     renderCertDefs();
     toast(s("toast.saved"));
@@ -3262,7 +3281,7 @@ async function saveCertDef() {
     certEditId = savedId;
     renderCertDefs();
 
-    closeModal("certDefModal");
+    closeModal("certDefModal", true);
     toast(s("admin.certDefSaved"));
   } catch(e) {
     toast(s("toast.saveFailed") + ": " + e.message, "err");
@@ -3278,7 +3297,7 @@ async function deleteCertDef() {
     certDefs = certDefs.filter(d => d.id !== certEditId);
     renderCertDefs();
 
-    closeModal("certDefModal");
+    closeModal("certDefModal", true);
     toast(s("toast.deleted"));
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
 }
@@ -3987,7 +4006,7 @@ async function saveCurrentSlot() {
       date: date, startTime: startTime, endTime: endTime,
       note: document.getElementById("smNote").value || '',
     });
-    closeModal("slotModal");
+    closeModal("slotModal", true);
     toast(s('toast.saved'));
     loadSlotCalendar();
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
@@ -3998,7 +4017,7 @@ async function deleteCurrentSlot() {
   if (!(await ymConfirm(s('slot.confirmDelete')))) return;
   try {
     await apiPost("deleteSlot", { slotId: _editingSlot.slotId });
-    closeModal("slotModal");
+    closeModal("slotModal", true);
     toast(s('toast.deleted'));
     loadSlotCalendar();
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
@@ -4059,7 +4078,7 @@ async function saveRecurringSlots() {
       fromDate: fromDate, toDate: toDate,
       note: document.getElementById("rsNote").value || '',
     });
-    closeModal("recurSlotModal");
+    closeModal("recurSlotModal", true);
     toast(s('slot.created', { count: res.count || 0 }));
     loadSlotCalendar();
   } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
@@ -4221,7 +4240,7 @@ function savePassportSettings() {
   p.fromSub       = document.getElementById('ppsFromSub').value.trim() || 'restricted';
   p.toSub         = document.getElementById('ppsToSub').value.trim() || 'released';
   _ppMarkDirty();
-  closeModal('passportSettingsModal');
+  closeModal('passportSettingsModal', true);
   drawPassportEditor();
 }
 
@@ -4276,7 +4295,7 @@ function savePassportItem() {
     it.retired = payload.retired;
   }
   _ppMarkDirty();
-  closeModal('passportItemModal');
+  closeModal('passportItemModal', true);
   drawPassportEditor();
 }
 
@@ -4295,7 +4314,7 @@ async function deletePassportItem() {
     toast(s('passport.itemRetiredSoft'));
   }
   _ppMarkDirty();
-  closeModal('passportItemModal');
+  closeModal('passportItemModal', true);
   drawPassportEditor();
 }
 
@@ -4334,7 +4353,7 @@ function savePassportCategory() {
     cat.name.IS = nameIS;
   }
   _ppMarkDirty();
-  closeModal('passportCategoryModal');
+  closeModal('passportCategoryModal', true);
   drawPassportEditor();
 }
 
@@ -4346,7 +4365,7 @@ async function deletePassportCategory() {
   p.categories.splice(ci, 1);
   _ppMarkDirty();
   toast(s('passport.categoryDeleted'));
-  closeModal('passportCategoryModal');
+  closeModal('passportCategoryModal', true);
   drawPassportEditor();
 }
 

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -104,11 +104,11 @@
 </div>
 
 <!-- Entry modal -->
-<div id="prModal" class="modal-bg hidden" onclick="if(event.target===this)prCloseModal()">
+<div id="prModal" class="modal-bg hidden" onclick="if(event.target===this)closeModal('prModal')">
   <div class="modal-box">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
       <h3 class="modal-title" id="prModalTitle" style="margin:0"></h3>
-      <button class="modal-close-x" onclick="prCloseModal()">&times;</button>
+      <button class="modal-close-x" onclick="closeModal('prModal')">&times;</button>
     </div>
     <div class="field"><label data-s="payroll.employee"></label>
       <select id="meEmp" style="width:100%"></select></div>
@@ -124,7 +124,7 @@
     <div class="modal-actions">
       <button id="meDelBtn" class="btn-del" style="display:none" onclick="meDelete()" data-s="payroll.deleteEntry"></button>
       <span style="margin-left:auto"></span>
-      <button class="btn btn-secondary" onclick="prCloseModal()" data-s="btn.cancel"></button>
+      <button class="btn btn-secondary" onclick="closeModal('prModal')" data-s="btn.cancel"></button>
       <button class="btn btn-primary" onclick="meSave()" data-s="btn.save"></button>
     </div>
   </div>
@@ -135,6 +135,8 @@
 function prHide(id){var el=document.getElementById(id);if(el)el.classList.add('hidden');}
 function prShow(id){var el=document.getElementById(id);if(el)el.classList.remove('hidden');}
 function prToggleId(id){var el=document.getElementById(id);if(el)el.classList.toggle('hidden');}
+// Opt-in to unsaved-changes guard for the time-entry modal.
+if(typeof guardUnsavedChanges==='function')guardUnsavedChanges('prModal');
 
 /* == Bootstrap == */
 var user=requireAuth(isAdmin);
@@ -225,7 +227,50 @@ function prEmpRowHTML(m,emp,act){
   h+='</div></div>';
   return h;
 }
-function prToggleEdit(mid){var el=document.getElementById('empedit_'+mid);if(!el)return;var was=el.classList.toggle('hidden');if(!was)applyStrings(el);}
+// Inline employee edit panels: track their initial state so we can detect
+// unsaved edits on close / page unload. Keyed by member id.
+var _empEditBaseline={};
+function _empEditSnapshot(mid){
+  var pan=document.getElementById('empedit_'+mid);
+  if(!pan){delete _empEditBaseline[mid];return;}
+  var en=document.getElementById('prEnabled_'+mid);
+  var ti=document.getElementById('prTitle_'+mid);
+  _empEditBaseline[mid]={enabled:en?en.checked:false,title:ti?ti.value:''};
+}
+function _empEditIsDirty(mid){
+  var base=_empEditBaseline[mid];if(!base)return false;
+  var en=document.getElementById('prEnabled_'+mid);
+  var ti=document.getElementById('prTitle_'+mid);
+  if(en&&en.checked!==base.enabled)return true;
+  if(ti&&ti.value!==base.title)return true;
+  return false;
+}
+function _anyEmpEditDirty(){
+  for(var k in _empEditBaseline){
+    var pan=document.getElementById('empedit_'+k);
+    if(pan&&!pan.classList.contains('hidden')&&_empEditIsDirty(k))return true;
+  }
+  return false;
+}
+function prToggleEdit(mid){
+  var el=document.getElementById('empedit_'+mid);if(!el)return;
+  var wasOpen=!el.classList.contains('hidden');
+  if(wasOpen&&_empEditIsDirty(mid)){
+    ymConfirm(s('msg.unsavedChanges')).then(function(ok){
+      if(!ok)return;
+      el.classList.add('hidden');
+      delete _empEditBaseline[mid];
+    });
+    return;
+  }
+  el.classList.toggle('hidden');
+  if(wasOpen){delete _empEditBaseline[mid];return;}
+  applyStrings(el);
+  _empEditSnapshot(mid);
+}
+window.addEventListener('beforeunload',function(e){
+  if(_anyEmpEditDirty()){e.preventDefault();e.returnValue='';return '';}
+});
 async function prSaveEmployee(memberId){
   var msg=document.getElementById('prMsg_'+memberId);
   var member=_members.find(function(m){return m.id===memberId;});if(!member)return;
@@ -240,6 +285,7 @@ async function prSaveEmployee(memberId){
     await apiPost('saveEmployee',payload);
     _empData[empId]=Object.assign({},existing||{},payload);
     _empByMember[memberId]=_empData[empId];
+    delete _empEditBaseline[memberId];
     if(msg){msg.textContent='\u2713';msg.style.color='var(--green)';}
     setTimeout(function(){prLoadEmployees();},800);
   }catch(e){if(msg){msg.textContent=e.message;msg.style.color='var(--red)';}}
@@ -430,9 +476,9 @@ function prOpenModal(entry,dateStr){
     document.getElementById('meNote').value='';
   }
   document.getElementById('meErr').textContent='';
-  prShow('prModal');
+  openModal('prModal');
 }
-function prCloseModal(){prHide('prModal');_editId=null;}
+function prCloseModal(force){closeModal('prModal',force===true);_editId=null;}
 function meCalcMins(){
   var i=document.getElementById('meIn').value,o=document.getElementById('meOut').value;
   if(!i||!o)return;var d=Math.round((new Date(o)-new Date(i))/60000);if(d>0)document.getElementById('meMins').value=d;
@@ -453,13 +499,13 @@ async function meSave(){
     }else{
       await apiPost('adminAddTime',{employeeId:empId,clockIn:new Date(inV).toISOString(),timestamp:new Date(outV).toISOString(),durationMinutes:mins,note:note||'admin entry',source:'admin'});
     }
-    prCloseModal();showToast(s('toast.saved'));prLoadTsEntries();
+    prCloseModal(true);showToast(s('toast.saved'));prLoadTsEntries();
   }catch(e){err.textContent=e.message;}
 }
 async function meDelete(){
   if(!_editId)return;
   if(!await ymConfirm(s('payroll.deleteConfirm')))return;
-  try{await apiPost('adminDeleteTime',{id:_editId});prCloseModal();showToast(s('toast.deleted'));prLoadTsEntries();}
+  try{await apiPost('adminDeleteTime',{id:_editId});prCloseModal(true);showToast(s('toast.deleted'));prLoadTsEntries();}
   catch(e){document.getElementById('meErr').textContent=e.message;}
 }
 

--- a/shared/mcm.js
+++ b/shared/mcm.js
@@ -143,6 +143,8 @@
     document.getElementById('mcmDescription').value = '';
     document.getElementById('mcmAssignBtn').textContent = s('cert.assign');
     document.getElementById('mcmCancelEditBtn').classList.add('hidden');
+    // Refresh the unsaved-changes baseline so a just-reset form reads as clean.
+    if (typeof resnapshotModal === 'function') resnapshotModal('memberCertModal');
   }
 
   /* ── open modal ────────────────────────────────────────────────────────── */

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -46,6 +46,7 @@ var _STRINGS_FLAT = {
   "lbl.sortOrder": "Sort order",
   "lbl.selectDots": "Select…",
   "lbl.Dash": "—  —",
+  "msg.unsavedChanges": "You have unsaved changes. Discard them?",
   "toast.saved": "Saved",
   "toast.saveFailed": "Save failed",
   "toast.deleted": "Deleted",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -46,6 +46,7 @@ var _STRINGS_FLAT = {
   "lbl.sortOrder": "Röðun",
   "lbl.selectDots": "Veldu…",
   "lbl.noneDash": "— ekkert —",
+  "msg.unsavedChanges": "Þú átt óvistaðar breytingar. Henda þeim?",
   "toast.saved": "Vistað",
   "toast.saveFailed": "Mistókst að vista",
   "toast.deleted": "Eytt",

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -121,8 +121,71 @@ window.replaceWithFragment = function (container, items, buildNodeFn) {
 };
 
 // ── MODAL HELPERS ──────────────────────────────────────────────────────────────
-window.openModal  = id => document.getElementById(id)?.classList.remove('hidden');
-window.closeModal = id => document.getElementById(id)?.classList.add('hidden');
+// Unsaved-changes guard: opt-in per modal via guardUnsavedChanges(modalId).
+// When a guarded modal is opened, its form inputs are snapshotted; when closed
+// without `force === true`, it confirms before discarding dirty edits.
+;(function () {
+  const _tracked  = new Set();           // modalIds that opt into the guard
+  const _baseline = new Map();           // modalId -> [[el, value], ...]
+
+  function _snapshot(modalId) {
+    const m = document.getElementById(modalId);
+    if (!m) { _baseline.delete(modalId); return; }
+    const snap = [];
+    m.querySelectorAll('input, textarea, select').forEach(el => {
+      if (el.type === 'file') return;
+      const val = (el.type === 'checkbox' || el.type === 'radio') ? el.checked : el.value;
+      snap.push([el, val]);
+    });
+    _baseline.set(modalId, snap);
+  }
+
+  function _isDirty(modalId) {
+    const snap = _baseline.get(modalId);
+    if (!snap) return false;
+    for (let i = 0; i < snap.length; i++) {
+      const el = snap[i][0], was = snap[i][1];
+      if (!el.isConnected) continue;
+      const cur = (el.type === 'checkbox' || el.type === 'radio') ? el.checked : el.value;
+      if (cur !== was) return true;
+    }
+    return false;
+  }
+
+  window.guardUnsavedChanges = function (modalId) { _tracked.add(modalId); };
+  window.isModalDirty        = function (modalId) { return _isDirty(modalId); };
+  window.resnapshotModal     = function (modalId) { if (_tracked.has(modalId)) _snapshot(modalId); };
+
+  window.openModal = function (id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.remove('hidden');
+    if (_tracked.has(id)) _snapshot(id);
+  };
+
+  window.closeModal = function (id, force) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const doClose = () => { el.classList.add('hidden'); _baseline.delete(id); };
+    if (force === true || !_tracked.has(id) || !_isDirty(id)) { doClose(); return; }
+    const msg = (typeof s === 'function') ? s('msg.unsavedChanges')
+              : 'You have unsaved changes. Discard them?';
+    // ymConfirm returns a promise; close only if the user confirms.
+    Promise.resolve(ymConfirm(msg)).then(ok => { if (ok) doClose(); });
+  };
+
+  // Warn before leaving the page while a guarded modal has unsaved edits.
+  window.addEventListener('beforeunload', function (e) {
+    for (const id of _tracked) {
+      const el = document.getElementById(id);
+      if (el && !el.classList.contains('hidden') && _isDirty(id)) {
+        e.preventDefault();
+        e.returnValue = '';
+        return '';
+      }
+    }
+  });
+})();
 
 // ── GLOBAL ESCAPE-TO-CLOSE ────────────────────────────────────────────────────
 document.addEventListener('keydown', function (e) {
@@ -134,7 +197,9 @@ document.addEventListener('keydown', function (e) {
   if (!overlays.length) return;
   // pick the one with highest z-index (last in DOM if equal)
   let top = overlays[overlays.length - 1];
-  top.classList.add('hidden');
+  // Route through closeModal so the unsaved-changes guard (if active) fires.
+  if (top.id && typeof window.closeModal === 'function') window.closeModal(top.id);
+  else top.classList.add('hidden');
 });
 
 // ── SYSTEM DIALOGS (ymAlert / ymConfirm / ymPrompt) ──────────────────────────


### PR DESCRIPTION
Adds an opt-in unsaved-changes guard to shared/ui.js: openModal snapshots input state; closeModal confirms before discarding dirty edits unless called with force=true. All admin save/delete flows are updated to force-close. Also guards the payroll time-entry modal, the inline employee editor, and the shared member credential modal, and installs a beforeunload prompt so tab/window close is covered too.

https://claude.ai/code/session_01DmngtEo2MZkE6MTdzGVVKX