### PR TITLE
Restructure boat access gates as {certId, sub, minRank}

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1862,7 +1862,7 @@ function openBoatModal(id) {
   document.getElementById("bOwnerSuggestions").innerHTML = '';
   // Access mode
   document.getElementById("bAccessMode").value = b && b.accessMode === 'controlled' ? 'controlled' : 'free';
-  populateGateCertSelect(b ? (b.accessGateCert || '') : '');
+  populateGateCertSelect(_currentGateFor(b));
   _editAllowlist = b && Array.isArray(b.accessAllowlist) ? b.accessAllowlist.slice() : [];
   renderAllowlistChips();
   updateAccessFields();
@@ -1924,15 +1924,69 @@ function updateSlotFields() {
   document.getElementById("bSlotOptions").classList.toggle("hidden", !enabled);
 }
 
-function populateGateCertSelect(current) {
+// Encode a gate descriptor as a stable option value. Empty fields are omitted
+// and the result is a compact JSON string. Decoded by _decodeGateValue().
+function _encodeGateValue(gate) {
+  if (!gate || !gate.certId) return '';
+  var out = { certId: gate.certId };
+  if (gate.sub) out.sub = gate.sub;
+  if (gate.minRank) out.minRank = Number(gate.minRank);
+  return JSON.stringify(out);
+}
+function _decodeGateValue(v) {
+  if (!v) return null;
+  try { var o = JSON.parse(v); return (o && o.certId) ? o : null; } catch (e) { return null; }
+}
+// Return the stored gate for a boat as a {certId, sub, minRank} object, or
+// null. Uses normalizeAccessGate (from shared/boats.js) so legacy boats with
+// just accessGateCert still resolve to the correct {certId, sub} pair.
+function _currentGateFor(boat) {
+  if (!boat) return null;
+  if (typeof normalizeAccessGate === 'function') {
+    return normalizeAccessGate(boat, certDefs);
+  }
+  // Defensive fallback — should not trigger in practice.
+  if (boat.accessGate && boat.accessGate.certId) return boat.accessGate;
+  return null;
+}
+
+function populateGateCertSelect(currentGate) {
   var sel = document.getElementById("bGateCert");
   sel.innerHTML = '<option value="">' + esc(s('boat.gateCertNone')) + '</option>';
-  // Collect all subcats from all cert defs — labels resolved via bilingual helpers.
+  var selectedVal = _encodeGateValue(currentGate);
+  // Build options: one entry per credential "grade".
+  //   Flat defs (no subcats) → a single def-level entry.
+  //   Defs with subcats → a def-level "(any level)" entry, one exact-match
+  //     entry per subcat, plus a "… or higher" entry for each ranked subcat.
+  var anyLbl   = s('boat.gateCertAny');
+  var orHigher = s('boat.gateCertOrHigher');
   (certDefs || []).forEach(function(def) {
-    if (!def.subcats || !def.subcats.length) return;
-    def.subcats.forEach(function(sc) {
-      sel.innerHTML += '<option value="' + esc(sc.key) + '"' + (sc.key === current ? ' selected' : '') + '>'
-        + esc(certDefName(def) + ' — ' + certSubcatLabel(sc)) + '</option>';
+    if (!def || !def.id) return;
+    var defName = certDefName(def);
+    var subs    = Array.isArray(def.subcats) ? def.subcats : [];
+    if (!subs.length) {
+      var v0 = _encodeGateValue({ certId: def.id });
+      sel.innerHTML += '<option value="' + esc(v0) + '"' + (v0 === selectedVal ? ' selected' : '') + '>'
+        + esc(defName) + '</option>';
+      return;
+    }
+    // def-level "(any level)" option
+    var vAny = _encodeGateValue({ certId: def.id });
+    sel.innerHTML += '<option value="' + esc(vAny) + '"' + (vAny === selectedVal ? ' selected' : '') + '>'
+      + esc(defName + ' — ' + anyLbl) + '</option>';
+    // exact-match subcat options
+    subs.forEach(function(sc) {
+      if (!sc || !sc.key) return;
+      var vExact = _encodeGateValue({ certId: def.id, sub: sc.key });
+      sel.innerHTML += '<option value="' + esc(vExact) + '"' + (vExact === selectedVal ? ' selected' : '') + '>'
+        + esc(defName + ' — ' + certSubcatLabel(sc)) + '</option>';
+    });
+    // rank-or-higher options (only for subcats with a numeric rank)
+    subs.forEach(function(sc) {
+      if (!sc || !sc.key || !sc.rank) return;
+      var vRank = _encodeGateValue({ certId: def.id, minRank: Number(sc.rank) });
+      sel.innerHTML += '<option value="' + esc(vRank) + '"' + (vRank === selectedVal ? ' selected' : '') + '>'
+        + esc(defName + ' — ' + certSubcatLabel(sc) + ' ' + orHigher) + '</option>';
     });
   });
 }
@@ -2088,9 +2142,13 @@ async function saveBoat() {
     ownership:      ownershipVal,
     ownerId:        ownershipVal === 'private' ? (document.getElementById("bOwnerId").value || '') : '',
     ownerName:      ownershipVal === 'private' ? (document.getElementById("bOwnerName").textContent || '') : '',
-    // access control
+    // access control — new structured gate, plus legacy mirror for older readers
     accessMode:     accessModeVal,
-    accessGateCert: accessModeVal === 'controlled' ? (document.getElementById("bGateCert").value || '') : '',
+    accessGate:     accessModeVal === 'controlled' ? _decodeGateValue(document.getElementById("bGateCert").value) : null,
+    accessGateCert: accessModeVal === 'controlled' ? (function() {
+      var _g = _decodeGateValue(document.getElementById("bGateCert").value);
+      return _g ? (_g.sub || _g.certId) : '';
+    })() : '',
     accessAllowlist: accessModeVal === 'controlled' ? _editAllowlist.slice() : [],
     // slot scheduling
     slotSchedulingEnabled: accessModeVal === 'controlled' && document.getElementById("bSlotScheduling").checked,

--- a/captain/index.html
+++ b/captain/index.html
@@ -1319,14 +1319,58 @@ function updateSlotFields() {
   document.getElementById('bSlotOptions').classList.toggle('hidden', !enabled);
 }
 
-function populateCqGateCertSelect(current) {
+// Gate encoding/decoding helpers — mirror of admin's version. See
+// populateGateCertSelect in admin/index.html for the canonical commentary.
+function _cqEncodeGateValue(gate) {
+  if (!gate || !gate.certId) return '';
+  var out = { certId: gate.certId };
+  if (gate.sub) out.sub = gate.sub;
+  if (gate.minRank) out.minRank = Number(gate.minRank);
+  return JSON.stringify(out);
+}
+function _cqDecodeGateValue(v) {
+  if (!v) return null;
+  try { var o = JSON.parse(v); return (o && o.certId) ? o : null; } catch (e) { return null; }
+}
+function _cqCurrentGateFor(boat) {
+  if (!boat) return null;
+  if (typeof normalizeAccessGate === 'function') {
+    return normalizeAccessGate(boat, _cqCertDefs);
+  }
+  if (boat.accessGate && boat.accessGate.certId) return boat.accessGate;
+  return null;
+}
+
+function populateCqGateCertSelect(currentGate) {
   var sel = document.getElementById('bGateCert');
   sel.innerHTML = '<option value="">' + esc(s('boat.gateCertNone')) + '</option>';
+  var selectedVal = _cqEncodeGateValue(currentGate);
+  var anyLbl   = s('boat.gateCertAny');
+  var orHigher = s('boat.gateCertOrHigher');
   (_cqCertDefs || []).forEach(function(def) {
-    if (!def.subcats || !def.subcats.length) return;
-    def.subcats.forEach(function(sc) {
-      sel.innerHTML += '<option value="' + esc(sc.key) + '"' + (sc.key === current ? ' selected' : '') + '>'
-        + esc(certDefName(def) + ' — ' + certSubcatLabel(sc)) + '</option>';
+    if (!def || !def.id) return;
+    var defName = certDefName(def);
+    var subs    = Array.isArray(def.subcats) ? def.subcats : [];
+    if (!subs.length) {
+      var v0 = _cqEncodeGateValue({ certId: def.id });
+      sel.innerHTML += '<option value="' + esc(v0) + '"' + (v0 === selectedVal ? ' selected' : '') + '>'
+        + esc(defName) + '</option>';
+      return;
+    }
+    var vAny = _cqEncodeGateValue({ certId: def.id });
+    sel.innerHTML += '<option value="' + esc(vAny) + '"' + (vAny === selectedVal ? ' selected' : '') + '>'
+      + esc(defName + ' — ' + anyLbl) + '</option>';
+    subs.forEach(function(sc) {
+      if (!sc || !sc.key) return;
+      var vExact = _cqEncodeGateValue({ certId: def.id, sub: sc.key });
+      sel.innerHTML += '<option value="' + esc(vExact) + '"' + (vExact === selectedVal ? ' selected' : '') + '>'
+        + esc(defName + ' — ' + certSubcatLabel(sc)) + '</option>';
+    });
+    subs.forEach(function(sc) {
+      if (!sc || !sc.key || !sc.rank) return;
+      var vRank = _cqEncodeGateValue({ certId: def.id, minRank: Number(sc.rank) });
+      sel.innerHTML += '<option value="' + esc(vRank) + '"' + (vRank === selectedVal ? ' selected' : '') + '>'
+        + esc(defName + ' — ' + certSubcatLabel(sc) + ' ' + orHigher) + '</option>';
     });
   });
 }
@@ -1473,7 +1517,7 @@ function openCqBoatModal(id) {
   document.getElementById('bOwnerSuggestions').innerHTML = '';
   // Access mode
   document.getElementById('bAccessMode').value = b && b.accessMode === 'controlled' ? 'controlled' : 'free';
-  populateCqGateCertSelect(b ? (b.accessGateCert || '') : '');
+  populateCqGateCertSelect(_cqCurrentGateFor(b));
   _bmEditAllowlist = b && Array.isArray(b.accessAllowlist) ? b.accessAllowlist.slice() : [];
   renderCqAllowlistChips();
   updateAccessFields();
@@ -1518,7 +1562,11 @@ async function saveCqBoat() {
     ownerId: ownershipVal === 'private' ? (document.getElementById('bOwnerId').value || '') : '',
     ownerName: ownershipVal === 'private' ? (document.getElementById('bOwnerName').textContent || '') : '',
     accessMode: accessModeVal,
-    accessGateCert: accessModeVal === 'controlled' ? (document.getElementById('bGateCert').value || '') : '',
+    accessGate: accessModeVal === 'controlled' ? _cqDecodeGateValue(document.getElementById('bGateCert').value) : null,
+    accessGateCert: accessModeVal === 'controlled' ? (function() {
+      var _g = _cqDecodeGateValue(document.getElementById('bGateCert').value);
+      return _g ? (_g.sub || _g.certId) : '';
+    })() : '',
     accessAllowlist: accessModeVal === 'controlled' ? _bmEditAllowlist.slice() : [],
     slotSchedulingEnabled: accessModeVal === 'controlled' && document.getElementById('bSlotScheduling').checked,
     availableOutsideSlots: accessModeVal === 'controlled' && document.getElementById('bSlotScheduling').checked ? document.getElementById('bAvailOutside').checked : true

--- a/code.gs
+++ b/code.gs
@@ -1670,6 +1670,76 @@ function getCertDefs_() {
   try { return normalizeCertDefsRaw_(JSON.parse(raw)); } catch (e) { return []; }
 }
 
+// ── Unified boat access-gate helpers ──────────────────────────────────────────
+// Mirrors normalizeAccessGate / memberHasGate in shared/boats.js. Keep the two
+// in sync: any semantic change here (shape, rank handling, expiry) must also
+// land in shared/boats.js so frontend and backend never disagree.
+function normalizeAccessGate_(boat, certDefs) {
+  if (!boat) return null;
+  var defs = Array.isArray(certDefs) ? certDefs : [];
+  if (boat.accessGate && typeof boat.accessGate === 'object' && boat.accessGate.certId) {
+    var minRank = Number(boat.accessGate.minRank || 0) || 0;
+    return {
+      certId:  String(boat.accessGate.certId),
+      sub:     boat.accessGate.sub ? String(boat.accessGate.sub) : '',
+      minRank: minRank > 0 ? minRank : 0,
+    };
+  }
+  var raw = boat.accessGateCert;
+  if (!raw || typeof raw !== 'string') return null;
+  if (defs.length) {
+    for (var i = 0; i < defs.length; i++) {
+      var def = defs[i];
+      if (def && Array.isArray(def.subcats)) {
+        for (var j = 0; j < def.subcats.length; j++) {
+          if (def.subcats[j] && def.subcats[j].key === raw) {
+            return { certId: def.id, sub: raw, minRank: 0 };
+          }
+        }
+      }
+    }
+    for (var k = 0; k < defs.length; k++) {
+      if (defs[k] && defs[k].id === raw) return { certId: raw, sub: '', minRank: 0 };
+    }
+  }
+  return { certId: '', sub: raw, minRank: 0 };
+}
+
+function _gateSubcatRank_(certDefs, certId, subKey) {
+  if (!Array.isArray(certDefs) || !certDefs.length || !certId || !subKey) return 0;
+  var def = null;
+  for (var i = 0; i < certDefs.length; i++) { if (certDefs[i] && certDefs[i].id === certId) { def = certDefs[i]; break; } }
+  if (!def || !Array.isArray(def.subcats)) return 0;
+  for (var j = 0; j < def.subcats.length; j++) {
+    var sc = def.subcats[j];
+    if (sc && sc.key === subKey) return Number(sc.rank || 0) || 0;
+  }
+  return 0;
+}
+
+function memberHasGate_(certs, gate, certDefs) {
+  if (!gate || (!gate.certId && !gate.sub)) return true;
+  if (!Array.isArray(certs)) return false;
+  var today = new Date().toISOString().slice(0, 10);
+  return certs.some(function(c) {
+    if (!c) return false;
+    if (c.expiresAt && c.expiresAt < today) return false;
+    if (!gate.certId) return gate.sub && c.sub === gate.sub;
+    if (c.certId !== gate.certId) return false;
+    if (gate.minRank > 0) {
+      return _gateSubcatRank_(certDefs, gate.certId, c.sub) >= gate.minRank;
+    }
+    if (gate.sub) return c.sub === gate.sub;
+    return true;
+  });
+}
+
+function _parseMemberCerts_(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  try { var p = JSON.parse(raw); return Array.isArray(p) ? p : []; } catch (e) { return []; }
+}
+
 // Pad legacy cert-def entries with the new bilingual fields so server-side
 // consumers (public record page, captain report, getConfig) always see the
 // extended shape. Mirrors new fields onto legacy fields too.
@@ -1947,10 +2017,14 @@ function saveCheckout_(b) {
           var hasAccess = false;
           // Owner check
           if (checkBoat.ownership === 'private' && String(checkBoat.ownerId || checkBoat.ownerKennitala || '') === checkKt) hasAccess = true;
-          // Cert gate check
-          if (!hasAccess && checkBoat.accessGateCert && checkMember && checkMember.certifications) {
-            var memberCerts = typeof checkMember.certifications === 'string' ? JSON.parse(checkMember.certifications) : (checkMember.certifications || []);
-            if (Array.isArray(memberCerts) && memberCerts.some(function(c) { return c.sub === checkBoat.accessGateCert || c.certId === checkBoat.accessGateCert; })) hasAccess = true;
+          // Cert gate check (unified helper — honours expiry, rank, structured + legacy shapes)
+          if (!hasAccess && checkMember) {
+            var _coDefs = getCertDefsFromMap_(cfgMap);
+            var _coGate = normalizeAccessGate_(checkBoat, _coDefs);
+            if (_coGate) {
+              var memberCerts = _parseMemberCerts_(checkMember.certifications);
+              if (memberHasGate_(memberCerts, _coGate, _coDefs)) hasAccess = true;
+            }
           }
           // Allowlist check
           if (!hasAccess && checkBoat.accessAllowlist && Array.isArray(checkBoat.accessAllowlist) && checkBoat.accessAllowlist.indexOf(checkKt) !== -1) hasAccess = true;
@@ -2149,7 +2223,26 @@ function saveBoatAccess_(b) {
   const idx = boats.findIndex(x => x.id === b.boatId);
   if (idx < 0) return failJ('Boat not found');
   if (b.accessMode !== undefined) boats[idx].accessMode = b.accessMode === 'controlled' ? 'controlled' : 'free';
-  if (b.accessGateCert !== undefined) boats[idx].accessGateCert = String(b.accessGateCert || '');
+  // New structured gate wins. Also mirror a legacy accessGateCert string
+  // (sub || certId) so older readers keep working until fully migrated.
+  if (b.accessGate !== undefined) {
+    if (b.accessGate && typeof b.accessGate === 'object' && b.accessGate.certId) {
+      var _sg = {
+        certId:  String(b.accessGate.certId),
+        sub:     b.accessGate.sub     ? String(b.accessGate.sub)     : '',
+        minRank: Number(b.accessGate.minRank || 0) || 0,
+      };
+      boats[idx].accessGate = _sg;
+      boats[idx].accessGateCert = _sg.sub || _sg.certId;
+    } else {
+      boats[idx].accessGate = null;
+      boats[idx].accessGateCert = '';
+    }
+  } else if (b.accessGateCert !== undefined) {
+    // Legacy callers still work
+    boats[idx].accessGateCert = String(b.accessGateCert || '');
+    if (!b.accessGateCert) boats[idx].accessGate = null;
+  }
   if (b.accessAllowlist !== undefined) boats[idx].accessAllowlist = Array.isArray(b.accessAllowlist) ? b.accessAllowlist.map(String) : [];
   setConfigSheetValue_('boats', JSON.stringify(boats));
   cDel_('config');
@@ -2497,14 +2590,21 @@ function bookSlot_(b) {
   } else {
     // Individual booking (keelboats — captain required)
     if (!b.kennitala) return failJ('kennitala required');
-    if (boat.category === 'keelboat' && boat.accessGateCert) {
-      var member = findOne_('members', 'kennitala', String(b.kennitala).trim());
-      if (!member) return failJ('Member not found');
-      var isStaffRole = member.role === 'staff' || member.role === 'admin';
-      if (!isStaffRole) {
-        var certs = typeof member.certifications === 'string' ? JSON.parse(member.certifications) : (member.certifications || []);
-        if (!Array.isArray(certs) || !certs.some(function(c) { return c.sub === boat.accessGateCert; })) {
-          return failJ('You do not have the required certification to book this boat');
+    // Keelboat-only gate: rowing shells enforce cert access via their own
+    // released-rower path. For keelboats, honour the boat's access gate
+    // (structured or legacy) via the unified helper — blocks expired certs.
+    if (boat.category === 'keelboat') {
+      var _bsDefs = getCertDefsFromMap_(cfgMap);
+      var _bsGate = normalizeAccessGate_(boat, _bsDefs);
+      if (_bsGate) {
+        var member = findOne_('members', 'kennitala', String(b.kennitala).trim());
+        if (!member) return failJ('Member not found');
+        var isStaffRole = member.role === 'staff' || member.role === 'admin';
+        if (!isStaffRole) {
+          var certs = _parseMemberCerts_(member.certifications);
+          if (!memberHasGate_(certs, _bsGate, _bsDefs)) {
+            return failJ('You do not have the required certification to book this boat');
+          }
         }
       }
     }
@@ -2565,14 +2665,20 @@ function bulkBookSlots_(b) {
     updates.bookedByKennitala = String(b.kennitala);
     if (crew.status === 'forming') updates.tentative = 'true';
   } else {
-    if (boat.category === 'keelboat' && boat.accessGateCert) {
-      var member = findOne_('members', 'kennitala', String(b.kennitala).trim());
-      if (!member) return failJ('Member not found');
-      var isStaffRole = member.role === 'staff' || member.role === 'admin';
-      if (!isStaffRole) {
-        var certs = typeof member.certifications === 'string' ? JSON.parse(member.certifications) : (member.certifications || []);
-        if (!Array.isArray(certs) || !certs.some(function(c) { return c.sub === boat.accessGateCert; })) {
-          return failJ('You do not have the required certification to book this boat');
+    // Keelboat-only gate (same rationale as bookSlot_): use unified helper so
+    // structured, legacy, and rank-based gates all agree and expiry blocks.
+    if (boat.category === 'keelboat') {
+      var _bbDefs = getCertDefsFromMap_(cfgMap);
+      var _bbGate = normalizeAccessGate_(boat, _bbDefs);
+      if (_bbGate) {
+        var member = findOne_('members', 'kennitala', String(b.kennitala).trim());
+        if (!member) return failJ('Member not found');
+        var isStaffRole = member.role === 'staff' || member.role === 'admin';
+        if (!isStaffRole) {
+          var certs = _parseMemberCerts_(member.certifications);
+          if (!memberHasGate_(certs, _bbGate, _bbDefs)) {
+            return failJ('You do not have the required certification to book this boat');
+          }
         }
       }
     }

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -411,9 +411,14 @@ window.showCxTab = showCxTab;
     _myCrews = _allBoardCrews.filter(function(c) { return _isMyMember(c); });
 
     if (cfgRes.boatCategories) registerBoatCats(cfgRes.boatCategories);
+    // Register cert defs so normalizeAccessGate can resolve legacy bare-string
+    // gate values (e.g. 'released_rower') to their {certId, sub} object shape.
+    if (cfgRes.certDefs && typeof registerCertDefsForBoats === 'function') {
+      registerCertDefsForBoats(cfgRes.certDefs);
+    }
 
     // Filter trips to rowing-division-gated boats
-    var cxBoatIds = new Set(_boats.filter(b => b.accessGateCert === 'released_rower').map(b => b.id));
+    var cxBoatIds = new Set(_boats.filter(_isRowingGatedBoat).map(function(b) { return b.id; }));
     _allTrips = (tripsRes.trips || []).filter(t => cxBoatIds.has(t.boatId));
 
     renderStats();
@@ -461,12 +466,28 @@ function renderStats() {
   document.getElementById('statDist').textContent = '—';
 }
 
+// ══ ROWING-GATE PREDICATE ════════════════════════════════════════════════════
+// True if the boat's access gate references the rowing division. Uses
+// normalizeAccessGate() to handle both new {accessGate:{certId,sub,minRank}}
+// shapes and legacy bare-string accessGateCert values. Also accepts the known
+// legacy subcat strings so pre-migration clubs that don't use the
+// 'rowing_division' canonical certId still get the right filter.
+function _isRowingGatedBoat(b) {
+  if (!b) return false;
+  var gate = (typeof normalizeAccessGate === 'function') ? normalizeAccessGate(b) : null;
+  if (gate && gate.certId === 'rowing_division') return true;
+  var raw = b.accessGateCert;
+  return raw === 'released_rower' || raw === 'released'
+      || raw === 'restricted_rower' || raw === 'restricted'
+      || raw === 'coxswain' || raw === 'rowing_division';
+}
+
 // ══ MAINTENANCE ══════════════════════════════════════════════════════════════
 var _rowingBoatIdSet = null;
 function renderMaint() {
   var el = document.getElementById('maintList');
   if (!_rowingBoatIdSet) {
-    _rowingBoatIdSet = new Set(_boats.filter(b => b.accessGateCert === 'released_rower').map(b => b.id));
+    _rowingBoatIdSet = new Set(_boats.filter(_isRowingGatedBoat).map(function(b) { return b.id; }));
   }
   var items = _allMaint.filter(m => _rowingBoatIdSet.has(m.boatId) && m.status !== 'resolved');
   if (!items.length) {
@@ -825,7 +846,7 @@ var _cxSlotBoats = [];
 function initCxSlots() {
   // Find rowing-shell boats with slot scheduling
   _cxSlotBoats = (_boats || []).filter(function(b) {
-    return boolVal(b.slotSchedulingEnabled) && b.accessGateCert === 'released_rower';
+    return boolVal(b.slotSchedulingEnabled) && _isRowingGatedBoat(b);
   });
   var sect = document.getElementById('sectSlots');
   // Show section if there are slot-scheduled boats (no longer requires active crews)

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -85,6 +85,107 @@ function boatEmoji(cat) {
   return BOAT_EMOJI[key] || "⛵";
 }
 
+// ── Access-gate registry & normalization ──────────────────────────────────────
+// Pages that need cert-aware access checks (rank gates, legacy subcat-key
+// disambiguation) should call registerCertDefsForBoats(cfgRes.certDefs) after
+// loading config. Pages that don't register still get correct behaviour for
+// structured gates and exact subcat matches — only rank-based gates and
+// legacy-string → certId resolution require defs.
+var _boatAccessCertDefs = [];
+function registerCertDefsForBoats(defs) {
+  _boatAccessCertDefs = Array.isArray(defs) ? defs : [];
+}
+
+/**
+ * Return a {certId, sub, minRank} object describing the boat's access gate,
+ * or null if no gate is set. Handles three input shapes:
+ *   1. New:     boat.accessGate = { certId, sub?, minRank? }
+ *   2. Legacy subcat key:  boat.accessGateCert = 'released'        → resolves via defs
+ *   3. Legacy def id:      boat.accessGateCert = 'support_boat_skipper'
+ * When defs are unavailable and the legacy string can't be resolved, returns
+ * a sub-only shape ({certId:'', sub:raw}) which memberHasGate() treats as a
+ * loose subcat match — preserving pre-migration behaviour.
+ */
+function normalizeAccessGate(boat, certDefs) {
+  if (!boat) return null;
+  var defs = Array.isArray(certDefs) ? certDefs : _boatAccessCertDefs;
+  // Shape 1: structured object
+  if (boat.accessGate && typeof boat.accessGate === 'object' && boat.accessGate.certId) {
+    var minRank = Number(boat.accessGate.minRank || 0) || 0;
+    return {
+      certId:  String(boat.accessGate.certId),
+      sub:     boat.accessGate.sub ? String(boat.accessGate.sub) : '',
+      minRank: minRank > 0 ? minRank : 0,
+    };
+  }
+  // Shape 2/3: bare string
+  var raw = boat.accessGateCert;
+  if (!raw || typeof raw !== 'string') return null;
+  if (defs.length) {
+    // Try subcat key match first (most legacy values are subcat keys)
+    for (var i = 0; i < defs.length; i++) {
+      var def = defs[i];
+      if (def && Array.isArray(def.subcats)) {
+        for (var j = 0; j < def.subcats.length; j++) {
+          if (def.subcats[j] && def.subcats[j].key === raw) {
+            return { certId: def.id, sub: raw, minRank: 0 };
+          }
+        }
+      }
+    }
+    // Then def id match (flat credentials like 'support_boat_skipper')
+    for (var k = 0; k < defs.length; k++) {
+      if (defs[k] && defs[k].id === raw) return { certId: raw, sub: '', minRank: 0 };
+    }
+  }
+  // Unresolved legacy: treat as sub-only match
+  return { certId: '', sub: raw, minRank: 0 };
+}
+
+function _gateSubcatRank(certDefs, certId, subKey) {
+  var defs = Array.isArray(certDefs) ? certDefs : _boatAccessCertDefs;
+  if (!defs.length || !certId || !subKey) return 0;
+  var def = null;
+  for (var i = 0; i < defs.length; i++) { if (defs[i] && defs[i].id === certId) { def = defs[i]; break; } }
+  if (!def || !Array.isArray(def.subcats)) return 0;
+  for (var j = 0; j < def.subcats.length; j++) {
+    var sc = def.subcats[j];
+    if (sc && sc.key === subKey) return Number(sc.rank || 0) || 0;
+  }
+  return 0;
+}
+
+/**
+ * Unified predicate: does `certs` (a member's credentials array) satisfy
+ * `gate` (a normalized access gate)?
+ *
+ * Rules:
+ *   - No gate (null / empty) → always true
+ *   - Expired credentials (c.expiresAt < today) never match
+ *   - gate.minRank > 0: any subcat on the same certId whose rank >= minRank
+ *   - gate.sub: exact subcat match on the same certId
+ *   - gate.certId only: member holds any credential with that certId
+ *   - gate.sub without certId (unresolved legacy): match by sub alone
+ */
+function memberHasGate(certs, gate, certDefs) {
+  if (!gate || (!gate.certId && !gate.sub)) return true;
+  if (!Array.isArray(certs)) return false;
+  var today = todayISO();
+  var defs = Array.isArray(certDefs) ? certDefs : _boatAccessCertDefs;
+  return certs.some(function(c) {
+    if (!c) return false;
+    if (c.expiresAt && c.expiresAt < today) return false;
+    // Legacy sub-only gate (certId unknown): match by sub alone
+    if (!gate.certId) return gate.sub && c.sub === gate.sub;
+    if (c.certId !== gate.certId) return false;
+    if (gate.minRank > 0) {
+      return _gateSubcatRank(defs, gate.certId, c.sub) >= gate.minRank;
+    }
+    if (gate.sub) return c.sub === gate.sub;
+    return true; // certId-only gate satisfied
+  });
+}
+
 // ── Ownership / charter helpers ───────────────────────────────────────────────
 
 /** Returns true if the boat is privately owned. */
@@ -157,16 +258,11 @@ function canAccessBoat(boat, user, opts) {
   if (isStaff(user)) return true;
   // Private boat owner always has access
   if (boat.ownership === 'private' && String(boat.ownerId || boat.ownerKennitala || '') === String(user.kennitala)) return true;
-  // Check cert gate (excluding expired certs)
-  if (boat.accessGateCert) {
+  // Check cert gate via unified helper (honours expiry + rank + new structured shape)
+  var gate = normalizeAccessGate(boat, opts && opts.certDefs);
+  if (gate) {
     var certs = parseJson(user.certifications, []);
-    var today = todayISO();
-    if (Array.isArray(certs) && certs.some(function(c) {
-      var matches = c.sub === boat.accessGateCert || c.certId === boat.accessGateCert;
-      if (!matches) return false;
-      if (c.expiresAt && c.expiresAt < today) return false;
-      return true;
-    })) return true;
+    if (memberHasGate(certs, gate, opts && opts.certDefs)) return true;
   }
   // Check allowlist
   if (boat.accessAllowlist && Array.isArray(boat.accessAllowlist) && boat.accessAllowlist.indexOf(String(user.kennitala)) !== -1) return true;

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -546,6 +546,8 @@ var _STRINGS_FLAT = {
   "boat.accessControlled": "Controlled Access",
   "boat.gateCert": "Required Certification",
   "boat.gateCertNone": "None (Specific members only)",
+  "boat.gateCertAny": "any level",
+  "boat.gateCertOrHigher": "or higher",
   "boat.allowlist": "Allowed Members",
   "boat.reservations": "Charter Status",
   "boat.addReservation": "Assign Charter",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -546,6 +546,8 @@ var _STRINGS_FLAT = {
   "boat.accessControlled": "Stýrður aðgangur",
   "boat.gateCert": "Nauðsynleg vottun",
   "boat.gateCertNone": "Ekkert (aðeins listi)",
+  "boat.gateCertAny": "hvaða stig sem er",
+  "boat.gateCertOrHigher": "eða hærra",
   "boat.allowlist": "Leyfilegir meðlimir",
   "boat.reservations": "Úthluta leigu",
   "boat.addReservation": "Bæta við leigu",


### PR DESCRIPTION
Boats stored their controlled-access gate as a bare subcat key on accessGateCert, which forced every credential into a parent>subcat shape and silently broke flat credentials like Support Boat Skipper. The frontend and backend also disagreed on whether expired certs counted, and the slot-booking enforcement matched on c.sub only while checkout matched on c.sub or c.certId.

Replace the bare-string gate with a structured accessGate object { certId, sub?, minRank? } and route every gate check (frontend canAccessBoat, backend saveCheckout_, bookSlot_, bulkBookSlots_) through one shared predicate (memberHasGate / memberHasGate_) so the rules can never drift again. The predicate honours expiry everywhere, supports rank-or-higher gates via minRank, and falls back gracefully when cert defs aren't loaded.

A normaliser resolves legacy boats whose gate is still a bare accessGateCert string by looking the value up in cert defs as either a subcat key or a def id, so existing data round-trips without migration. Saves still mirror a legacy accessGateCert (sub || certId) for any older readers that haven't been updated yet.

The admin and captain boat-edit dropdowns now expose, for each cert def: a flat entry (when there are no subcats), a "(any level)" entry, one option per subcat for exact match, and a "Subcat or higher" option for every ranked subcat. Coxswain's three rowing-gated boat filters move behind a single _isRowingGatedBoat helper that accepts both new and legacy shapes.

⚠️ Updates code.gs (the backend): adds normalizeAccessGate_, memberHasGate_, _gateSubcatRank_, _parseMemberCerts_; rewrites the cert-gate branch in saveCheckout_, bookSlot_, and bulkBookSlots_ to use the unified helper; extends saveBoatAccess_ to accept the new accessGate payload while continuing to write the legacy string.

https://claude.ai/code/session_01HBRm3mPFH9qzVxwn5Xwwkp