### PR TITLE
Fix slot-booking control bar overflow on mobile

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -601,13 +601,13 @@
           <select id="slotBoatFilter" onchange="renderSlotCalendar()" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px">
             <option value="" data-s="slot.allBoats">All boats</option>
           </select>
-          <div style="display:flex;align-items:center;gap:6px">
-            <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="shiftSlotWeek(-1)">&larr;</button>
-            <span id="slotWeekLabel" style="font-size:11px;min-width:140px;text-align:center"></span>
-            <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="shiftSlotWeek(1)">&rarr;</button>
-            <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="slotWeekToday()" data-s="slot.today">Today</button>
+          <div class="slot-week-nav">
+            <button class="btn btn-secondary" onclick="shiftSlotWeek(-1)">&larr;</button>
+            <span id="slotWeekLabel" class="week-label"></span>
+            <button class="btn btn-secondary" onclick="shiftSlotWeek(1)">&rarr;</button>
+            <button class="btn btn-secondary" onclick="slotWeekToday()" data-s="slot.today">Today</button>
+            <button class="btn btn-primary" data-icon="+" onclick="openRecurringSlotModal()"><span class="btn-label" data-s="slot.addRecurring">+ Recurring</span></button>
           </div>
-          <button class="btn btn-primary" style="font-size:11px" onclick="openRecurringSlotModal()" data-s="slot.addRecurring">+ Recurring</button>
         </div>
       </div>
       <div id="slotCalGrid" style="overflow-x:auto"></div>

--- a/captain/index.html
+++ b/captain/index.html
@@ -173,13 +173,13 @@
     <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap">
       <label data-s="slot.filterBoat" style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px">Boat</label>
       <select id="cqResBoat" onchange="loadCqSlots()" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px"></select>
-      <div style="display:flex;align-items:center;gap:6px">
-        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="shiftCqWeek(-1)">&larr;</button>
-        <span id="cqWeekLabel" style="font-size:11px;min-width:140px;text-align:center"></span>
-        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="shiftCqWeek(1)">&rarr;</button>
-        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="cqWeekToday()" data-s="slot.today">Today</button>
-        <button class="btn btn-primary" style="font-size:11px;padding:4px 10px" onclick="openCqCreateSlotModal()" data-s="slot.createAndBook" id="cqCreateSlotBtn">+ New Booking</button>
-        <button class="btn btn-primary" style="font-size:11px;padding:4px 10px" onclick="openCqBulkBookModal()" data-s="slot.bulkBook">Bulk Book</button>
+      <div class="slot-week-nav">
+        <button class="btn btn-secondary" onclick="shiftCqWeek(-1)">&larr;</button>
+        <span id="cqWeekLabel" class="week-label"></span>
+        <button class="btn btn-secondary" onclick="shiftCqWeek(1)">&rarr;</button>
+        <button class="btn btn-secondary" onclick="cqWeekToday()" data-s="slot.today">Today</button>
+        <button class="btn btn-primary" id="cqCreateSlotBtn" data-icon="+" onclick="openCqCreateSlotModal()"><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
+        <button class="btn btn-primary" data-icon="++" onclick="openCqBulkBookModal()"><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
       </div>
       <div style="display:flex;align-items:center;gap:6px;margin-left:auto">
         <label for="cqBookingColor" style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px" data-s="cq.bookingColor">My booking color</label>

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -169,12 +169,12 @@
         <select id="cxSlotBoat" onchange="loadCxSlots()" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px"></select>
         <label data-s="slot.filterCrew" style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px">Crew</label>
         <select id="cxSlotCrew" onchange="renderCxSlots()" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px"></select>
-        <div style="display:flex;align-items:center;gap:6px">
-          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="shiftCxWeek(-1)">&larr;</button>
-          <span id="cxWeekLabel" style="font-size:11px;min-width:140px;text-align:center"></span>
-          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="shiftCxWeek(1)">&rarr;</button>
-          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="cxWeekToday()" data-s="slot.today">Today</button>
-          <button class="btn btn-primary" style="font-size:11px;padding:4px 10px" onclick="openCxBulkBookModal()" data-s="slot.bulkBook">Bulk Book</button>
+        <div class="slot-week-nav">
+          <button class="btn btn-secondary" onclick="shiftCxWeek(-1)">&larr;</button>
+          <span id="cxWeekLabel" class="week-label"></span>
+          <button class="btn btn-secondary" onclick="shiftCxWeek(1)">&rarr;</button>
+          <button class="btn btn-secondary" onclick="cxWeekToday()" data-s="slot.today">Today</button>
+          <button class="btn btn-primary" data-icon="++" onclick="openCxBulkBookModal()"><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
         </div>
       </div>
       <div id="cxSlotGrid" style="overflow-x:auto"></div>

--- a/shared/style.css
+++ b/shared/style.css
@@ -1004,6 +1004,12 @@ textarea { min-height: 70px; }
 .sc-mpick-day { display: block; font-size: 8px; text-transform: uppercase; letter-spacing: .3px; }
 .sc-mpick-num { display: block; font-size: 13px; font-weight: 500; color: var(--text); margin-top: 1px; }
 
+/* ── Slot-calendar week navigation (captain/coxswain/admin) ── */
+.slot-week-nav { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.slot-week-nav .btn { font-size: 11px; padding: 4px 10px; min-height: 0; }
+.slot-week-nav .week-label { font-size: 11px; min-width: 140px; text-align: center; }
+.slot-week-nav .btn[data-icon]::before { content: attr(data-icon); display: none; }
+
 /* ══════════════════════════════════════════════════════════════════════════════
    RESPONSIVE — Mobile (≤ 600px)
    ══════════════════════════════════════════════════════════════════════════════ */
@@ -1085,6 +1091,13 @@ textarea { min-height: 70px; }
   .section-heading { margin: 16px 0 8px; }
   .info-panel { padding: 12px; }
   .input-row { flex-wrap: wrap; }
+
+  /* ── Slot-calendar week navigation — compact, allow wrap ── */
+  .slot-week-nav { gap: 4px; }
+  .slot-week-nav .btn { min-height: 32px; padding: 6px 10px; font-size: 11px; }
+  .slot-week-nav .week-label { flex: 1 1 100%; min-width: 0; order: -1; }
+  .slot-week-nav .btn[data-icon] .btn-label { display: none; }
+  .slot-week-nav .btn[data-icon]::before { display: inline; }
 }
 
 @media (max-width: 400px) {


### PR DESCRIPTION
Wrap the week navigation cluster in a shared `.slot-week-nav` class so the inner button group can flex-wrap, the week label gets its own row at ≤600px, and a compact 32px touch target overrides the global 44px mobile rule for this dense calendar control only. Primary action buttons (New Booking / Bulk Book / + Recurring) collapse to `+` and `++` icons on mobile via a `data-icon` + `.btn-label` pattern, preserving localization unchanged.

Applies to captain, coxswain, and admin slot-calendar pages.