### PR TITLE
Hide logbook stat-strip until visibility prefs are applied

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -153,7 +153,7 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 <div class="page">
 
   <!-- Stats -->
-  <div class="stat-strip">
+  <div class="stat-strip" style="display:none">
     <div class="stat-card"><div class="stat-val" id="stTrips">—</div><div class="stat-lbl">Trips</div></div>
     <div class="stat-card"><div class="stat-val" id="stHours">—</div><div class="stat-lbl">Hours</div></div>
     <div class="stat-card"><div class="stat-val" id="stSeason">—</div><div class="stat-lbl">This year</div></div>
@@ -629,7 +629,7 @@ function renderStats(){
   const visKeys=['career','hours','ytd','skipper','distance','longest','avgWind','streak','boats','crew','heavy','avgDuration','locations','verified','helmHours','student','favBoat','favLocation','peakWind'];
   const visibleCards=visKeys.filter(k=>isStatVisible(k,_statsVis)).length;
   const strip=document.querySelector('.stat-strip');
-  if(strip && visibleCards>0){strip.style.gridTemplateColumns='repeat('+Math.min(visibleCards,4)+',1fr)'}
+  if(strip && visibleCards>0){strip.style.gridTemplateColumns='repeat('+Math.min(visibleCards,4)+',1fr)';strip.style.display='grid'}
   else if(strip && visibleCards===0){strip.style.display='none'}
 
   if(!isStatVisible('byCategory',_statsVis)){document.getElementById('catHours').style.display='none';return}


### PR DESCRIPTION
The stat-strip was rendered visible in the static HTML, so all 19 stat boxes (with "—" placeholders) briefly flashed on page load before the async API data resolved and renderStats() applied the user's statsVisibility prefs. Users would see stats they had disabled.

Hide the strip initially with inline display:none (matching the pattern already used by #catHours and #memberHeatmapWrap on the same page), and reveal it with display:grid at the end of renderStats() once the correct set of cards has been determined.

https://claude.ai/code/session_01EXdf8hpKiT7HgVFQjVKsJS