### PR TITLE
Rework header: uniform button height, restore hub-switches on top-lev…

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -188,49 +188,32 @@ main.wide { max-width: 1100px; }
 
 /* ── HEADER BUTTONS ───────────────────────────────────────────────────────────── */
 
-.hbtn {
+.hbtn, .back-btn {
   background: none;
   border: 1px solid var(--border);
-  color: var(--muted);
   border-radius: var(--radius-sm);
-  padding: 5px 12px;
+  height: 30px;
+  padding: 0 12px;
   font-size: 12px;
   font-family: inherit;
   cursor: pointer;
   text-decoration: none;
-  display: inline-block;
-  white-space: nowrap;
-  line-height: 1.4;
-  transition: color .2s, border-color .2s, background .2s;
-}
-.hbtn:hover       { color: var(--brass); border-color: var(--brass); background: var(--brass)08; }
-.hbtn.active      { color: var(--brass); border-color: var(--brass); }
-
-.hbtn.icon-only {
-  padding: 5px 8px;
-  font-size: 16px;
   display: inline-flex;
   align-items: center;
-  line-height: 1;
-}
-
-.back-btn {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text);
-  border-radius: var(--radius-sm);
-  padding: 5px 12px;
-  font-size: 12px;
-  font-family: inherit;
-  cursor: pointer;
-  text-decoration: none;
-  display: inline-block;
-  font-weight: 500;
   white-space: nowrap;
-  line-height: 1.4;
-  transition: color .15s, border-color .15s;
+  line-height: 1;
+  box-sizing: border-box;
+  transition: color .2s, border-color .2s, background .2s;
 }
-.back-btn:hover { color: var(--brass); border-color: var(--brass); }
+.hbtn     { color: var(--muted); }
+.back-btn { color: var(--text); font-weight: 500; }
+.hbtn:hover, .back-btn:hover { color: var(--brass); border-color: var(--brass); background: var(--brass)08; }
+.hbtn.active { color: var(--brass); border-color: var(--brass); }
+
+.hbtn.icon-only {
+  padding: 0 8px;
+  font-size: 16px;
+}
 
 /* ── CARDS ────────────────────────────────────────────────────────────────────── */
 
@@ -1013,11 +996,8 @@ textarea { min-height: 70px; }
   header { padding: 10px 12px; gap: 8px; }
   .logo { font-size: 15px; }
   .logo-icon { width: 28px; aspect-ratio: 1170 / 1450; }
-  .hbtn { padding: 6px 8px; font-size: 11px; }
-  .back-btn { padding: 6px 8px; font-size: 11px; }
-  .back-btn .back-label { display: none; }
-  .hub-switch { display: none; }
-  .hbtn.icon-only { padding: 6px 8px; font-size: 18px; }
+  .hbtn, .back-btn { height: 32px; padding: 0 10px; font-size: 11px; }
+  .hbtn.icon-only { padding: 0 8px; font-size: 18px; }
   .header-left { gap: 8px; }
   .header-right { gap: 6px; }
   .page-title { font-size: 11px; padding-left: 8px; }
@@ -1092,8 +1072,7 @@ textarea { min-height: 70px; }
   .btn-row { gap: 6px; }
   .card { padding: 12px 10px; }
   header { padding: 8px 10px; }
-  .hbtn { padding: 5px 6px; font-size: 10px; }
-  .back-btn { padding: 5px 6px; font-size: 10px; }
+  .hbtn, .back-btn { padding: 0 6px; font-size: 10px; }
   .logo-icon { width: 28px; aspect-ratio: 1170 / 1459 }
   main { padding: 12px 10px; }
   .page-content { padding: 10px 10px 80px; }

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -335,16 +335,8 @@ window.buildHeader = function (page) {
   function link(href, label, cls, hub) {
     const a = document.createElement('a');
     a.href = href; a.className = cls || 'hbtn';
-    const iconHtml = (hub && NAV_ICONS_[hub]) ? NAV_ICONS_[hub] + ' ' : '';
-    if ((cls || '').indexOf('back-btn') !== -1) {
-      // back-btn: wrap label in a span so it can be hidden on mobile,
-      // leaving just the hub icon + arrow visible.
-      a.innerHTML = iconHtml + '← <span class="back-label">' + label + '</span>';
-    } else if (iconHtml) {
-      a.innerHTML = iconHtml + label;
-    } else {
-      a.textContent = label;
-    }
+    if (hub && NAV_ICONS_[hub]) { a.innerHTML = NAV_ICONS_[hub] + ' ' + label; }
+    else { a.textContent = label; }
     return a;
   }
   function btn(label, fn, cls) {
@@ -371,18 +363,19 @@ window.buildHeader = function (page) {
   left.appendChild(logo);
 
   // LEFT: back link on subpages
-  if (isStaffSub)  left.appendChild(link(depth + 'staff/',  s('nav.staffHub'),  'back-btn', 'staff'));
-  if (isAdminSub)  left.appendChild(link(depth + 'admin/',  s('nav.admin'),     'back-btn', 'admin'));
-  if (isMemberSub) left.appendChild(link(depth + 'member/', s('nav.memberHub'), 'back-btn', 'member'));
+  if (isStaffSub)  left.appendChild(link(depth + 'staff/',  '← ' + s('nav.staffHub'),  'back-btn', 'staff'));
+  if (isAdminSub)  left.appendChild(link(depth + 'admin/',  '← ' + s('nav.admin'),     'back-btn', 'admin'));
+  if (isMemberSub) left.appendChild(link(depth + 'member/', '← ' + s('nav.memberHub'), 'back-btn', 'member'));
 
-  // LEFT: hub-switch buttons (staff/admin only)
-  if (user) {
+  // LEFT: hub-switch buttons — only on top-level hub pages, not subpages
+  const isSubpage = isStaffSub || isAdminSub || isMemberSub;
+  if (user && !isSubpage) {
     const canStaff = typeof isStaff === 'function' && isStaff(user);
     const canAdmin = typeof isAdmin === 'function' && isAdmin(user);
 
-    if (canStaff && currentHub !== 'staff')  left.appendChild(link(depth + 'staff/',  s('nav.staffHub'),  'hbtn hub-switch', 'staff'));
-    if (canStaff && currentHub !== 'member') left.appendChild(link(depth + 'member/', s('nav.memberHub'), 'hbtn hub-switch', 'member'));
-    if (canAdmin && currentHub !== 'admin')  left.appendChild(link(depth + 'admin/',  s('nav.admin'),     'hbtn hub-switch', 'admin'));
+    if (canStaff && currentHub !== 'staff')  left.appendChild(link(depth + 'staff/',  s('nav.staffHub'),  'hbtn', 'staff'));
+    if (canStaff && currentHub !== 'member') left.appendChild(link(depth + 'member/', s('nav.memberHub'), 'hbtn', 'member'));
+    if (canAdmin && currentHub !== 'admin')  left.appendChild(link(depth + 'admin/',  s('nav.admin'),     'hbtn', 'admin'));
   }
 
   // RIGHT: guardian-acting-as-ward badge (if applicable)


### PR DESCRIPTION
…el, restore back label

- Give .hbtn and .back-btn a fixed 30 px height (32 px on mobile) via flex alignment so text buttons and icon-only buttons line up exactly.
- Hub-switch links (Staff / Admin / Home) reappear on top-level hub pages so users can jump between admin/staff/member without logging out — they stay hidden on deeper subpages to avoid wrapping.
- Back button text restored; drop the now-unused .back-label span and .hub-switch mobile CSS rules.