### PR TITLE
Show crew member initials with click-to-reveal on coxswain page

### DIFF
--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -71,10 +71,12 @@
   font-size:11px; padding:0 8px; overflow:hidden; white-space:nowrap; }
 .cb-seat:first-of-type { border-radius:6px 6px 0 0; border-bottom:none; }
 .cb-seat:last-of-type { border-radius:0 0 6px 6px; }
-.cb-seat--filled { background:var(--surface); color:var(--text); }
-.cb-seat--you { background:var(--brass)18; color:var(--brass); border-color:var(--brass)66; font-weight:500; }
+.cb-seat--filled { background:var(--surface); color:var(--text); cursor:pointer; }
+.cb-seat--you { background:var(--brass)18; color:var(--brass); border-color:var(--brass)66; font-weight:500; cursor:pointer; }
 .cb-seat--open { background:transparent; color:var(--muted); border-style:dashed; cursor:pointer; transition:all .15s; }
 .cb-seat--open:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)08; }
+.cb-seat--expanded { height:auto; min-height:28px; white-space:normal; padding-top:4px; padding-bottom:4px; }
+.cb-seat--expanded .cb-seat-name { overflow:visible; text-overflow:clip; white-space:normal; word-break:break-word; line-height:1.2; }
 .cb-seat-role { font-size:8px; color:var(--muted); min-width:28px; opacity:.7; }
 .cb-seat-name { overflow:hidden; text-overflow:ellipsis; }
 .cb-actions { display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
@@ -627,17 +629,27 @@ function renderSeat(crew, pairId, seatIdx, member, isOpen, isMine) {
   var kt = String(user.kennitala);
   var isYou = member && String(member.kennitala) === kt;
   var roleLabel = '<span class="cb-seat-role">' + (seatIdx === 0 ? s('cox.bow') : s('cox.stern')) + '</span>';
-  if (isYou) {
-    return '<div class="cb-seat cb-seat--you">' + roleLabel + '<span class="cb-seat-name">' + esc(memberDisplayName(member, _members)) + '</span></div>';
-  }
   if (member) {
-    return '<div class="cb-seat cb-seat--filled">' + roleLabel + '<span class="cb-seat-name">' + esc(memberDisplayName(member, _members)) + '</span></div>';
+    var full = esc(memberDisplayName(member, _members));
+    var ini  = esc(memberInitials(member, _members)) || full;
+    var cls  = isYou ? 'cb-seat cb-seat--you' : 'cb-seat cb-seat--filled';
+    return '<div class="' + cls + '" title="' + full + '" data-full="' + full + '" data-ini="' + ini + '" onclick="toggleSeatName(this)">'
+      + roleLabel + '<span class="cb-seat-name">' + ini + '</span></div>';
   }
   if (isOpen && _isReleasedRower && !isMine) {
     return '<div class="cb-seat cb-seat--open" onclick="joinSeat(\'' + esc(crew.id) + '\',\'' + esc(pairId) + '\',' + seatIdx + ')">'
       + roleLabel + '<span class="cb-seat-name">' + s('cox.join') + '</span></div>';
   }
   return '<div class="cb-seat cb-seat--open" style="cursor:default">' + roleLabel + '<span class="cb-seat-name">—</span></div>';
+}
+
+// Toggle a filled seat between initials and full name. Uses data- attributes
+// populated by renderSeat so we don't need to re-derive the values here.
+function toggleSeatName(el) {
+  var nameEl = el.querySelector('.cb-seat-name');
+  if (!nameEl) return;
+  var expanded = el.classList.toggle('cb-seat--expanded');
+  nameEl.textContent = expanded ? (el.dataset.full || '') : (el.dataset.ini || '');
 }
 
 function renderCrewInvites() {

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -85,6 +85,43 @@ window.memberDisplayName = function (member, allMembers) {
   return name;
 };
 
+// ── MEMBER INITIALS ───────────────────────────────────────────────────────────
+// Compact label for tight spaces. Prefers the stored `initials` field (set by
+// the backend in _memberRow_), otherwise computes from `name` using the same
+// rule as code.gs extractInitials_: split on whitespace, drop all-lowercase
+// tokens (connectors like "van", "de", "af"), strip hyphens, take first char
+// of each remaining token, uppercase. When two members in `allMembers` would
+// collapse to the same initials and the member has a birthYear, append the
+// last two digits as a disambiguator (e.g. "JM'98").
+function _computeInitials(name) {
+  if (!name) return '';
+  return String(name).trim().split(/\s+/)
+    .filter(function(t) { return t && t !== t.toLowerCase(); })
+    .map(function(t) { return t.replace(/-/g, '').charAt(0); })
+    .join('').toUpperCase();
+}
+window.memberInitials = function (member, allMembers) {
+  if (!member) return '';
+  var ini = (member.initials && String(member.initials).trim())
+    || _computeInitials(member.name || '');
+  if (!ini || !Array.isArray(allMembers)) return ini;
+  var dupes = 0;
+  for (var i = 0; i < allMembers.length; i++) {
+    var other = allMembers[i];
+    if (!other) continue;
+    var otherIni = (other.initials && String(other.initials).trim())
+      || _computeInitials(other.name || '');
+    if (otherIni === ini) {
+      if (++dupes > 1) break;
+    }
+  }
+  if (dupes > 1 && member.birthYear) {
+    var yy = String(member.birthYear).slice(-2);
+    return ini + "'" + yy;
+  }
+  return ini;
+};
+
 // Build a Set of names that occur more than once in the given array.
 window.duplicateMemberNames = function (allMembers) {
   var seen = Object.create(null), dupes = new Set();


### PR DESCRIPTION
Crew member names overflow the narrow seat boxes on the rowing division page. Display compact initials by default and toggle the full name in-place on click; native title tooltip provides desktop hover disclosure. Closes #573.

https://claude.ai/code/session_01PMXRKRRXCxPmVgyxHby35Q