### PR TITLE
incidents: fix card click, simplify summary, restore EN none label

### DIFF
--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -525,7 +525,8 @@ function renderIncidentSection(incidents) {
   heading.textContent = `${s('daily.incidentReport')} · ${incidents.length}`;
   container.innerHTML = incidents.map(inc => {
     const types = (function() { try { var t = typeof inc.types === 'string' ? JSON.parse(inc.types) : inc.types; return Array.isArray(t) ? t.map(function(k){ return s('incident.type.'+k)||k; }).join(', ') : ''; } catch(e){ return ''; } })();
-    const time = sstr(inc.filedAt||inc.time).slice(11,16) || '';
+    const dateStr = inc.date || sstr(inc.filedAt).slice(0,10);
+    const timeStr = inc.time || sstr(inc.filedAt).slice(11,16);
     const sevLabel = inc.severity ? (s('incident.sev.'+inc.severity) || inc.severity) : '';
     const sevClass = inc.severity === 'critical' ? 'red'
       : inc.severity === 'high' ? 'orange'
@@ -534,20 +535,21 @@ function renderIncidentSection(incidents) {
       : 'muted';
     const resolved = inc.resolved && inc.resolved !== 'false';
     const inReview = !resolved && inc.status === 'review';
-    const statusLabel = resolved ? '✓ ' + s('incident.resolved')
+    const statusLabel = resolved ? s('incident.resolved')
       : inReview ? s('incident.statusReview')
-      : (inc.followUp ? 'Follow-up pending' : '');
+      : s('incident.open');
+    const statusClass = resolved ? 'green' : (inReview ? 'orange' : 'yellow');
     const descStr = sstr(inc.description);
     const desc = descStr.slice(0,140);
     const descMore = descStr.length > 140 ? '…' : '';
-    return `<a href="../incidents/#${inc.id}" class="incident-btn" style="align-items:flex-start">
-      <div style="flex:1;font-size:12px">
+    return `<a href="../incidents/#${esc(inc.id)}" class="incident-btn" style="align-items:flex-start">
+      <div style="flex:1;font-size:12px;min-width:0">
         <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-          <span class="fw-500">${esc(types || inc.title || s('incident.title'))}</span>
+          <span class="fw-500">${esc(types || inc.title || '')}</span>
           ${sevLabel ? `<span class="badge badge-${sevClass}">${esc(sevLabel)}</span>` : ''}
-          ${time ? `<span class="text-muted">${esc(time)}</span>` : ''}
-          ${statusLabel ? `<span class="text-muted" style="font-style:italic">${esc(statusLabel)}</span>` : ''}
+          <span class="badge badge-${statusClass}">${esc(statusLabel)}</span>
         </div>
+        <div class="text-muted" style="margin-top:3px">${esc(dateStr)}${timeStr ? ' ' + esc(timeStr) : ''}</div>
         ${desc ? `<div class="text-muted" style="margin-top:4px">${esc(desc)}${descMore}</div>` : ''}
       </div>
       <span class="ml-auto text-brass" style="font-size:16px">→</span>

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -288,6 +288,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       `<div class="empty-note text-red">${s('toast.loadFailed')}: ${esc(e.message)}</div>`;
   }
 
+  // Delegated click handler — opens detail modal for any incident row
+  document.getElementById('incidentsList').addEventListener('click', e => {
+    const row = e.target.closest('.incident-row');
+    if (!row) return;
+    const inc = incidentById(row.dataset.id);
+    if (inc) openDetail(inc);
+  });
+
   // Handle hash → jump to detail
   if (window.location.hash) {
     const id = window.location.hash.slice(1);
@@ -373,25 +381,31 @@ function renderList() {
   const sevBadge = { low:'badge-green', medium:'badge-yellow', high:'badge-orange', critical:'badge-red' };
   el.innerHTML = incidents.map(i => {
     const types = parseJson(i.types, []);
-    const rNotes = parseJson(i.reviewerNotes, []);
-    return `<div class="incident-row" onclick="openDetail(incidentById('${i.id}'))">
+    const typeLabels = types.map(t => {
+      const def = INCIDENT_TYPES.find(x => x.v === t);
+      return def ? s(def.key) : t;
+    }).join(', ');
+    const sevLabel = i.severity ? (s('incident.sev.'+i.severity) || i.severity) : '';
+    const resolved = i.resolved && i.resolved !== 'false';
+    const inReview = !resolved && i.status === 'review';
+    const statusCls = resolved ? 'badge-green' : (inReview ? 'badge-orange' : 'badge-yellow');
+    const statusLbl = resolved ? s('incident.resolved')
+      : (inReview ? s('incident.statusReview') : s('incident.open'));
+    const dateStr = i.date || sstr(i.filedAt).slice(0, 10);
+    const timeStr = i.time || sstr(i.filedAt).slice(11, 16);
+    const descStr = sstr(i.description);
+    const desc = descStr.slice(0, 140) + (descStr.length > 140 ? '…' : '');
+    return `<div class="incident-row" data-id="${esc(i.id)}">
       <div class="incident-header">
-        <span class="badge ${sevBadge[i.severity]||'badge-muted'}">${esc(s('incident.sev.'+i.severity)||i.severity||'')}</span>
-        <span class="fw-500 flex-1">${esc(i.title||s('incident.title'))}</span>
-        ${(function(){
-          const r = i.resolved && i.resolved !== 'false';
-          const rev = !r && i.status === 'review';
-          const cls = r ? 'badge-green' : (rev ? 'badge-orange' : 'badge-yellow');
-          const lbl = r ? s('incident.resolved') : (rev ? s('incident.statusReview') : s('incident.open'));
-          return `<span class="badge ${cls}">${lbl}</span>`;
-        })()}
+        <span class="fw-500 flex-1">${esc(typeLabels || i.title || '')}</span>
+        ${sevLabel ? `<span class="badge ${sevBadge[i.severity]||'badge-muted'}">${esc(sevLabel)}</span>` : ''}
+        <span class="badge ${statusCls}">${statusLbl}</span>
       </div>
-      <div class="incident-desc">${esc(sstr(i.description)).slice(0,120)}${sstr(i.description).length>120?'…':''}</div>
       <div class="incident-meta">
-        ${esc(sstr(i.filedAt).slice(0,16).replace('T',' '))}
+        ${esc(dateStr)}${timeStr ? ' ' + esc(timeStr) : ''}
         ${i.boatName ? ' · '+esc(i.boatName) : ''}
-        ${rNotes.length ? ` · ${rNotes.length} comment${rNotes.length===1?'':'s'}` : ''}
       </div>
+      ${desc ? `<div class="incident-desc">${esc(desc)}</div>` : ''}
     </div>`;
   }).join('');
 }

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -45,7 +45,7 @@ var _STRINGS_FLAT = {
   "lbl.type": "Type",
   "lbl.sortOrder": "Sort order",
   "lbl.selectDots": "Select…",
-  "lbl.Dash": "—  —",
+  "lbl.noneDash": "— none —",
   "msg.unsavedChanges": "You have unsaved changes. Discard them?",
   "toast.saved": "Saved",
   "toast.saveFailed": "Save failed",


### PR DESCRIPTION
- Use event delegation on the incidents list so rows reliably open the detail modal (inline onclick could fail silently).
- Rebuild the collapsed card on /incidents/ and /dailylog/ to show type, severity, date/time, status, and a truncated description — drop the generic "Incidents" fallback title.
- Fix a typo in strings-en.js: `lbl.Dash` (stray key with "—  —") is now `lbl.noneDash` ("— none —"), so the boat and hand-off "none" options render correctly in English.