### PR TITLE
Limit volunteer badge to 7-day window for actionable counts

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1619,7 +1619,7 @@ async function loadVolunteerSignups() {
   renderVolunteerNotifBadge();
 }
 
-// Counts unfilled volunteer-role slots across upcoming events (saved + virtual)
+// Counts unfilled volunteer-role slots across upcoming events (next 7 days)
 // and shows a notif badge on the Volunteer button if there are any.
 function renderVolunteerNotifBadge() {
   const btn = document.getElementById('volunteerBtn');
@@ -1628,8 +1628,10 @@ function renderVolunteerNotifBadge() {
   btn.querySelectorAll('.notif-badge').forEach(function(b) { b.remove(); });
 
   const today = new Date().toISOString().slice(0, 10);
+  // Limit badge to 7-day window so the count is actionable, not overwhelming.
+  const badgeHorizon = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const virtualEvents = (typeof expandVolunteerActivityTypes === 'function')
-    ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, null)
+    ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, badgeHorizon)
     : [];
   const merged = (typeof mergeVolunteerEvents === 'function')
     ? mergeVolunteerEvents(_volunteerEvents, virtualEvents)
@@ -1641,6 +1643,8 @@ function renderVolunteerNotifBadge() {
     // lies on or after today.
     const _endIso = (ev.endDate && ev.endDate > (ev.date || '')) ? ev.endDate : (ev.date || '');
     if (_endIso < today) return;
+    // Only count events starting within the badge horizon
+    if ((ev.date || '') > badgeHorizon) return;
     const roles = Array.isArray(ev.roles) ? ev.roles : [];
     roles.forEach(function(role) {
       const total = Number(role.slots) || 0;


### PR DESCRIPTION
The volunteer button badge counted unfilled role-slots across 90 days of upcoming events. For a typical activity type (3 events/week, 2 roles, 2 slots each) that's 150+ unfilled slots — always showing "99+" which conveys no useful information.

Narrow both the virtual event expansion and the slot counting to a 7-day horizon. The badge now shows unfilled slots for the coming week only, giving members an actionable number that changes as people sign up.

https://claude.ai/code/session_01GGAdybaPUW1LoiVt2L1aAP