### PR TITLE
Lay out staff nav-card icons beside label/description, not above

### DIFF
--- a/staff/index.html
+++ b/staff/index.html
@@ -23,10 +23,13 @@
 .nav-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:10px; margin-bottom:20px; }
 .nav-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
   padding:16px 14px; cursor:pointer; transition:all .2s;
-  text-decoration:none; display:flex; flex-direction:column; gap:6px; box-shadow:var(--shadow-sm); }
+  text-decoration:none; display:grid;
+  grid-template-columns:auto 1fr; column-gap:12px; row-gap:4px;
+  align-items:center; box-shadow:var(--shadow-sm); }
 .nav-card:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
 /* Icon span: empty, rendered as a brass-colored SVG mask */
 .nc-icon {
+  grid-column:1; grid-row:1/3;
   display:inline-block; width:24px; height:24px;
   background-color:var(--brass);
   -webkit-mask-repeat:no-repeat; mask-repeat:no-repeat;
@@ -54,8 +57,8 @@
   -webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z'/%3E%3C/svg%3E");
           mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z'/%3E%3C/svg%3E");
 }
-.nc-label { font-size:15px; font-weight:500; color:var(--text); letter-spacing:.3px; }
-.nc-desc  { font-size:11px; color:var(--muted); line-height:1.4; }
+.nc-label { grid-column:2; grid-row:1; font-size:15px; font-weight:500; color:var(--text); letter-spacing:.3px; }
+.nc-desc  { grid-column:2; grid-row:2; font-size:11px; color:var(--muted); line-height:1.4; }
 
 /* ── Stat strip ── */
 .stat-row  { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }


### PR DESCRIPTION
Convert .nav-card from a vertical flex stack to a 2-column grid so the Lucide glyph sits to the left of the title and description instead of stacked on its own line. The icon spans both text rows and centers vertically. The absolutely-positioned incidents badge is unaffected.