### PR TITLE
Add icon preview page for hand-drawn + library icon review

### DIFF
--- a/icon-preview.html
+++ b/icon-preview.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Icon Preview — Hand-drawn + Library</title>
+<style>
+* { margin:0; padding:0; box-sizing:border-box; }
+body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; background:#0b1929; color:#c8d6e5; padding:24px; }
+h1 { font-size:14px; letter-spacing:1px; color:#d4af37; margin-bottom:20px; }
+h2 { font-size:11px; letter-spacing:1.5px; color:#d4af37; margin:28px 0 12px; text-transform:uppercase; }
+.row { display:flex; gap:24px; flex-wrap:wrap; margin-bottom:16px; }
+.icon-card { background:#111d2e; border:1px solid #1e3a5f; border-radius:8px; padding:16px; text-align:center; min-width:120px; }
+.icon-card .label { font-size:10px; color:#8899aa; margin-bottom:10px; letter-spacing:.5px; }
+.sizes { display:flex; align-items:flex-end; gap:14px; justify-content:center; }
+.sizes .sz { text-align:center; }
+.sizes .sz span { display:block; font-size:8px; color:#556677; margin-top:4px; }
+svg { display:block; margin:0 auto; }
+
+/* Light preview section */
+.light-bg { background:#f5f0e8; border-color:#d4c9b0; }
+.light-bg .label { color:#665544; }
+.light-bg svg { color:#8b7330; }
+
+/* Dark uses brass */
+.dark-bg svg { color:#d4af37; }
+</style>
+</head>
+<body>
+
+<h1>ÝMIR ICON PREVIEW</h1>
+
+<!-- ════════════════════════════════════════════ -->
+<h2>Hand-drawn: Rowing Shell (coxswain / rowing-shell category)</h2>
+<div class="row">
+  <div class="icon-card dark-bg">
+    <div class="label">ROWING — dark / brass</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>48px</span>
+      </div>
+      <div class="sz">
+        <svg width="96" height="96" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>96px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card light-bg">
+    <div class="label">ROWING — light</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c4-2 8-3 10-3s6 1 10 3c-4 2-8 3-10 3s-6-1-10-3z"/><line x1="10" y1="12" x2="4" y2="5"/><line x1="14" y1="12" x2="20" y2="5"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════ -->
+<h2>Hand-drawn: Surfboard (SUP category)</h2>
+<div class="row">
+  <div class="icon-card dark-bg">
+    <div class="label">SURFBOARD — dark / brass</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="96" height="96" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>96px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card light-bg">
+    <div class="label">SURFBOARD — light</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2c-2.5 4-3.5 8-3.5 10s1 6 3.5 10c2.5-4 3.5-8 3.5-10s-1-6-3.5-10z"/><line x1="12" y1="7" x2="12" y2="18"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════ -->
+<h2>Hand-drawn: Chinese Hand Fan (wingfoil category — inside joke)</h2>
+<div class="row">
+  <div class="icon-card dark-bg">
+    <div class="label">HAND FAN — dark / brass</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>48px</span>
+      </div>
+      <div class="sz">
+        <svg width="96" height="96" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>96px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card light-bg">
+    <div class="label">HAND FAN — light</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>24px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20L4 10Q12 3 20 10Z"/><line x1="12" y1="20" x2="6" y2="8.5"/><line x1="12" y1="20" x2="9" y2="7"/><line x1="12" y1="20" x2="12" y2="6.5"/><line x1="12" y1="20" x2="15" y2="7"/><line x1="12" y1="20" x2="18" y2="8.5"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════ -->
+<h2>For comparison: Library icons being used</h2>
+<div class="row">
+  <div class="icon-card dark-bg">
+    <div class="label">Lucide sailboat</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 2v15"/><path d="M7 22a4 4 0 0 1-4-4 1 1 0 0 1 1-1h16a1 1 0 0 1 1 1 4 4 0 0 1-4 4z"/><path d="M9.159 2.46a1 1 0 0 1 1.521-.193l9.977 8.98A1 1 0 0 1 20 13H4a1 1 0 0 1-.824-1.567z"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 2v15"/><path d="M7 22a4 4 0 0 1-4-4 1 1 0 0 1 1-1h16a1 1 0 0 1 1 1 4 4 0 0 1-4 4z"/><path d="M9.159 2.46a1 1 0 0 1 1.521-.193l9.977 8.98A1 1 0 0 1 20 13H4a1 1 0 0 1-.824-1.567z"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Lucide ship-wheel</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M12 2v7.5"/><path d="m19 5-5.23 5.23"/><path d="M22 12h-7.5"/><path d="m19 19-5.23-5.23"/><path d="M12 14.5V22"/><path d="M10.23 13.77 5 19"/><path d="M9.5 12H2"/><path d="M10.23 10.23 5 5"/><circle cx="12" cy="12" r="2.5"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M12 2v7.5"/><path d="m19 5-5.23 5.23"/><path d="M22 12h-7.5"/><path d="m19 19-5.23-5.23"/><path d="M12 14.5V22"/><path d="M10.23 13.77 5 19"/><path d="M9.5 12H2"/><path d="M10.23 10.23 5 5"/><circle cx="12" cy="12" r="2.5"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Lucide spool</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 13.44 4.442 17.082A2 2 0 0 0 4.982 21H19a2 2 0 0 0 .558-3.921l-1.115-.32A2 2 0 0 1 17 14.837V7.66"/><path d="m7 10.56 12.558-3.642A2 2 0 0 0 19.018 3H5a2 2 0 0 0-.558 3.921l1.115.32A2 2 0 0 1 7 9.163v7.178"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 13.44 4.442 17.082A2 2 0 0 0 4.982 21H19a2 2 0 0 0 .558-3.921l-1.115-.32A2 2 0 0 1 17 14.837V7.66"/><path d="m7 10.56 12.558-3.642A2 2 0 0 0 19.018 3H5a2 2 0 0 0-.558 3.921l1.115.32A2 2 0 0 1 7 9.163v7.178"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Tabler kayak</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6.414 6.414a2 2 0 0 0 0 -2.828l-1.414 -1.414l-2.828 2.828l1.414 1.414a2 2 0 0 0 2.828 0"/><path d="M17.586 17.586a2 2 0 0 0 0 2.828l1.414 1.414l2.828 -2.828l-1.414 -1.414a2 2 0 0 0 -2.828 0"/><path d="M6.5 6.5l11 11"/><path d="M22 2.5c-9.983 2.601 -17.627 7.952 -20 19.5c9.983 -2.601 17.627 -7.952 20 -19.5"/><path d="M6.5 12.5l5 5"/><path d="M12.5 6.5l5 5"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6.414 6.414a2 2 0 0 0 0 -2.828l-1.414 -1.414l-2.828 2.828l1.414 1.414a2 2 0 0 0 2.828 0"/><path d="M17.586 17.586a2 2 0 0 0 0 2.828l1.414 1.414l2.828 -2.828l-1.414 -1.414a2 2 0 0 0 -2.828 0"/><path d="M6.5 6.5l11 11"/><path d="M22 2.5c-9.983 2.601 -17.627 7.952 -20 19.5c9.983 -2.601 17.627 -7.952 20 -19.5"/><path d="M6.5 12.5l5 5"/><path d="M12.5 6.5l5 5"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Tabler speedboat</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 17h14.4a3 3 0 0 0 2.5 -1.34l3.1 -4.66h-6.23a4 4 0 0 0 -1.49 .29l-3.56 1.42a4 4 0 0 1 -1.49 .29h-5.73l-1.5 4"/><path d="M6 13l1.5 -5"/><path d="M6 8h8l2 3"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 17h14.4a3 3 0 0 0 2.5 -1.34l3.1 -4.66h-6.23a4 4 0 0 0 -1.49 .29l-3.56 1.42a4 4 0 0 1 -1.49 .29h-5.73l-1.5 4"/><path d="M6 13l1.5 -5"/><path d="M6 8h8l2 3"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="icon-card dark-bg">
+    <div class="label">Phosphor lighthouse (fill)</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 256 256" fill="currentColor"><path d="M208,80a8,8,0,0,0-8,8v16H188.85L184,55.2A8,8,0,0,0,181.32,50L138.44,11.88l-.2-.17a16,16,0,0,0-20.48,0l-.2.17L74.68,50A8,8,0,0,0,72,55.2L67.15,104H56V88a8,8,0,0,0-16,0v24a8,8,0,0,0,8,8H65.54l-9.47,94.48A16,16,0,0,0,72,232H184a16,16,0,0,0,15.92-17.56L190.46,120H208a8,8,0,0,0,8-8V88A8,8,0,0,0,208,80ZM128,24l27,24H101ZM87.24,64h81.52l4,40H136V88a8,8,0,0,0-16,0v16H83.23ZM72,216l4-40H180l4,40Zm106.39-56H77.61l4-40h92.76Z"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 256 256" fill="currentColor"><path d="M208,80a8,8,0,0,0-8,8v16H188.85L184,55.2A8,8,0,0,0,181.32,50L138.44,11.88l-.2-.17a16,16,0,0,0-20.48,0l-.2.17L74.68,50A8,8,0,0,0,72,55.2L67.15,104H56V88a8,8,0,0,0-16,0v24a8,8,0,0,0,8,8H65.54l-9.47,94.48A16,16,0,0,0,72,232H184a16,16,0,0,0,15.92-17.56L190.46,120H208a8,8,0,0,0,8-8V88A8,8,0,0,0,208,80ZM128,24l27,24H101ZM87.24,64h81.52l4,40H136V88a8,8,0,0,0-16,0v16H83.23ZM72,216l4-40H180l4,40Zm106.39-56H77.61l4-40h92.76Z"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Phosphor sailboat (fill)</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 256 256" fill="currentColor"><path d="M247.21,172.53A8,8,0,0,0,240,168H144V144h72a8,8,0,0,0,5.92-13.38L144,44.91V8a8,8,0,0,0-14.21-5l-104,128A8,8,0,0,0,32,144h96v24H16a8,8,0,0,0-6.25,13l29.6,37a15.93,15.93,0,0,0,12.49,6H204.16a15.93,15.93,0,0,0,12.49-6l29.6-37A8,8,0,0,0,247.21,172.53ZM197.92,128H144V68.69ZM48.81,128,128,30.53V128Zm155.35,80H51.84l-19.2-24H223.36Z"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 256 256" fill="currentColor"><path d="M247.21,172.53A8,8,0,0,0,240,168H144V144h72a8,8,0,0,0,5.92-13.38L144,44.91V8a8,8,0,0,0-14.21-5l-104,128A8,8,0,0,0,32,144h96v24H16a8,8,0,0,0-6.25,13l29.6,37a15.93,15.93,0,0,0,12.49,6H204.16a15.93,15.93,0,0,0,12.49-6l29.6-37A8,8,0,0,0,247.21,172.53ZM197.92,128H144V68.69ZM48.81,128,128,30.53V128Zm155.35,80H51.84l-19.2-24H223.36Z"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Phosphor compass-rose (fill)</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 256 256" fill="currentColor"><path d="M249.94,120.24l-27.05-6.76a95.86,95.86,0,0,0-80.37-80.37l-6.76-27a8,8,0,0,0-15.52,0l-6.76,27.05a95.86,95.86,0,0,0-80.37,80.37l-27,6.76a8,8,0,0,0,0,15.52l27.05,6.76a95.86,95.86,0,0,0,80.37,80.37l6.76,27.05a8,8,0,0,0,15.52,0l6.76-27.05a95.86,95.86,0,0,0,80.37-80.37l27.05-6.76a8,8,0,0,0,0-15.52Zm-95.49,22.9L139.31,128l15.14-15.14L215,128Zm-52.9,0L41,128l60.57-15.14L116.69,128ZM205.77,109.2,158.6,97.4,146.8,50.23A79.88,79.88,0,0,1,205.77,109.2Zm-62.63-7.65L128,116.69l-15.14-15.14L128,41ZM109.2,50.23,97.4,97.4,50.23,109.2A79.88,79.88,0,0,1,109.2,50.23Zm-59,96.57L97.4,158.6l11.8,47.17A79.88,79.88,0,0,1,50.23,146.8Zm62.63,7.65L128,139.31l15.14,15.14L128,215Zm33.94,51.32,11.8-47.17,47.17-11.8A79.88,79.88,0,0,1,146.8,205.77Z"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 256 256" fill="currentColor"><path d="M249.94,120.24l-27.05-6.76a95.86,95.86,0,0,0-80.37-80.37l-6.76-27a8,8,0,0,0-15.52,0l-6.76,27.05a95.86,95.86,0,0,0-80.37,80.37l-27,6.76a8,8,0,0,0,0,15.52l27.05,6.76a95.86,95.86,0,0,0,80.37,80.37l6.76,27.05a8,8,0,0,0,15.52,0l6.76-27.05a95.86,95.86,0,0,0,80.37-80.37l27.05-6.76a8,8,0,0,0,0-15.52Zm-95.49,22.9L139.31,128l15.14-15.14L215,128Zm-52.9,0L41,128l60.57-15.14L116.69,128ZM205.77,109.2,158.6,97.4,146.8,50.23A79.88,79.88,0,0,1,205.77,109.2Zm-62.63-7.65L128,116.69l-15.14-15.14L128,41ZM109.2,50.23,97.4,97.4,50.23,109.2A79.88,79.88,0,0,1,109.2,50.23Zm-59,96.57L97.4,158.6l11.8,47.17A79.88,79.88,0,0,1,50.23,146.8Zm62.63,7.65L128,139.31l15.14,15.14L128,215Zm33.94,51.32,11.8-47.17,47.17-11.8A79.88,79.88,0,0,1,146.8,205.77Z"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+  <div class="icon-card dark-bg">
+    <div class="label">Lucide settings (gear)</div>
+    <div class="sizes">
+      <div class="sz">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"/><circle cx="12" cy="12" r="3"/></svg>
+        <span>16px</span>
+      </div>
+      <div class="sz">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"/><circle cx="12" cy="12" r="3"/></svg>
+        <span>48px</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Temporary preview file showing the three hand-drawn icons (rowing shell, surfboard, hand fan) alongside verified library icons (Lucide, Tabler, Phosphor) at multiple sizes on dark/light backgrounds.

https://claude.ai/code/session_01Y9eXKfBwZJAhGxrqmmMpdp