### PR TITLE
Rework member shortcut buttons: monochrome icons + primary CTA

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -22,30 +22,64 @@
 /* ── Quick-action header strip ── */
 .member-actions { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
 .member-actions .act-btn {
-  flex:1 1 140px; min-width:110px; min-height:52px;
+  flex:1 1 140px; min-width:110px; min-height:56px;
   background:var(--surface); border:1px solid var(--border);
   border-radius:var(--radius-md); padding:10px 14px; cursor:pointer; font-family:inherit;
-  font-size:11px; color:var(--text); text-align:center; text-decoration:none;
-  display:inline-flex; align-items:center; justify-content:center; gap:8px;
+  font-size:13px; color:var(--text); text-align:center; text-decoration:none;
+  display:inline-flex; align-items:center; justify-content:center; gap:10px;
   line-height:1.25; box-shadow:var(--shadow-sm);
   transition:border-color .15s, background-color .15s, transform .15s, box-shadow .15s;
 }
 .member-actions .act-btn::before {
-  flex-shrink:0; font-size:15px; line-height:1;
-  filter:grayscale(.15) saturate(.85);
+  content:''; display:inline-block; width:16px; height:16px; flex-shrink:0;
+  background-color:var(--brass);
+  -webkit-mask-repeat:no-repeat; mask-repeat:no-repeat;
+  -webkit-mask-size:contain; mask-size:contain;
+  -webkit-mask-position:center; mask-position:center;
 }
 .member-actions .act-btn:hover {
   border-color:var(--brass); background:var(--card);
   transform:translateY(-1px); box-shadow:var(--shadow-md);
 }
-.member-actions .act-btn:hover::before { filter:none; }
-.member-actions .act-btn--launch::before   { content:'🟧'; }
-.member-actions .act-btn--report::before   { content:'🔧'; }
-.member-actions .act-btn--logbook::before  { content:'📖'; }
-.member-actions .act-btn--captain::before  { content:'⎈'; }
-.member-actions .act-btn--coxswain::before { content:'🚣'; }
-.member-actions .act-btn--sauma::before    { content:'🧵'; }
-.member-actions .act-btn--volunteer::before { content:'🛟'; }
+/* Per-button monochrome SVG glyphs (rendered in --brass via mask-image) */
+.member-actions .act-btn--launch::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='black'%3E%3Cpath d='M6 3v18l14-9z'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='black'%3E%3Cpath d='M6 3v18l14-9z'/%3E%3C/svg%3E");
+}
+.member-actions .act-btn--report::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z'/%3E%3C/svg%3E");
+}
+.member-actions .act-btn--logbook::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 7v14'/%3E%3Cpath d='M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 7v14'/%3E%3Cpath d='M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z'/%3E%3C/svg%3E");
+}
+.member-actions .act-btn--sauma::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='6' cy='6' r='3'/%3E%3Cpath d='M8.12 8.12 12 12'/%3E%3Cpath d='M20 4 8.12 15.88'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Cpath d='M14.8 14.8 20 20'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='6' cy='6' r='3'/%3E%3Cpath d='M8.12 8.12 12 12'/%3E%3Cpath d='M20 4 8.12 15.88'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Cpath d='M14.8 14.8 20 20'/%3E%3C/svg%3E");
+}
+.member-actions .act-btn--volunteer::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='m4.93 4.93 4.24 4.24'/%3E%3Cpath d='m14.83 9.17 4.24-4.24'/%3E%3Cpath d='m14.83 14.83 4.24 4.24'/%3E%3Cpath d='m9.17 14.83-4.24 4.24'/%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='m4.93 4.93 4.24 4.24'/%3E%3Cpath d='m14.83 9.17 4.24-4.24'/%3E%3Cpath d='m14.83 14.83 4.24 4.24'/%3E%3Cpath d='m9.17 14.83-4.24 4.24'/%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3C/svg%3E");
+}
+.member-actions .act-btn--captain::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Ccircle cx='12' cy='12' r='1' fill='black' stroke='none'/%3E%3Cline x1='12' y1='2' x2='12' y2='6'/%3E%3Cline x1='12' y1='18' x2='12' y2='22'/%3E%3Cline x1='2' y1='12' x2='6' y2='12'/%3E%3Cline x1='18' y1='12' x2='22' y2='12'/%3E%3Cline x1='4.93' y1='4.93' x2='7.76' y2='7.76'/%3E%3Cline x1='16.24' y1='16.24' x2='19.07' y2='19.07'/%3E%3Cline x1='19.07' y1='4.93' x2='16.24' y2='7.76'/%3E%3Cline x1='4.93' y1='19.07' x2='7.76' y2='16.24'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Ccircle cx='12' cy='12' r='1' fill='black' stroke='none'/%3E%3Cline x1='12' y1='2' x2='12' y2='6'/%3E%3Cline x1='12' y1='18' x2='12' y2='22'/%3E%3Cline x1='2' y1='12' x2='6' y2='12'/%3E%3Cline x1='18' y1='12' x2='22' y2='12'/%3E%3Cline x1='4.93' y1='4.93' x2='7.76' y2='7.76'/%3E%3Cline x1='16.24' y1='16.24' x2='19.07' y2='19.07'/%3E%3Cline x1='19.07' y1='4.93' x2='16.24' y2='7.76'/%3E%3Cline x1='4.93' y1='19.07' x2='7.76' y2='16.24'/%3E%3C/svg%3E");
+}
+.member-actions .act-btn--coxswain::before {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m3 11 18-5v12L3 14v-3z'/%3E%3Cpath d='M11.6 16.8a3 3 0 1 1-5.8-1.6'/%3E%3C/svg%3E");
+  mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m3 11 18-5v12L3 14v-3z'/%3E%3Cpath d='M11.6 16.8a3 3 0 1 1-5.8-1.6'/%3E%3C/svg%3E");
+}
+/* Primary CTA — Launch is the single filled-brass action */
+.member-actions .act-btn--launch {
+  background:var(--brass); border-color:var(--brass); color:var(--surface);
+  font-weight:500;
+}
+.member-actions .act-btn--launch::before { background-color:var(--surface); }
+.member-actions .act-btn--launch:hover {
+  background:var(--brass); border-color:var(--brass);
+  filter:brightness(1.08);
+}
 
 /* ── Tabs ── */
 .hub-tabs { display:flex; gap:0; border-bottom:1px solid var(--border); margin-bottom:14px; overflow-x:auto; }
@@ -161,8 +195,8 @@
 @media(max-width:600px){
   .fsb-bar-wrap{flex:1;width:auto}
   .ir-type-grid{grid-template-columns:1fr}
-  .member-actions .act-btn{flex-basis:calc(50% - 4px);min-width:0;min-height:46px;padding:8px 10px;font-size:10px;gap:6px}
-  .member-actions .act-btn::before{font-size:13px}
+  .member-actions .act-btn{flex-basis:calc(50% - 4px);min-width:0;min-height:50px;padding:8px 10px;font-size:12px;gap:8px}
+  .member-actions .act-btn::before{width:14px;height:14px}
   .pub-trip{padding:10px 12px}
   .stat-box .sn{font-size:20px}
 }

--- a/staff/index.html
+++ b/staff/index.html
@@ -26,8 +26,8 @@
   text-decoration:none; display:flex; flex-direction:column; gap:6px; box-shadow:var(--shadow-sm); }
 .nav-card:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
 .nc-icon  { font-size:22px; }
-.nc-label { font-size:12px; font-weight:500; color:var(--text); letter-spacing:.3px; }
-.nc-desc  { font-size:10px; color:var(--muted); line-height:1.4; }
+.nc-label { font-size:15px; font-weight:500; color:var(--text); letter-spacing:.3px; }
+.nc-desc  { font-size:11px; color:var(--muted); line-height:1.4; }
 
 /* ── Stat strip ── */
 .stat-row  { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }


### PR DESCRIPTION
The member-hub quick-action strip used colored emoji (🟧 🔧 📖 🧵 🛟 ⎈ 🚣) which functioned as de facto per-button color coding — but that coding was unmoored from meaning because every hue on the page is already spoken for by boat categories, severity levels, or availability states.

Drop the emoji and replace with monochrome SVG glyphs rendered in --brass via CSS mask-image (inline data URIs), bump label font-size 11px → 13px (10px → 12px mobile), and split action vs navigation semantically: Launch becomes the single brass-filled primary CTA with inverted surface label and icon; the other six buttons stay as quiet outlined secondaries. The mask-image approach survives applyStrings() overwriting button textContent since ::before pseudo-elements are untouched.

Staff nav-cards get a lighter companion treatment: keep the four emoji icons (they have room to breathe in the card layout), but bump .nc-label 12px → 15px and .nc-desc 10px → 11px so the label leads visually.

https://claude.ai/code/session_01Y9eXKfBwZJAhGxrqmmMpdp