### PR TITLE
Use real club logo SVG file instead of inline approximation

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -14,7 +14,7 @@
     body { display:flex; align-items:center; justify-content:center; min-height:100vh; padding:20px; }
     .login-box { width:100%; max-width:400px; }
     .login-logo { text-align:center; margin-bottom:32px; }
-    .login-logo svg { width:140px; height:auto; display:block; margin:0 auto 12px; color:var(--brass); }
+    .login-logo img { width:140px; height:auto; display:block; margin:0 auto 12px; filter:brightness(0) invert(1) sepia(1) saturate(3) hue-rotate(15deg) brightness(.85); }
     .login-logo p { color:var(--muted); font-size:12px; letter-spacing:1px; margin-top:4px; }
     .kt-input { text-align:center; font-size:22px; letter-spacing:4px; }
     .lang-row { text-align:center; margin-top:16px; }
@@ -45,13 +45,7 @@
 <body>
 <div class="login-box">
   <div class="login-logo">
-    <svg viewBox="0 0 300 350" fill="currentColor" aria-label="Ýmir Siglingafélag">
-      <defs><path id="ta" d="M 20,155 A 130,130 0 0,1 280,155"/></defs>
-      <circle cx="150" cy="155" r="112" fill="none" stroke="currentColor" stroke-width="5"/>
-      <path d="M125,263 L125,162 L68,98 A100,100 0 0,0 124,58 L150,153 L176,58 A100,100 0 0,1 232,98 L175,162 L175,263Z"/>
-      <text font-family="Arial,Helvetica,sans-serif" font-size="25" font-weight="700" letter-spacing="3"><textPath href="#ta" startOffset="50%" text-anchor="middle">SIGLINGAFÉLAGIÐ</textPath></text>
-      <text x="150" y="328" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="50" font-weight="900" letter-spacing="4">ÝMIR</text>
-    </svg>
+    <img src="../shared/logo.svg" alt="Ýmir Siglingafélag">
     <p id="subtitle"></p>
   </div>
 

--- a/shared/logo.svg
+++ b/shared/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<!-- Paste real logo SVG content here -->
+</svg>

--- a/shared/style.css
+++ b/shared/style.css
@@ -168,6 +168,7 @@ header {
   width: 26px;
   height: 26px;
   flex-shrink: 0;
+  filter: brightness(0) invert(1) sepia(1) saturate(3) hue-rotate(15deg) brightness(.85);
 }
 
 .page-title {

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -345,7 +345,12 @@ window.buildHeader = function (page) {
   // LEFT: logo
   const logo = document.createElement('span');
   logo.className = 'logo';
-  logo.innerHTML = '<svg class="logo-icon" viewBox="0 0 300 300" aria-hidden="true"><circle cx="150" cy="150" r="112" fill="none" stroke="currentColor" stroke-width="5"/><path fill="currentColor" d="M125,258 L125,157 L68,93 A100,100 0 0,0 124,53 L150,148 L176,53 A100,100 0 0,1 232,93 L175,157 L175,258Z"/></svg>ÝMIR';
+  var img = document.createElement('img');
+  img.className = 'logo-icon';
+  img.src = depth + 'shared/logo.svg';
+  img.alt = '';
+  logo.appendChild(img);
+  logo.appendChild(document.createTextNode('ÝMIR'));
   left.appendChild(logo);
 
   // LEFT: back link on subpages


### PR DESCRIPTION
Replace the hand-drawn inline SVG with an <img> referencing shared/logo.svg. Both the login page and header bar now load the logo file and apply a CSS filter to tint it brass/gold. The logo.svg file is a placeholder for the user to paste the real SVG content into.

https://claude.ai/code/session_015BvYeqY4xzyATRjZNaBnqS