### PR TITLE
Revert syncVolunteerEvents_ to lightweight materialize-only approach

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2575,7 +2575,7 @@ async function saveActType() {
   if (isVol) {
     _volSyncDone = false;
     apiPost('syncVolunteerEvents', {}).then(function(res) {
-      if (res && (res.added > 0 || res.removed > 0 || res.softDeleted > 0)) {
+      if (res && res.added > 0) {
         apiGet('getConfig', { _fresh: true }).then(function(cfg) {
           volunteerEvents = cfg.volunteerEvents || [];
           renderVolunteerEvents();

--- a/code.gs
+++ b/code.gs
@@ -5968,26 +5968,30 @@ function reconcileVolunteerEventsForAt_(at) {
 }
 
 // Materialize for all active, volunteer-flagged activity types. Intended for
-// Reconcile all activity types: materialize new events AND prune stale ones.
-// Runs in the background when the admin Volunteer tab renders.
+// Materialize bulk-scheduled volunteer events for all active, volunteer-flagged
+// activity types. Reads activity_types and volunteer_events once, expands all
+// schedules, merges new events, writes once. No signups sheet access — kept
+// lightweight so it can run as a background call from the admin page.
 function syncVolunteerEvents_(b) {
   try {
     var actTypes = [];
     try { actTypes = JSON.parse(getConfigSheetValue_('activity_types') || '[]'); } catch(e) { actTypes = []; }
-    var totalAdded = 0, totalRemoved = 0, totalSoftDeleted = 0;
-    actTypes.forEach(function(at) {
-      try {
-        var r = reconcileVolunteerEventsForAt_(at);
-        if (r) {
-          totalAdded += r.added || 0;
-          totalRemoved += r.removed || 0;
-          totalSoftDeleted += r.softDeleted || 0;
-        }
-      } catch(e) {}
-    });
     var arr = [];
     try { arr = JSON.parse(getConfigSheetValue_('volunteer_events') || '[]'); } catch(e) { arr = []; }
-    return okJ({ added: totalAdded, removed: totalRemoved, softDeleted: totalSoftDeleted, total: arr.length });
+    var fromIso = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    var totalAdded = 0;
+    actTypes.forEach(function(at) {
+      var expanded = _volExpandActType_(at, fromIso, '2099-12-31');
+      if (!expanded.length) return;
+      var merged = _volMergeMaterialized_(arr, expanded);
+      arr = merged.arr;
+      totalAdded += merged.added;
+    });
+    if (totalAdded > 0) {
+      setConfigSheetValue_('volunteer_events', JSON.stringify(arr));
+      cDel_('config');
+    }
+    return okJ({ added: totalAdded, total: arr.length });
   } catch(e) { return failJ('syncVolunteerEvents failed: ' + e.message); }
 }
 


### PR DESCRIPTION
The previous commit upgraded syncVolunteerEvents_ to call reconcileVolunteerEventsForAt_() per activity type, which reads the entire volunteer_signups sheet and does N separate config reads/writes. This caused the same GAS timeout issue, preventing volunteer events from appearing on the admin Volunteer tab.

Revert to the original single-pass approach: read activity_types and volunteer_events once, expand all schedules (CPU only), merge, write once. No signups sheet access, no per-AT I/O — fast enough for a background call from the admin page.

https://claude.ai/code/session_01GGAdybaPUW1LoiVt2L1aAP