### PR TITLE
Prune stale materialized events in syncVolunteerEvents_

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -5970,8 +5970,9 @@ function reconcileVolunteerEventsForAt_(at) {
 // Materialize for all active, volunteer-flagged activity types. Intended for
 // Materialize bulk-scheduled volunteer events for all active, volunteer-flagged
 // activity types. Reads activity_types and volunteer_events once, expands all
-// schedules, merges new events, writes once. No signups sheet access — kept
-// lightweight so it can run as a background call from the admin page.
+// schedules, merges new events, prunes stale ones, writes once. No signups
+// sheet access — kept lightweight so it can run as a background call from the
+// admin page.
 function syncVolunteerEvents_(b) {
   try {
     var actTypes = [];
@@ -5979,19 +5980,39 @@ function syncVolunteerEvents_(b) {
     var arr = [];
     try { arr = JSON.parse(getConfigSheetValue_('volunteer_events') || '[]'); } catch(e) { arr = []; }
     var fromIso = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    // Build the full set of wanted event IDs from current activity type config.
+    var wantedIds = {};
     var totalAdded = 0;
     actTypes.forEach(function(at) {
       var expanded = _volExpandActType_(at, fromIso, '2099-12-31');
+      expanded.forEach(function(e) { if (e && e.id) wantedIds[e.id] = true; });
       if (!expanded.length) return;
       var merged = _volMergeMaterialized_(arr, expanded);
       arr = merged.arr;
       totalAdded += merged.added;
     });
-    if (totalAdded > 0) {
+    // Prune stale materialized events: future events with a sourceActivityTypeId
+    // whose ID is no longer in the wanted set (schedule changed, subtype removed,
+    // volunteer flag toggled off, activity type deleted, etc.).
+    var pruned = 0;
+    arr = arr.filter(function(ev) {
+      if (!ev) return false;
+      // Keep manually-created events (no sourceActivityTypeId) untouched.
+      if (!ev.sourceActivityTypeId) return true;
+      // Keep past events (don't rewrite history).
+      if ((ev.date || '') < fromIso) return true;
+      // Keep events the current config still wants.
+      if (wantedIds[ev.id]) return true;
+      // Stale — drop it.
+      pruned++;
+      return false;
+    });
+    var changed = totalAdded > 0 || pruned > 0;
+    if (changed) {
       setConfigSheetValue_('volunteer_events', JSON.stringify(arr));
       cDel_('config');
     }
-    return okJ({ added: totalAdded, total: arr.length });
+    return okJ({ added: totalAdded, pruned: pruned, total: arr.length });
   } catch(e) { return failJ('syncVolunteerEvents failed: ' + e.message); }
 }
 

--- a/member/index.html
+++ b/member/index.html
@@ -1619,7 +1619,7 @@ async function loadVolunteerSignups() {
   renderVolunteerNotifBadge();
 }
 
-// Counts unfilled volunteer-role slots across upcoming events (next 7 days)
+// Counts unfilled volunteer-role slots across upcoming events (saved + virtual)
 // and shows a notif badge on the Volunteer button if there are any.
 function renderVolunteerNotifBadge() {
   const btn = document.getElementById('volunteerBtn');
@@ -1628,10 +1628,8 @@ function renderVolunteerNotifBadge() {
   btn.querySelectorAll('.notif-badge').forEach(function(b) { b.remove(); });
 
   const today = new Date().toISOString().slice(0, 10);
-  // Limit badge to 7-day window so the count is actionable, not overwhelming.
-  const badgeHorizon = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const virtualEvents = (typeof expandVolunteerActivityTypes === 'function')
-    ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, badgeHorizon)
+    ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, null)
     : [];
   const merged = (typeof mergeVolunteerEvents === 'function')
     ? mergeVolunteerEvents(_volunteerEvents, virtualEvents)
@@ -1643,8 +1641,6 @@ function renderVolunteerNotifBadge() {
     // lies on or after today.
     const _endIso = (ev.endDate && ev.endDate > (ev.date || '')) ? ev.endDate : (ev.date || '');
     if (_endIso < today) return;
-    // Only count events starting within the badge horizon
-    if ((ev.date || '') > badgeHorizon) return;
     const roles = Array.isArray(ev.roles) ? ev.roles : [];
     roles.forEach(function(role) {
       const total = Number(role.slots) || 0;


### PR DESCRIPTION
syncVolunteerEvents_ only added new events but never removed stale ones. When an activity type's schedule changed (subtypes removed, days changed, volunteer toggled off, AT deleted), old materialized events stayed in the config indefinitely. The member badge counted unfilled slots for all of them, inflating the number far beyond actual open slots.

Fix: after expanding the current config into wanted event IDs, filter out any future materialized event (has sourceActivityTypeId) whose ID is not in the wanted set. Past events and manually-created events are preserved. Still no signups sheet access — stays lightweight for background calls.

Also reverts the 7-day badge window from the previous commit since the inflated count was caused by stale events, not the window size.

https://claude.ai/code/session_01GGAdybaPUW1LoiVt2L1aAP