### PR TITLE
Fix incident/volunteer cards across pages

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2807,68 +2807,50 @@ function _volTogglePast() {
   renderVolunteerEvents();
 }
 
+// Localized "Wed, 15 Apr" / "Wed 15 Apr – Fri 17 Apr" for a volunteer event.
+function _volFormatDayLabel(ev) {
+  const startIso = ev && ev.date ? ev.date : '';
+  if (!startIso) return '';
+  const endIso = (ev && ev.endDate && ev.endDate !== startIso) ? ev.endDate : '';
+  const dows = ['day.sun','day.mon','day.tue','day.wed','day.thu','day.fri','day.sat'];
+  const months = ['month.jan','month.feb','month.mar','month.apr','month.may','month.jun',
+                  'month.jul','month.aug','month.sep','month.oct','month.nov','month.dec'];
+  const a = new Date(startIso + 'T00:00:00');
+  const left = s(dows[a.getDay()]) + ', ' + a.getDate() + ' ' + s(months[a.getMonth()]);
+  if (!endIso) return left;
+  const b = new Date(endIso + 'T00:00:00');
+  const right = s(dows[b.getDay()]) + ' ' + b.getDate() + ' ' + s(months[b.getMonth()]);
+  return left + ' – ' + right;
+}
+
+function _volFormatTimeRange(ev) {
+  const a = (ev && ev.startTime || '').slice(0, 5);
+  const b = (ev && ev.endTime   || '').slice(0, 5);
+  if (a && b) return a + '–' + b;
+  if (a) return a;
+  return '';
+}
+
+// Admin volunteer row — reuses the shared /volunteer/ card renderer so the
+// two views stay visually identical. Adds an Edit button that opens the
+// full volunteer-event modal and a Delete button for destructive removal.
 function _volRowHtml(ev, L) {
-  const title = (L === 'IS' && ev.titleIS ? ev.titleIS : ev.title) || ev.title || '—';
-  const subtitle = (L === 'IS' && ev.subtitleIS ? ev.subtitleIS : ev.subtitle) || ev.subtitle || '';
-  const roles = Array.isArray(ev.roles) ? ev.roles : [];
-  const rolesHtml = roles.map(r => {
-    const rn = (L === 'IS' && r.nameIS ? r.nameIS : r.name) || r.name || '';
-    const endorseStr = r.requiredEndorsement
-      ? ' <span style="color:var(--brass)">[' + esc(certDefName((certDefs || []).find(function(d){ return d.id === r.requiredEndorsement; })) || r.requiredEndorsement) + ']</span>'
-      : '';
-    const signups = (volunteerSignups || []).filter(function(su) { return su.eventId === ev.id && su.roleId === r.id; });
-    const filled = signups.length;
-    const slotsLbl = (r.slots ? (filled + '/' + r.slots) : (filled + '/∞')) + ' ' + s('admin.volSlots').toLowerCase();
-    const chipsHtml = signups.length
-      ? '<div style="padding:2px 0 4px 18px;display:flex;flex-wrap:wrap;gap:4px">'
-        + signups.map(function(su) {
-            // Live-lookup phone + consent from member record so the current
-            // preference state is always reflected (not a stale snapshot).
-            const mem = (members || []).find(function(m) {
-              return String(m.kennitala) === String(su.kennitala);
-            });
-            let showPhone = false;
-            let phone = '';
-            if (mem) {
-              phone = mem.phone || '';
-              let prefs = {};
-              try { prefs = JSON.parse(mem.preferences || '{}'); } catch(e) { prefs = {}; }
-              showPhone = prefs.sharePhoneVolunteer === true || prefs.sharePhoneVolunteer === 'true';
-            }
-            const phoneHtml = (showPhone && phone)
-              ? ' · <a href="tel:' + esc(phone) + '" onclick="event.stopPropagation()" style="color:var(--brass);text-decoration:none">' + esc(phone) + '</a>'
-              : '';
-            return '<span style="font-size:10px;color:var(--text);background:var(--faint);border:1px solid var(--border);border-radius:10px;padding:2px 8px">'
-              + esc(su.name || '—') + phoneHtml + '</span>';
-          }).join('')
-        + '</div>'
-      : '';
-    return '<span style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px;display:block">→ ' + esc(rn) + ' (' + slotsLbl + ')' + endorseStr + '</span>'
-      + chipsHtml;
-  }).join('');
-  const stopProp = 'onclick="event.stopPropagation();';
-  const leaderHtml = ev.leaderName
-    ? (function() {
-        const phoneLink = (ev.leaderPhone && ev.showLeaderPhone)
-          ? ' · <a href="tel:' + esc(ev.leaderPhone) + '" onclick="event.stopPropagation()" style="color:var(--brass);text-decoration:none">' + esc(ev.leaderPhone) + '</a>'
-          : '';
-        return '<div style="font-size:10px;color:var(--muted);padding:2px 0 4px 12px;display:flex;align-items:center;flex-wrap:wrap;gap:6px">'
-          + '<span>' + s('admin.volLeader') + ':</span>'
-          + '<span style="font-size:10px;color:var(--text);background:var(--faint);border:1px solid var(--border);border-radius:10px;padding:2px 8px">'
-          + esc(ev.leaderName) + phoneLink
-          + '</span>'
-          + '</div>';
-      })()
-    : '';
-  return '<div class="list-row" onclick="openVolEventModal(\'' + ev.id + '\')" style="flex-direction:column;align-items:stretch;gap:2px;cursor:pointer">'
-    + '<div style="display:flex;align-items:center;gap:10px">'
-    + '<span class="list-name">' + esc(title) + (subtitle ? '<span style="color:var(--muted);font-size:11px;margin-left:6px">· ' + esc(subtitle) + '</span>' : '') + '<span style="color:var(--muted);font-size:11px;margin-left:8px">' + esc(ev.date || '') + (ev.endDate && ev.endDate !== ev.date ? '→' + esc(ev.endDate) : '') + (ev.startTime ? ' · ' + esc(ev.startTime) : '') + (ev.endTime ? '–' + esc(ev.endTime) : '') + '</span></span>'
-    + '<button class="row-edit" ' + stopProp + 'openVolEventModal(\'' + ev.id + '\')">Edit</button>'
-    + '<button class="row-del" ' + stopProp + 'deleteVolEvent(\'' + ev.id + '\')">×</button>'
-    + '</div>'
-    + leaderHtml
-    + rolesHtml
-    + '</div>';
+  if (typeof renderVolunteerCard !== 'function') return '';
+  return renderVolunteerCard(ev, {
+    mode: 'admin',
+    lang: L || getLang(),
+    signups: volunteerSignups,
+    members: members,
+    certDefs: certDefs,
+    certDefName: (typeof certDefName === 'function') ? certDefName : function(d) { return d && (d.name || d.id) || ''; },
+    esc: esc,
+    s: s,
+    formatDay: _volFormatDayLabel,
+    formatTime: _volFormatTimeRange,
+    onCardClick:   "openVolEventModal('" + ev.id + "')",
+    onEditClick:   "openVolEventModal('" + ev.id + "')",
+    onDeleteClick: "deleteVolEvent('" + ev.id + "')",
+  });
 }
 
 function openVolEventModal(id) {

--- a/code.gs
+++ b/code.gs
@@ -1941,8 +1941,23 @@ function getIncidents_(b) {
 
 function createIncident_(b) {
   const ts = now_(), id = uid_();
+  // Normalize `types` to a single-level JSON string. The client already sends
+  // it as a JSON-encoded array (JSON.stringify(['injury', ...])), so calling
+  // JSON.stringify again would double-encode and leave a string — not an
+  // array — sitting in the sheet. Parse/re-stringify to keep storage clean.
+  let typesJson = '[]';
+  if (Array.isArray(b.types)) {
+    typesJson = JSON.stringify(b.types);
+  } else if (typeof b.types === 'string' && b.types) {
+    try {
+      const parsed = JSON.parse(b.types);
+      typesJson = JSON.stringify(Array.isArray(parsed) ? parsed : []);
+    } catch (e) {
+      typesJson = '[]';
+    }
+  }
   insertRow_('incidents', {
-    id, types: JSON.stringify(b.types || []), severity: b.severity || 'minor',
+    id, types: typesJson, severity: b.severity || 'minor',
     date: b.date || ts.slice(0, 10), time: b.time || ts.slice(11, 16),
     locationId: b.locationId || '', locationName: b.locationName || '',
     boatId: b.boatId || '', boatName: b.boatName || '',

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -299,6 +299,22 @@
   </div>
 </div>
 
+<!-- ══ INCIDENT DETAIL MODAL ══ -->
+<div class="modal-overlay hidden" id="incidentDetailModal"
+  onclick="if(event.target===this)closeModal('incidentDetailModal')">
+  <div class="modal" style="max-width:560px">
+    <div class="modal-header">
+      <h3 id="idTitle"></h3>
+      <button class="modal-close-x" onclick="closeModal('incidentDetailModal')">×</button>
+    </div>
+    <div id="idStatusRow" class="mb-10" style="display:flex;gap:6px;flex-wrap:wrap"></div>
+    <div class="info-panel" id="idBody"></div>
+    <div class="flex-center mt-14">
+      <a id="idOpenFull" class="btn-ghost" href="#">→ <span data-s="incident.viewList"></span></a>
+    </div>
+  </div>
+</div>
+
 <script>
 // ════════════════════════════════════════════════════════════════════════════
 // SECTION 1 — AUTH + CONSTANTS
@@ -513,10 +529,27 @@ function renderActivitiesReadonly() {
   });
 }
 
-// ── Incident section — fully bilingual ───────────────────────────────────────
+// ── Incident helpers — fully bilingual ───────────────────────────────────────
+// Older rows in the incidents sheet were written double-stringified (see the
+// createIncident_ backend fix), so a single JSON.parse yields a string. Peel
+// until we reach an array and return that, otherwise an empty array.
+function _dlParseIncidentTypes(v) {
+  if (v == null || v === '') return [];
+  let cur = v;
+  for (let i = 0; i < 3 && typeof cur === 'string'; i++) {
+    try { cur = JSON.parse(cur); } catch(e) { return []; }
+  }
+  return Array.isArray(cur) ? cur : [];
+}
+
+// Cache the incidents shown under a given daily log so the click handler can
+// look up the row without another network call.
+let _dlIncidentsById = {};
+
 function renderIncidentSection(incidents) {
   const container = dom.incidentContainer;
   const heading   = dom.incidentHeading;
+  _dlIncidentsById = {};
   if (!incidents || !incidents.length) {
     heading.textContent = s('daily.incidentReport');
     container.innerHTML = `<div class="content-card text-muted text-md">${s('daily.noIncidents')}</div>`;
@@ -524,7 +557,11 @@ function renderIncidentSection(incidents) {
   }
   heading.textContent = `${s('daily.incidentReport')} · ${incidents.length}`;
   container.innerHTML = incidents.map(inc => {
-    const types = (function() { try { var t = typeof inc.types === 'string' ? JSON.parse(inc.types) : inc.types; return Array.isArray(t) ? t.map(function(k){ return s('incident.type.'+k)||k; }).join(', ') : ''; } catch(e){ return ''; } })();
+    _dlIncidentsById[inc.id] = inc;
+    const typeList = _dlParseIncidentTypes(inc.types);
+    const typeLabels = typeList
+      .map(function(k) { return s('incident.type.' + k) || k; })
+      .join(', ');
     const dateStr = inc.date || sstr(inc.filedAt).slice(0,10);
     const timeStr = inc.time || sstr(inc.filedAt).slice(11,16);
     const sevLabel = inc.severity ? (s('incident.sev.'+inc.severity) || inc.severity) : '';
@@ -542,19 +579,79 @@ function renderIncidentSection(incidents) {
     const descStr = sstr(inc.description);
     const desc = descStr.slice(0,140);
     const descMore = descStr.length > 140 ? '…' : '';
-    return `<a href="../incidents/#${esc(inc.id)}" class="incident-btn" style="align-items:flex-start">
+    return `<div class="incident-btn" style="align-items:flex-start" data-incident-id="${esc(inc.id)}">
       <div style="flex:1;font-size:12px;min-width:0">
         <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-          <span class="fw-500">${esc(types || inc.title || '')}</span>
+          <span class="fw-500">${esc(typeLabels || inc.title || '')}</span>
           ${sevLabel ? `<span class="badge badge-${sevClass}">${esc(sevLabel)}</span>` : ''}
           <span class="badge badge-${statusClass}">${esc(statusLabel)}</span>
         </div>
-        <div class="text-muted" style="margin-top:3px">${esc(dateStr)}${timeStr ? ' ' + esc(timeStr) : ''}</div>
+        <div class="text-muted" style="margin-top:3px">${esc(dateStr)}${timeStr ? ' ' + esc(timeStr) : ''}${inc.boatName ? ' · ' + esc(inc.boatName) : ''}</div>
         ${desc ? `<div class="text-muted" style="margin-top:4px">${esc(desc)}${descMore}</div>` : ''}
       </div>
       <span class="ml-auto text-brass" style="font-size:16px">→</span>
-    </a>`;
+    </div>`;
   }).join('');
+}
+
+// ── Incident detail modal ───────────────────────────────────────────────────
+function _dlIncidentField(label, val) {
+  if (val == null || val === '' || val === '—') return '';
+  return '<div class="dl-drow"><span class="dl-dlbl">' + esc(label) + '</span>'
+    + '<span class="dl-dval">' + esc(val) + '</span></div>';
+}
+
+function openIncidentDetail(id) {
+  const inc = _dlIncidentsById[id];
+  if (!inc) return;
+  const typeList = _dlParseIncidentTypes(inc.types);
+  const typeLabels = typeList
+    .map(function(k) { return s('incident.type.' + k) || k; })
+    .join(', ');
+  const sevLabel = inc.severity ? (s('incident.sev.' + inc.severity) || inc.severity) : '';
+  const sevClass = inc.severity === 'critical' ? 'red'
+    : inc.severity === 'high' ? 'orange'
+    : inc.severity === 'medium' ? 'yellow'
+    : inc.severity === 'low' ? 'green'
+    : 'muted';
+  const resolved = inc.resolved && inc.resolved !== 'false';
+  const inReview = !resolved && inc.status === 'review';
+  const statusLabel = resolved ? s('incident.resolved')
+    : inReview ? s('incident.statusReview')
+    : s('incident.open');
+  const statusClass = resolved ? 'green' : (inReview ? 'orange' : 'yellow');
+
+  document.getElementById('idTitle').textContent = typeLabels || inc.title || s('incident.title');
+  document.getElementById('idStatusRow').innerHTML =
+    (sevLabel ? '<span class="badge badge-' + sevClass + '">' + esc(sevLabel) + '</span>' : '')
+    + '<span class="badge badge-' + statusClass + '">' + esc(statusLabel) + '</span>';
+
+  const handoffVal = inc.handOffTo
+    ? (inc.handOffTo
+       + (inc.handOffName  ? ' — ' + inc.handOffName  : '')
+       + (inc.handOffNotes ? ' · ' + inc.handOffNotes : ''))
+    : '';
+  const filedAtStr = inc.filedAt ? (fmtDate(inc.filedAt) + ' ' + fmtTime(inc.filedAt)) : '';
+  const filedByVal = (inc.filedBy || s('lbl.unknown')) + (filedAtStr ? ' · ' + filedAtStr : '');
+  const dateTimeVal = (inc.date || '') + (inc.time ? ' ' + inc.time : '');
+
+  document.getElementById('idBody').innerHTML =
+    _dlIncidentField(s('lbl.date') + ' / ' + s('lbl.time'), dateTimeVal)
+    + _dlIncidentField(s('lbl.location'),                   inc.locationName)
+    + _dlIncidentField(s('incident.boatLabel').replace(' (if applicable)', ''), inc.boatName)
+    + _dlIncidentField(s('incident.description'),           inc.description)
+    + _dlIncidentField(s('incident.personsInvolved'),       inc.involved)
+    + _dlIncidentField(s('incident.witnesses'),             inc.witnesses)
+    + _dlIncidentField(s('incident.immediateAction'),       inc.immediateAction)
+    + _dlIncidentField(s('incident.followUp'),              inc.followUp)
+    + _dlIncidentField(s('incident.handoffTo'),             handoffVal)
+    + _dlIncidentField(s('incident.filedBy'),               filedByVal);
+
+  // Deep-link into /incidents/ for review/resolve controls
+  const full = document.getElementById('idOpenFull');
+  if (full) full.href = '../incidents/#' + encodeURIComponent(inc.id);
+
+  openModal('incidentDetailModal');
 }
 
 // ── Activity type buttons ─────────────────────────────────────────────────────
@@ -652,6 +749,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const row = e.target.closest('[data-trip-id]');
     if (!row) return;
     openTripDetail(row.dataset.tripId);
+  });
+
+  // Open the incident detail modal on card click. The modal reads its
+  // data from _dlIncidentsById, which is populated by renderIncidentSection.
+  dom.incidentContainer.addEventListener('click', e => {
+    const card = e.target.closest('[data-incident-id]');
+    if (!card) return;
+    // Let taps on inner links (e.g. phone) through.
+    if (e.target.closest('a')) return;
+    openIncidentDetail(card.dataset.incidentId);
   });
 
   function debounce(fn, ms) {

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -380,7 +380,7 @@ function renderList() {
   }
   const sevBadge = { low:'badge-green', medium:'badge-yellow', high:'badge-orange', critical:'badge-red' };
   el.innerHTML = incidents.map(i => {
-    const types = parseJson(i.types, []);
+    const types = parseJsonArray(i.types);
     const typeLabels = types.map(t => {
       const def = INCIDENT_TYPES.find(x => x.v === t);
       return def ? s(def.key) : t;
@@ -416,8 +416,8 @@ function incidentById(id) { return incidents.find(i => i.id === id); }
 function openDetail(i) {
   if (!i) return;
   detailId = i.id;
-  const reviewerNotes = parseJson(i.reviewerNotes, []);
-  const types    = parseJson(i.types, []);
+  const reviewerNotes = parseJsonArray(i.reviewerNotes);
+  const types    = parseJsonArray(i.types);
   const resolved = i.resolved && i.resolved !== 'false';
   const inReview = !resolved && i.status === 'review';
 
@@ -646,9 +646,26 @@ function closeDetail() {
   if (window.location.hash) history.replaceState(null,'',window.location.pathname+window.location.search);
 }
 
+// Parse a cell that should hold a JSON array. Older rows on /incidents/
+// were saved double-encoded (a JSON string whose contents were another JSON
+// string), so one pass of JSON.parse yields a string instead of an array.
+// Peel until we get something non-string, and always return an array.
+function parseJsonArray(v) {
+  if (v == null || v === '') return [];
+  let cur = v;
+  for (let i = 0; i < 3 && typeof cur === 'string'; i++) {
+    try { cur = JSON.parse(cur); } catch(e) { return []; }
+  }
+  return Array.isArray(cur) ? cur : [];
+}
+
 function parseJson(v, fallback) {
   if (!v) return fallback;
-  try { return typeof v === 'string' ? JSON.parse(v) : v; } catch(e) { return fallback; }
+  let cur = v;
+  for (let i = 0; i < 3 && typeof cur === 'string'; i++) {
+    try { cur = JSON.parse(cur); } catch(e) { return fallback; }
+  }
+  return cur == null ? fallback : cur;
 }
 </script>
 </body>

--- a/shared/volunteer.js
+++ b/shared/volunteer.js
@@ -211,7 +211,9 @@
     const subtitle = (L === 'IS' && ev.subtitleIS ? ev.subtitleIS : ev.subtitle) || ev.subtitle || '';
     const notes    = (L === 'IS' && ev.notesIS ? ev.notesIS : ev.notes) || ev.notes || '';
     const roles    = Array.isArray(ev.roles) ? ev.roles : [];
-    const dayLbl   = ctx.formatDay  ? ctx.formatDay(ev.date || '') : (ev.date || '');
+    // formatDay receives the full event so callers can render multi-day
+    // ranges (ev.date → ev.endDate) as "Wed 15 Apr – Fri 17 Apr".
+    const dayLbl   = ctx.formatDay  ? ctx.formatDay(ev) : (ev.date || '');
     const timeLbl  = ctx.formatTime ? ctx.formatTime(ev) : '';
 
     // Header row — date · title · subtype all on one line (flex-wrap for narrow screens)

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -149,6 +149,7 @@ const user = requireAuth();
 let _volEvents = [];
 let _volSignups = [];
 let _volActTypes = [];
+let _volCertDefs = [];
 let _vpView = 'list';
 let _vpMonth = (function() { const d = new Date(); return { y: d.getFullYear(), m: d.getMonth() }; })();
 let _vpDayModalIso = null;
@@ -173,6 +174,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     ]);
     _volEvents   = (cfgRes.volunteerEvents || []).filter(e => e.active !== false);
     _volActTypes = cfgRes.activityTypes || [];
+    _volCertDefs = (typeof certDefsFromConfig === 'function'
+      ? certDefsFromConfig(cfgRes.certDefs || [])
+      : (cfgRes.certDefs || []));
     _volSignups  = (suRes && suRes.signups) || [];
   } catch(e) {
     document.getElementById('vpListContainer').innerHTML =
@@ -208,18 +212,6 @@ function getMergedEvents(rangeFrom, rangeTo) {
 function localizedTitle(ev) {
   const L = getLang();
   return (L === 'IS' && ev.titleIS ? ev.titleIS : ev.title) || ev.title || '';
-}
-function localizedSubtitle(ev) {
-  const L = getLang();
-  return (L === 'IS' && ev.subtitleIS ? ev.subtitleIS : ev.subtitle) || ev.subtitle || '';
-}
-function localizedNotes(ev) {
-  const L = getLang();
-  return (L === 'IS' && ev.notesIS ? ev.notesIS : ev.notes) || ev.notes || '';
-}
-function localizedRoleName(role) {
-  const L = getLang();
-  return (L === 'IS' && role.nameIS ? role.nameIS : role.name) || role.name || '';
 }
 
 // "Wed, 15 Apr"
@@ -340,86 +332,27 @@ function renderVpList() {
   container.innerHTML = html;
 }
 
+// Delegate to the shared volunteer card renderer so /volunteer/ and
+// /admin/ stay visually consistent. The shared helper handles the
+// date · title · subtype header line, a leader chip badge, inline
+// signup chips next to the progress bar, and an on-click role
+// description (member mode).
 function renderVpCard(ev) {
-  const title    = localizedTitle(ev);
-  const subtitle = localizedSubtitle(ev);
-  const notes    = localizedNotes(ev);
-  const dayLbl   = formatEventDateLabel(ev);
-  const timeLbl  = formatTimeRange(ev);
-  const roles    = Array.isArray(ev.roles) ? ev.roles : [];
-
-  const leaderHtml = ev.leaderName
-    ? '<div class="vp-card-leader">'
-      + '<span class="vp-card-leader-label">' + s('volunteer.inCharge') + ':</span> '
-      + '<span class="vp-card-leader-name">' + esc(ev.leaderName) + '</span>'
-      + (ev.showLeaderPhone && ev.leaderPhone
-          ? ' <span class="vp-card-leader-phone">· <a href="tel:' + esc(ev.leaderPhone) + '">' + esc(ev.leaderPhone) + '</a></span>'
-          : '')
-      + '</div>'
-    : '';
-
-  const subtitleHtml = subtitle ? '<div class="vp-card-subtitle">' + esc(subtitle) + '</div>' : '';
-  const notesHtml    = notes ? '<div class="vp-card-notes">' + esc(notes) + '</div>' : '';
-
-  const rolesHtml = roles.length
-    ? roles.map(function(r) { return renderVpRole(ev, r); }).join('')
-    : '<div class="vp-card-notes">' + s('admin.noRoles') + '</div>';
-
-  return '<div class="vp-card">'
-    + '<div class="vp-card-date">' + esc(dayLbl) + (timeLbl ? ' · ' + esc(timeLbl) : '') + '</div>'
-    + '<div class="vp-card-title">' + esc(title) + '</div>'
-    + subtitleHtml
-    + leaderHtml
-    + notesHtml
-    + rolesHtml
-    + '</div>';
-}
-
-function renderVpRole(ev, role) {
-  const rn      = localizedRoleName(role);
-  const signups = _volSignups.filter(function(su) { return su.eventId === ev.id && su.roleId === role.id; });
-  const filled  = signups.length;
-  const total   = Number(role.slots) || 0;
-  const isFull  = total > 0 && filled >= total;
-  const mySignup = signups.find(isMineSignup);
-  const pct     = total > 0 ? Math.min(100, Math.round(filled / total * 100)) : 0;
-  const allowed = (typeof memberCanTakeRole === 'function') ? memberCanTakeRole(role, _myCerts) : true;
-
-  // Names of all signups; "me" replaces own name
-  const chipsHtml = signups.length
-    ? '<div class="vp-role-signups">'
-      + signups.map(function(su) {
-          const isMine = isMineSignup(su);
-          const label = isMine ? s('volunteer.me') : (su.name || '—');
-          return '<span class="vp-chip' + (isMine ? ' me' : '') + '">' + esc(label) + '</span>';
-        }).join('')
-      + '</div>'
-    : '';
-
-  let actionHtml = '';
-  if (mySignup) {
-    actionHtml = '<button class="vp-btn signed-up" onclick="vpWithdraw(\'' + mySignup.id + '\')">'
-      + s('member.volWithdraw') + '</button>';
-  } else if (!allowed) {
-    actionHtml = '<span class="vp-role-note">' + s('member.volNeedsEndorsement') + '</span>';
-  } else if (isFull) {
-    actionHtml = '<span class="vp-role-note full">' + s('member.volFull') + '</span>';
-  } else {
-    actionHtml = '<button class="vp-btn" onclick="vpSignup(\'' + ev.id + '\',\'' + role.id + '\')">'
-      + s('member.volSignUp') + '</button>';
-  }
-
-  return '<div class="vp-role">'
-    + '<div class="vp-role-left">'
-      + '<div class="vp-role-name">' + esc(rn) + '</div>'
-      + '<div class="vp-role-meta">'
-        + '<div class="vp-bar"><div class="vp-bar-fill' + (isFull ? ' full' : '') + '" style="width:' + pct + '%"></div></div>'
-        + '<span class="vp-role-status">' + filled + '/' + total + '</span>'
-      + '</div>'
-      + chipsHtml
-    + '</div>'
-    + '<div class="vp-role-right">' + actionHtml + '</div>'
-    + '</div>';
+  return renderVolunteerCard(ev, {
+    mode: 'member',
+    lang: getLang(),
+    signups: _volSignups,
+    certDefs: _volCertDefs,
+    certDefName: (typeof certDefName === 'function') ? certDefName : function(d) { return d && (d.name || d.id) || ''; },
+    esc: esc,
+    s: s,
+    formatDay: formatEventDateLabel,
+    formatTime: formatTimeRange,
+    userKennitala: user && user.kennitala,
+    myCerts: _myCerts,
+    onSignup: 'vpSignup',
+    onWithdraw: 'vpWithdraw',
+  });
 }
 
 // ══ CALENDAR VIEW ════════════════════════════════════════════════════════════


### PR DESCRIPTION
- incidents: stop double-encoding the `types` column in the backend createIncident_ so new rows store a clean JSON array. On the frontend add a parseJsonArray helper that peels multi-level encoding so legacy rows still render without throwing `types.map is not a function`.
- dailylog: incident cards now open an in-page detail modal (full record incl. filed-by/filed-at) instead of deep-linking to /incidents/. The same robust type parser is used so cards don't break on legacy data.
- volunteer: delegate renderVpCard to the shared renderVolunteerCard helper so the member view gets the date · title · subtype header, leader chip badge, and inline signup chips next to each role bar.
- admin: volunteer events use the same shared renderer via _volRowHtml with an Edit button that opens the full volunteer-event modal and a Delete button — visuals match /volunteer/ for consistency.
- shared/volunteer.js: pass the full event to ctx.formatDay so callers can render multi-day spans like "Wed 15 Apr – Fri 17 Apr".

https://claude.ai/code/session_0167mgrGHdYLoSi1fF5Z1iEy