### PR TITLE
Fix deleteActivityType_ so admin deletions persist

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1580,10 +1580,10 @@ function saveActivityType_(b) {
   } catch(e) { return failJ('saveActivityType failed: ' + e.message); }
 }
 
-function deleteActivityType_(b) {
+function deleteActivityType_(id) {
   try {
     let arr = JSON.parse(getConfigSheetValue_('activity_types') || '[]');
-    arr = arr.filter(a => a.id !== b.id);
+    arr = arr.filter(a => a.id !== id);
     setConfigSheetValue_('activity_types', JSON.stringify(arr));
     cDel_('config');
     return okJ({ deleted: true });


### PR DESCRIPTION
The dispatch at code.gs:442 passes b.id (a string), but the handler was defined as deleteActivityType_(b) and did arr.filter(a => a.id !== b.id). Since b was already a string, b.id was undefined and the filter kept every activity type, so nothing was ever actually removed from the sheet. Rename the parameter to id and filter against it directly, matching deleteChecklistItem_ / deleteCertDef_.

https://claude.ai/code/session_01MhGFkyNpBibajNAosgdcXX