### PR TITLE
Remove all event materialization from saveActivityType_ save path

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2569,6 +2569,20 @@ async function saveActType() {
     payload, modalId: "actTypeModal",
     renderFn:  renderActTypes,
   });
+  // Volunteer event materialization is deferred to syncVolunteerEvents.
+  // Trigger it in the background after a successful save so new events
+  // appear on the Volunteer tab without a manual refresh.
+  if (isVol) {
+    _volSyncDone = false;
+    apiPost('syncVolunteerEvents', {}).then(function(res) {
+      if (res && (res.added > 0 || res.removed > 0 || res.softDeleted > 0)) {
+        apiGet('getConfig', { _fresh: true }).then(function(cfg) {
+          volunteerEvents = cfg.volunteerEvents || [];
+          renderVolunteerEvents();
+        }).catch(function() {});
+      }
+    }).catch(function() {});
+  }
 }
 
 async function deleteActType(id) {

--- a/code.gs
+++ b/code.gs
@@ -1569,15 +1569,11 @@ function saveActivityType_(b) {
     }
     setConfigSheetValue_('activity_types', JSON.stringify(arr));
     cDel_('config');
-    // Materialize bulk-scheduled volunteer events into volunteer_events so
-    // each occurrence exists as a standalone record. Only adds new events —
-    // pruning of stale events is handled by syncVolunteerEvents_ which runs
-    // in the background when the admin Volunteer tab renders.
-    var materialized = 0;
-    if (isVol) {
-      try { materialized = materializeVolunteerEventsForAt_(item); } catch(e) {}
-    }
-    return okJ({ id: item.id, item: item, materialized: materialized });
+    // Volunteer event materialization is handled by syncVolunteerEvents_
+    // which runs in the background when the admin Volunteer tab renders.
+    // Keeping it out of the save path avoids GAS execution timeouts that
+    // surface as "Failed to fetch" in the browser.
+    return okJ({ id: item.id, item: item });
   } catch(e) { return failJ('saveActivityType failed: ' + e.message); }
 }
 


### PR DESCRIPTION
The previous fix still called materializeVolunteerEventsForAt_() during save, which reads/writes volunteer_events and expands date ranges — slow enough to cause GAS execution timeouts. This explained three symptoms:

1. "Failed to fetch" — GAS timeout kills the response after the activity type is already persisted (line 1570 runs before materialization)
2. Data saves even when user cancels — the write completed before timeout
3. Volunteer events missing — materialization was interrupted by timeout

Fix: remove ALL materialization from saveActivityType_. The save now only writes the activity type and returns immediately. Volunteer event materialization is triggered from the frontend as a background syncVolunteerEvents call after a successful save, keeping the save fast and the volunteer tab up to date.

https://claude.ai/code/session_01GGAdybaPUW1LoiVt2L1aAP