### PR TITLE
Convert staff nav-card emoji to Lucide glyphs, drop member Launch CTA

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -77,16 +77,6 @@
   -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m3 11 18-5v12L3 14v-3z'/%3E%3Cpath d='M11.6 16.8a3 3 0 1 1-5.8-1.6'/%3E%3C/svg%3E");
   mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m3 11 18-5v12L3 14v-3z'/%3E%3Cpath d='M11.6 16.8a3 3 0 1 1-5.8-1.6'/%3E%3C/svg%3E");
 }
-/* Primary CTA — Launch is the single filled-brass action */
-.member-actions .act-btn--launch {
-  background:var(--brass); border-color:var(--brass); color:var(--surface);
-  font-weight:500;
-}
-.member-actions .act-btn--launch::before { background-color:var(--surface); }
-.member-actions .act-btn--launch:hover {
-  background:var(--brass); border-color:var(--brass);
-  filter:brightness(1.08);
-}
 
 /* ── Tabs ── */
 .hub-tabs { display:flex; gap:0; border-bottom:1px solid var(--border); margin-bottom:14px; overflow-x:auto; }

--- a/staff/index.html
+++ b/staff/index.html
@@ -25,7 +25,35 @@
   padding:16px 14px; cursor:pointer; transition:all .2s;
   text-decoration:none; display:flex; flex-direction:column; gap:6px; box-shadow:var(--shadow-sm); }
 .nav-card:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
-.nc-icon  { font-size:22px; }
+/* Icon span: empty, rendered as a brass-colored SVG mask */
+.nc-icon {
+  display:inline-block; width:24px; height:24px;
+  background-color:var(--brass);
+  -webkit-mask-repeat:no-repeat; mask-repeat:no-repeat;
+  -webkit-mask-size:contain;     mask-size:contain;
+  -webkit-mask-position:center;  mask-position:center;
+}
+/* Per-card monochrome SVG glyphs (rendered in --brass via mask-image) */
+/* Daily Log: Lucide clipboard-list */
+.nc-icon--dailylog {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3Cpath d='M12 11h4'/%3E%3Cpath d='M12 16h4'/%3E%3Cpath d='M8 11h.01'/%3E%3Cpath d='M8 16h.01'/%3E%3C/svg%3E");
+          mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3Cpath d='M12 11h4'/%3E%3Cpath d='M12 16h4'/%3E%3Cpath d='M8 11h.01'/%3E%3Cpath d='M8 16h.01'/%3E%3C/svg%3E");
+}
+/* Log Review: Lucide book-open-check */
+.nc-icon--review {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 21V7'/%3E%3Cpath d='m16 12 2 2 4-4'/%3E%3Cpath d='M22 6V4a1 1 0 0 0-1-1h-5a4 4 0 0 0-4 4 4 4 0 0 0-4-4H3a1 1 0 0 0-1 1v13a1 1 0 0 0 1 1h6a3 3 0 0 1 3 3 3 3 0 0 1 3-3h6a1 1 0 0 0 1-1v-1.3'/%3E%3C/svg%3E");
+          mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 21V7'/%3E%3Cpath d='m16 12 2 2 4-4'/%3E%3Cpath d='M22 6V4a1 1 0 0 0-1-1h-5a4 4 0 0 0-4 4 4 4 0 0 0-4-4H3a1 1 0 0 0-1 1v13a1 1 0 0 0 1 1h6a3 3 0 0 1 3 3 3 3 0 0 1 3-3h6a1 1 0 0 0 1-1v-1.3'/%3E%3C/svg%3E");
+}
+/* Incidents: Lucide triangle-alert */
+.nc-icon--incidents {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+          mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+}
+/* Maintenance: Lucide wrench */
+.nc-icon--maint {
+  -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z'/%3E%3C/svg%3E");
+          mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z'/%3E%3C/svg%3E");
+}
 .nc-label { font-size:15px; font-weight:500; color:var(--text); letter-spacing:.3px; }
 .nc-desc  { font-size:11px; color:var(--muted); line-height:1.4; }
 
@@ -380,23 +408,23 @@
   <div class="divider-label" data-s="staff.toolsLabel">TOOLS</div>
   <div class="nav-grid">
     <a href="../dailylog/" class="nav-card">
-      <span class="nc-icon">📋</span>
+      <span class="nc-icon nc-icon--dailylog" aria-hidden="true"></span>
       <span class="nc-label" data-s="staff.dailyLog"></span>
       <span class="nc-desc" data-s="staff.dailyLogDesc"></span>
     </a>
     <a href="staff_logbook-review.html" class="nav-card">
-      <span class="nc-icon">✓</span>
+      <span class="nc-icon nc-icon--review" aria-hidden="true"></span>
       <span class="nc-label" data-s="staff.logbook"></span>
       <span class="nc-desc" data-s="staff.logbookDesc"></span>
     </a>
     <a href="../incidents/" class="nav-card" id="incidentsNavCard" style="position:relative">
-      <span class="nc-icon">⚠️</span>
+      <span class="nc-icon nc-icon--incidents" aria-hidden="true"></span>
       <span class="nc-label" data-s="staff.incidents"></span>
       <span class="nc-desc" data-s="staff.incidentsDesc"></span>
       <span id="incidentsNavBadge" class="badge badge-orange hidden" style="position:absolute;top:8px;right:8px;font-size:10px"></span>
     </a>
     <a href="../maintenance/" class="nav-card">
-      <span class="nc-icon">🔧</span>
+      <span class="nc-icon nc-icon--maint" aria-hidden="true"></span>
       <span class="nc-label" data-s="staff.maintAndSauma"></span>
       <span class="nc-desc" data-s="staff.maintAndSaumaDesc"></span>
     </a>


### PR DESCRIPTION
Replace the four staff page TOOLS emoji (clipboard, check, warning, wrench) with monochrome Lucide SVG masks rendered in --brass, matching the pattern used on the member page. Also revert the member page Launch button from its filled-brass primary CTA treatment back to the shared outlined style used by the other act-btn buttons.