### PR TITLE
Crop logo SVG viewBox to fit content tightly

### DIFF
--- a/shared/logo.svg
+++ b/shared/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1800 1800">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="300 170 1160 1350">
 <g transform="translate(0.000000,1800.000000) scale(0.100000,-0.100000)"
 fill="#000000" stroke="none">
 <path d="M8680 16008 c-11 -18 -20 -37 -20 -43 0 -13 -45 -123 -54 -132 -3 -3


### PR DESCRIPTION
The 1800x1800 viewBox had large empty margins around the actual logo content, making it appear small inside its container. Cropped to 300,170 1160x1350 to eliminate dead space.

https://claude.ai/code/session_015BvYeqY4xzyATRjZNaBnqS