### PR TITLE
Rework light/dark palette around club navy + moss

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -106,11 +106,11 @@
     .col-hint-vals  { color:var(--muted); }
     .import-summary { display:flex; gap:8px; flex-wrap:wrap; margin:12px 0; }
     .import-chip { padding:5px 11px; border-radius:20px; font-size:11px; font-weight:500; }
-    .chip-green  { background:#27ae6022; color:#27ae60; border:1px solid #27ae6044; }
-    .chip-brass  { background:var(--brass)22; color:var(--brass); border:1px solid var(--brass)44; }
-    .chip-orange { background:#e67e2222; color:#e67e22; border:1px solid #e67e2244; }
+    .chip-green  { background:color-mix(in srgb, var(--green) 15%, transparent);  color:var(--green);  border:1px solid color-mix(in srgb, var(--green) 30%, transparent); }
+    .chip-brass  { background:color-mix(in srgb, var(--brass) 15%, transparent);  color:var(--brass);  border:1px solid color-mix(in srgb, var(--brass) 30%, transparent); }
+    .chip-orange { background:color-mix(in srgb, var(--orange) 15%, transparent); color:var(--orange); border:1px solid color-mix(in srgb, var(--orange) 30%, transparent); }
     .chip-muted  { background:var(--surface); color:var(--muted); border:1px solid var(--border); }
-    .chip-red    { background:#e74c3c22; color:#e74c3c; border:1px solid #e74c3c44; }
+    .chip-red    { background:color-mix(in srgb, var(--red) 15%, transparent);    color:var(--red);    border:1px solid color-mix(in srgb, var(--red) 30%, transparent); }
     .import-list { max-height:220px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm); margin-top:6px; }
     .import-row  { display:flex; gap:10px; padding:6px 12px; border-bottom:1px solid var(--border)33;
       font-size:11px; align-items:center; }
@@ -124,8 +124,8 @@
     .import-ambig-btns button:hover { border-color:var(--brass); }
     .import-ambig-btns button.selected { background:var(--brass); color:#000; border-color:var(--brass); }
 
-    .minor-badge { font-size:10px; background:#f1c40f22; color:#c9a800;
-      border:1px solid #f1c40f44; border-radius:3px; padding:1px 5px; }
+    .minor-badge { font-size:10px; background:color-mix(in srgb, var(--yellow) 15%, transparent); color:var(--yellow);
+      border:1px solid color-mix(in srgb, var(--yellow) 30%, transparent); border-radius:3px; padding:1px 5px; }
     .oos-badge   { font-size:10px; background:var(--red)22; color:var(--red);
       border:1px solid var(--red)44; border-radius:3px; padding:1px 5px; }
 
@@ -214,7 +214,7 @@
               <div class="text-sm text-muted mb-4">Admin/staff roles never overwritten.</div>
               <div class="import-summary" id="importSummary"></div>
               <div id="importLists"></div>
-              <div id="importError" class="text-red text-md mb-8 hidden" style="padding:8px;background:#e74c3c11;border-radius:4px;border:1px solid var(--red)44"></div>
+              <div id="importError" class="text-red text-md mb-8 hidden" style="padding:8px;background:color-mix(in srgb, var(--red) 8%, transparent);border-radius:4px;border:1px solid color-mix(in srgb, var(--red) 27%, transparent)"></div>
               <div class="btn-row mt-14">
                 <button class="btn btn-secondary" onclick="resetImport()" data-s="admin.backToList"></button>
                 <button class="btn btn-primary" onclick="confirmImport()" id="confirmImportBtn" data-s="admin.confirmImport"></button>
@@ -465,9 +465,9 @@
         </div>
         <div class="col-body" id="flagThresholdsCard">
           <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:12px">
-            <div class="field"><label style="color:#f1c40f">🟡 <span data-s="admin.yellowGte"></span></label><input type="number" id="fcThreshY" min="1" max="99" value="25" oninput="updateFlagPreview()"></div>
-            <div class="field"><label style="color:#e67e22">🟠 <span data-s="admin.orangeGte"></span></label><input type="number" id="fcThreshO" min="1" max="99" value="45" oninput="updateFlagPreview()"></div>
-            <div class="field"><label style="color:#e74c3c">🔴 <span data-s="admin.redGte"></span></label><input type="number" id="fcThreshR" min="1" max="99" value="65" oninput="updateFlagPreview()"></div>
+            <div class="field"><label style="color:var(--yellow)">🟡 <span data-s="admin.yellowGte"></span></label><input type="number" id="fcThreshY" min="1" max="99" value="25" oninput="updateFlagPreview()"></div>
+            <div class="field"><label style="color:var(--orange)">🟠 <span data-s="admin.orangeGte"></span></label><input type="number" id="fcThreshO" min="1" max="99" value="45" oninput="updateFlagPreview()"></div>
+            <div class="field"><label style="color:var(--red)">🔴 <span data-s="admin.redGte"></span></label><input type="number" id="fcThreshR" min="1" max="99" value="65" oninput="updateFlagPreview()"></div>
             <div class="field"><label style="color:#999">⚫️ <span data-s="admin.closedGte"></span></label><input type="number" id="fcThreshB" min="1" max="120" value="80" oninput="updateFlagPreview()"></div>
           </div>
         </div>
@@ -3764,7 +3764,7 @@ function renderImportPreview(res) {
     });
   }
   if (res.added.length) {
-    html += `<div style="font-size:11px;color:#27ae60;margin:10px 0 4px;font-weight:500">NEW (${res.added.length})</div>
+    html += `<div style="font-size:11px;color:var(--green);margin:10px 0 4px;font-weight:500">NEW (${res.added.length})</div>
       <div class="import-list">${res.added.map(m => `
         <div class="import-row">
           <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
@@ -3783,7 +3783,7 @@ function renderImportPreview(res) {
         </div>`).join("")}</div>`;
   }
   if (res.flagged.length) {
-    html += `<div style="font-size:11px;color:#e67e22;margin:10px 0 4px;font-weight:500">NOT IN THIS IMPORT (${res.flagged.length})
+    html += `<div style="font-size:11px;color:var(--orange);margin:10px 0 4px;font-weight:500">NOT IN THIS IMPORT (${res.flagged.length})
       <span style="font-weight:400;opacity:.7"> — check to deactivate</span></div>
       <div style="margin-bottom:4px">
         <label style="font-size:10px;color:var(--muted);cursor:pointer;display:inline-flex;align-items:center;gap:4px">

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -501,9 +501,9 @@ function renderActivities() {
     row.className = 'activity-row';
     const info = document.createElement('div'); info.className = 'activity-info';
     const meta = [act.type, act.subtypeName||'', act.start && act.end ? act.start+'\u2013'+act.end : act.start, act.participants].filter(Boolean).join(' \u00b7 ');
-    const ablerBadge  = act.ablerRegistered ? '<span style="font-size:9px;background:#1a3a1a;border:1px solid #2e7d32;color:#4caf50;border-radius:10px;padding:1px 7px;margin-left:6px;letter-spacing:.3px">Abler ✓</span>' : '';
+    const ablerBadge  = act.ablerRegistered ? '<span style="font-size:9px;background:color-mix(in srgb, var(--moss) 12%, transparent);border:1px solid color-mix(in srgb, var(--moss) 40%, transparent);color:var(--moss);border-radius:10px;padding:1px 7px;margin-left:6px;letter-spacing:.3px">Abler ✓</span>' : '';
     const linkedCount = act.linkedGroupCheckoutIds && act.linkedGroupCheckoutIds.length
-      ? '<span style="font-size:9px;background:var(--card);border:1px solid #2e86c155;border-left:2px solid #2e86c1;border-radius:4px;padding:1px 7px;margin-left:4px">⛵ ' + act.linkedGroupCheckoutIds.length + ' ' + (act.linkedGroupCheckoutIds.length>1?s('daily.groups'):s('daily.group')) + '</span>' : '';
+      ? '<span style="font-size:9px;background:var(--card);border:1px solid color-mix(in srgb, var(--navy) 33%, transparent);border-left:2px solid var(--navy);border-radius:4px;padding:1px 7px;margin-left:4px">⛵ ' + act.linkedGroupCheckoutIds.length + ' ' + (act.linkedGroupCheckoutIds.length>1?s('daily.groups'):s('daily.group')) + '</span>' : '';
     info.innerHTML = `<div class="activity-name">${esc(act.name)}${ablerBadge}${linkedCount}</div>
       <div class="activity-meta">${esc(meta)}</div>
       ${act.notes ? `<div class="activity-nity-note">${esc(act.notes)}</div>` : ''}`;
@@ -1240,7 +1240,7 @@ function renderGroupLinkCards() {
   if (!wrap) return;
   if (!_linkedGroupCheckoutIds.length) { wrap.innerHTML = ''; return; }
   wrap.innerHTML = _linkedGroupCheckoutIds.map(function(id) {
-    return '<div class="flex-between callout-panel text-sm" style="border-left:3px solid #2e86c1;border-color:#2e86c155;border-left-color:#2e86c1;padding:6px 10px">' +
+    return '<div class="flex-between callout-panel text-sm" style="border-left:3px solid var(--navy);border-color:color-mix(in srgb, var(--navy) 33%, transparent);border-left-color:var(--navy);padding:6px 10px">' +
       '<span>⛵ Group checkout ' + esc(sstr(id).slice(-6)) + '</span>' +
       '<button class="btn-dismiss" onclick="_linkedGroupCheckoutIds=_linkedGroupCheckoutIds.filter(x=>x!==\'' + id + '\');renderGroupLinkCards()">✕</button>' +
       '</div>';
@@ -1264,7 +1264,7 @@ function openGroupLinkPicker() {
       let boatArr; try { boatArr = c.boatNames?(typeof c.boatNames==='string'?JSON.parse(c.boatNames):c.boatNames):[c.boatName||'—']; } catch(e){ boatArr=[c.boatName||'—']; }
       let staffArr; try { staffArr = c.staffNames?(typeof c.staffNames==='string'?JSON.parse(c.staffNames):c.staffNames):[]; } catch(e){ staffArr=[]; }
       const sel = _groupLinkPickerSelected.has(c.id);
-      return '<div onclick="toggleGroupLinkPick(\''+c.id+'\')" class="callout-panel mb-6" style="background:' + (sel?'#0a1e2e':'var(--surface)') + ';border-color:' + (sel?'#2e86c1':'var(--border)') + ';border-left:3px solid #2e86c1;cursor:pointer">' +
+      return '<div onclick="toggleGroupLinkPick(\''+c.id+'\')" class="callout-panel mb-6" style="background:' + (sel?'color-mix(in srgb, var(--navy) 12%, transparent)':'var(--surface)') + ';border-color:' + (sel?'var(--navy)':'var(--border)') + ';border-left:3px solid var(--navy);cursor:pointer">' +
         '<div class="text-md fw-500">' + esc(boatArr.join(', ')) + '</div>' +
         '<div class="text-sm text-muted">' + (staffArr[0]?esc(staffArr[0])+' · ':'') + esc(c.activityTypeName||'—') + ' · Out ' + esc(sstr(c.checkedOutAt||c.timeOut).slice(0,5)) + '</div>' +
         '</div>';

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -29,10 +29,10 @@
     .sev-btn { flex:1; min-width:60px; padding:7px 4px; background:var(--surface);
       border-radius:var(--radius-sm); border:1px solid; font-size:11px; font-family:inherit;
       cursor:pointer; text-align:center; font-weight:600; letter-spacing:.4px; transition:all .2s; }
-    .sev-btn[data-v="low"]      { color:var(--green);  border-color:#27ae6055; background:#27ae6011; }
-    .sev-btn[data-v="medium"]   { color:#c9a800;       border-color:#f1c40f55; background:#f1c40f11; }
-    .sev-btn[data-v="high"]     { color:var(--orange); border-color:#e67e2255; background:#e67e2211; }
-    .sev-btn[data-v="critical"] { color:var(--red);    border-color:#e74c3c55; background:#e74c3c11; }
+    .sev-btn[data-v="low"]      { color:var(--green);  border-color:color-mix(in srgb, var(--green)  33%, transparent); background:color-mix(in srgb, var(--green)  8%, transparent); }
+    .sev-btn[data-v="medium"]   { color:var(--yellow); border-color:color-mix(in srgb, var(--yellow) 33%, transparent); background:color-mix(in srgb, var(--yellow) 8%, transparent); }
+    .sev-btn[data-v="high"]     { color:var(--orange); border-color:color-mix(in srgb, var(--orange) 33%, transparent); background:color-mix(in srgb, var(--orange) 8%, transparent); }
+    .sev-btn[data-v="critical"] { color:var(--red);    border-color:color-mix(in srgb, var(--red)    33%, transparent); background:color-mix(in srgb, var(--red)    8%, transparent); }
     .sev-btn.on { filter:brightness(1.4); box-shadow:0 0 0 2px currentColor; }
 
     .incident-row { padding:12px 0; border-bottom:1px solid var(--faint); font-size:13px; cursor:pointer; }
@@ -74,7 +74,7 @@
     </div>
 
     <!-- Needs-review alert -->
-    <div id="reviewAlert" class="hidden" style="background:#e67e2218;border:1px solid #e67e2255;color:var(--orange);border-radius:var(--radius-md);padding:10px 14px;margin-bottom:14px;font-size:13px;display:flex;align-items:center;gap:8px;box-shadow:var(--shadow-sm)">
+    <div id="reviewAlert" class="hidden" style="background:color-mix(in srgb, var(--orange) 10%, transparent);border:1px solid color-mix(in srgb, var(--orange) 33%, transparent);color:var(--orange);border-radius:var(--radius-md);padding:10px 14px;margin-bottom:14px;font-size:13px;display:flex;align-items:center;gap:8px;box-shadow:var(--shadow-sm)">
       <span style="font-size:16px">⚠️</span>
       <span id="reviewAlertText"></span>
     </div>

--- a/login/index.html
+++ b/login/index.html
@@ -30,11 +30,11 @@
     .role-btn .role-icon svg { width:100%; height:100%; }
     .role-btn .role-label { color:var(--text); font-size:13px; font-weight:500; letter-spacing:.5px; }
     .role-btn .role-desc { color:var(--muted); font-size:11px; margin-top:2px; }
-    .role-btn.role-admin  { border-color:#e74c3c44; }
-    .role-btn.role-admin:hover { border-color:#e74c3c; }
-    .role-btn.role-staff  { border-color:var(--brass)44; }
-    .role-btn.role-member { border-color:#2ecc7144; }
-    .role-btn.role-member:hover { border-color:#2ecc71; }
+    .role-btn.role-admin  { border-color:color-mix(in srgb, var(--red)  27%, transparent); }
+    .role-btn.role-admin:hover { border-color:var(--red); }
+    .role-btn.role-staff  { border-color:color-mix(in srgb, var(--brass) 27%, transparent); }
+    .role-btn.role-member { border-color:color-mix(in srgb, var(--moss) 33%, transparent); }
+    .role-btn.role-member:hover { border-color:var(--moss); }
     .role-btn.role-ward   { border-color:#9b59b644; }
     .role-btn.role-ward:hover { border-color:#9b59b6; }
     .back-link { display:block; text-align:center; margin-top:12px; color:var(--muted); font-size:12px; cursor:pointer; }

--- a/member/index.html
+++ b/member/index.html
@@ -143,7 +143,7 @@
 /* ── Fleet status ─────────────────────────── */
 .fleet-status-block { margin-bottom:4px; }
 .fsb-header { display:flex;align-items:center;gap:10px;padding:8px 12px;cursor:pointer;border-radius:var(--radius-sm);background:var(--surface);transition:background .2s;border-left:3px solid transparent; }
-.fsb-header:hover { background:var(--surface2,#132233); }
+.fsb-header:hover { background:var(--faint); }
 .fsb-emoji { width:16px; height:16px; flex-shrink:0; display:inline-flex; align-items:center; }
 .fsb-emoji svg { width:100%; height:100%; }
 .fsb-label { font-size:12px;color:var(--muted);flex:1;text-transform:uppercase;letter-spacing:.04em; }
@@ -156,8 +156,8 @@
 .fsb-body { padding:4px 0; }
 .fleet-cat-grid { display:flex;flex-wrap:wrap;gap:6px;padding:4px; }
 .bc-card { background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;font-size:12px; }
-.bc-avail { border-left:3px solid #2ecc71;cursor:pointer; }
-.bc-avail:hover { background:var(--surface2,#132233); }
+.bc-avail { border-left:3px solid var(--moss);cursor:pointer; }
+.bc-avail:hover { background:var(--faint); }
 .bc-out { border-left:3px solid var(--brass); }
 .bc-overdue { border-left:3px solid var(--red); }
 .bc-oos { opacity:.5; }
@@ -831,7 +831,7 @@ function renderCrewInputs() {
     inp.style.cssText='flex:1;min-width:0;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:6px 8px';
     const stuCb=document.createElement('input'); stuCb.type='checkbox'; stuCb.className='accent-checkbox crew-student-cb'; stuCb.title=s('tc.student'); stuCb.checked=!!prev.student;
     stuCb.addEventListener('change',function(){inp.dataset.student=this.checked?'1':'';});
-    const stuLbl=document.createElement('label'); stuLbl.style.cssText='display:flex;align-items:center;gap:3px;font-size:9px;color:#2e86c1;white-space:nowrap;cursor:pointer';
+    const stuLbl=document.createElement('label'); stuLbl.style.cssText='display:flex;align-items:center;gap:3px;font-size:9px;color:var(--navy-l);white-space:nowrap;cursor:pointer';
     stuLbl.appendChild(stuCb); stuLbl.appendChild(document.createTextNode(s('tc.student')));
     const drop=document.createElement('div'); drop.id='crewDrop'+i;
     drop.style.cssText='position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 6px 6px;z-index:100;max-height:160px;overflow-y:auto;display:none';
@@ -1216,7 +1216,7 @@ function _renderHelmSection(){
           '<input type="checkbox" class="helm-toggle accent-checkbox" data-helm-kt="'+esc(t.kennitala||'')+'" data-helm-name="'+esc(t.memberName||'')+'" data-guest="'+(_isGuest(t)?'1':'')+'">'+
           '<span>'+esc(t.memberName||'?')+_guestTag(t)+'</span>'+
         '</label>'+
-        '<label style="display:flex;align-items:center;gap:3px;font-size:9px;color:#2e86c1;white-space:nowrap;cursor:pointer">'+
+        '<label style="display:flex;align-items:center;gap:3px;font-size:9px;color:var(--navy-l);white-space:nowrap;cursor:pointer">'+
           '<input type="checkbox" class="student-toggle accent-checkbox" data-stu-kt="'+esc(t.kennitala||'')+'" data-stu-name="'+esc(t.memberName||'')+'" data-guest="'+(_isGuest(t)?'1':'')+'"'+(t.student?' checked':'')+'>'+
           s('tc.student')+
         '</label>'+
@@ -1577,10 +1577,10 @@ function _renderMemberStaffStatus() {
   if (!_staffStatus) { el.innerHTML = ''; return; }
   const onDuty = _staffStatus.onDuty;
   const boat   = _staffStatus.supportBoat;
-  const dutyCol  = onDuty ? '#27ae60' : 'var(--muted)';
-  const boatCol  = boat   ? '#5dade2'  : 'var(--muted)';
-  const dutyBg   = onDuty ? '#27ae6018;border-color:#27ae6044' : 'var(--surface);border-color:var(--border)';
-  const boatBg   = boat   ? '#2980b918;border-color:#2980b944' : 'var(--surface);border-color:var(--border)';
+  const dutyCol  = onDuty ? 'var(--moss)' : 'var(--muted)';
+  const boatCol  = boat   ? 'var(--navy)' : 'var(--muted)';
+  const dutyBg   = onDuty ? 'color-mix(in srgb, var(--moss) 10%, transparent);border-color:color-mix(in srgb, var(--moss) 27%, transparent)' : 'var(--surface);border-color:var(--border)';
+  const boatBg   = boat   ? 'color-mix(in srgb, var(--navy) 10%, transparent);border-color:color-mix(in srgb, var(--navy) 27%, transparent)' : 'var(--surface);border-color:var(--border)';
   el.innerHTML = '<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:2px">'
     + '<span style="display:inline-flex;align-items:center;gap:5px;padding:4px 12px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;background:' + dutyBg + ';color:' + dutyCol + '">'
     + '🧑 ' + s('wx.staffOnDuty') + '</span>'

--- a/public/index.html
+++ b/public/index.html
@@ -17,25 +17,28 @@
 <script src="../shared/tides.js" defer></script>
 <style>
 :root {
-  --bg:      #0b1f38;
-  --surface: #0f2847;
-  --card:    #132d50;
-  --border:  #1e3f6e;
-  --border-l:#1e3f6e;
-  --text:    #d6e4f0;
-  --muted:   #6b92b8;
-  --brass:   #d4af37;
-  --green:   #27ae60;
+  --bg:      #0a1a33;
+  --surface: #11264a;
+  --card:    #15305a;
+  --border:  #23457a;
+  --border-l:#365f9e;
+  --text:    #dce7f5;
+  --muted:   #7a9bc2;
+  --navy:    #3a5ea8;
+  --navy-l:  #5b83cf;
+  --moss:    #4fa55e;
+  --brass:   #d9b441;
+  --green:   var(--moss);
   --red:     #e74c3c;
   --yellow:  #f1c40f;
   --orange:  #e67e22;
-  --blue:    #2980b9;
-  --faint:   #6b92b844;
+  --blue:    var(--navy);
+  --faint:   #1a3863;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono: 'DM Mono', 'Courier New', monospace;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,.18);
-  --shadow-md: 0 2px 8px rgba(0,0,0,.22);
-  --shadow-lg: 0 8px 30px rgba(0,0,0,.35);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.22);
+  --shadow-md: 0 2px 10px rgba(0,0,0,.28);
+  --shadow-lg: 0 10px 32px rgba(0,0,0,.40);
   --radius-sm: 8px;
   --radius-md: 10px;
   --radius-lg: 14px;
@@ -485,10 +488,10 @@ function renderDutyPills() {
   if (!el || !_staffStatus) { if (el) el.innerHTML = ''; return; }
   var IS = lang() === 'IS';
   var bst = 'display:inline-flex;align-items:center;gap:4px;padding:4px 12px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;white-space:nowrap;';
-  var dc  = _staffStatus.onDuty      ? '#27ae60' : '#e74c3c';
-  var bc  = _staffStatus.supportBoat ? '#27ae60' : '#e74c3c';
-  var dbg = _staffStatus.onDuty      ? '#27ae6015;border-color:#27ae6040' : '#e74c3c15;border-color:#e74c3c40';
-  var bbg = _staffStatus.supportBoat ? '#27ae6015;border-color:#27ae6040' : '#e74c3c15;border-color:#e74c3c40';
+  var dc  = _staffStatus.onDuty      ? 'var(--moss)' : 'var(--red)';
+  var bc  = _staffStatus.supportBoat ? 'var(--moss)' : 'var(--red)';
+  var dbg = _staffStatus.onDuty      ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
+  var bbg = _staffStatus.supportBoat ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
   var dtx = IS ? (_staffStatus.onDuty      ? 'Starfsmaður á vakt' : 'Enginn starfsmaður')
                : (_staffStatus.onDuty      ? 'Staff on duty'      : 'No staff on duty');
   var btx = IS ? (_staffStatus.supportBoat ? 'Björgunarbátur á sjó' : 'Enginn björgunarbátur')

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -328,7 +328,7 @@ function renderBoatCard(boat, opts) {
 
   // Badge
   const badgeMap = {
-    avail:   { text:s("fleet.badgeAvail"),   style:"color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111" },
+    avail:   { text:s("fleet.badgeAvail"),   style:"color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)" },
     out:     { text:s("fleet.badgeOut"),      style:"color:var(--brass);border-color:var(--brass)55;background:var(--brass)11" },
     overdue: { text:s("fleet.badgeOverdue"),  style:"color:var(--red);border-color:var(--red)55;background:var(--red)11" },
     oos:     { text:s("fleet.badgeOos"),      style:"color:var(--muted);border-color:var(--border);background:var(--surface)" },
@@ -387,7 +387,7 @@ function renderBoatCard(boat, opts) {
   } else if (activeRes) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeChartered"))}</span>`;
   } else if (controlled && userCanAccess && !opts.staffView) {
-    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111;margin-left:4px">${_besc(s("fleet.badgeAuthorized"))}</span>`;
+    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent);margin-left:4px">${_besc(s("fleet.badgeAuthorized"))}</span>`;
   } else if (priv) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--muted);border-color:var(--border);background:var(--surface);margin-left:4px">${_besc(s("fleet.badgePrivate"))}</span>`;
   }
@@ -449,7 +449,7 @@ function renderCheckoutCard(co, opts) {
   let topBadge = "";
   if (!staffView) {
     if      (overdue) topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--red);border-color:var(--red)55;background:var(--red)11">${_besc(s("fleet.badgeOverdue"))}</span>`;
-    else if (isMe)    topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111">${_besc(s("fleet.badgeYours"))}</span>`;
+    else if (isMe)    topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)">${_besc(s("fleet.badgeYours"))}</span>`;
     else              topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11">${_besc(s("fleet.badgeOut"))}</span>`;
   } else if (overdue) {
     topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--red);border-color:var(--red)55;background:var(--red)11">⚠️ ${_besc(s("fleet.badgeOverdue"))}</span>`;

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -109,7 +109,7 @@ function tripCard(t){
   const guestLabel = s('tc.guest');
   const guestBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:2px">'+guestLabel+'</span>';
   const studentLabel = s('tc.student');
-  const studentBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid #2e86c155;background:#2e86c111;color:#2e86c1;margin-left:2px">'+studentLabel+'</span>';
+  const studentBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid color-mix(in srgb, var(--navy-l) 33%, transparent);background:color-mix(in srgb, var(--navy-l) 8%, transparent);color:var(--navy-l);margin-left:2px">'+studentLabel+'</span>';
   const skipperLabel = s('tc.skipper');
   const skipperBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:2px">'+skipperLabel+'</span>';
   const pendingTag = `<span class="conf-status pending" style="font-size:9px;padding:1px 6px">${s('tc.pending')}</span>`;
@@ -356,10 +356,10 @@ function tripCard(t){
           <span class="trip-badge ${isSki?'badge-skipper':'badge-crew'}">${isSki?s('tc.skipper'):s('tc.crew')}</span>
           ${helmPlainNames.length?`<span class="trip-badge badge-helm">⎈ ${(()=>{const _ini=n=>n.split(/\s+/).filter(t=>t&&t!==t.toLowerCase()).map(t=>t.replace(/-/g,'').charAt(0)).join('').toUpperCase();const _memberIni=h=>{const m=allMembers.find(x=>x.kennitala&&String(x.kennitala)===h.kt);return (m&&m.initials)?m.initials:_ini(h.name);};return helmPlainNames.map(h=>h.kt===String(user.kennitala)?s('tc.me'):_memberIni(h)).sort((a,b)=>a===s('tc.me')?-1:b===s('tc.me')?1:a.localeCompare(b,'is')).map(n=>esc(n)).join(', ')})()}</span>`:''}
           ${t.nonClub&&t.nonClub!=='false'?`<span class="trip-badge" style="background:var(--surface);border:1px solid var(--border);font-size:9px">${s('tc.nonClub')}</span>`:''}
-          ${(t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)))?`<span class="trip-badge" style="background:#2e86c111;border:1px solid #2e86c155;color:#2e86c1;font-size:9px">${s('tc.student')}</span>`:''}
+          ${(t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)))?`<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 8%, transparent);border:1px solid color-mix(in srgb, var(--navy-l) 33%, transparent);color:var(--navy-l);font-size:9px">${s('tc.student')}</span>`:''}
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':'' }
           ${!isVer && isSki && (pendingCrewConfs.length||pendingHelmConfs.length||pendingStudentConfs.length||pendingCrewIn.length||pendingHelmIn.length||pendingStudentIn.length) ? '<span class="trip-badge" style="background:var(--yellow)11;border:1px solid var(--yellow)55;color:var(--yellow);font-size:9px">⏳ '+s('tc.pending')+'</span>' : ''}
-          ${(t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer ? '<span class="trip-badge" style="background:#1a2a3a;border:1px solid #2e86c1;color:#2e86c1;font-size:9px">⏳ '+s('tc.verificationPending')+'</span>' : ''}
+          ${(t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer ? '<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 12%, transparent);border:1px solid var(--navy-l);color:var(--navy-l);font-size:9px">⏳ '+s('tc.verificationPending')+'</span>' : ''}
           <span>${esc(dur)}</span>
           ${_distNm?`<span>${esc(_distNm)} nm</span>`:''}
           ${windLine?'<span class="trip-wind">'+windLine+'</span>':''}

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -63,7 +63,7 @@ function maintRenderCardCompact(r) {
   const borderCol = SEV_CSS[r.severity] || 'var(--green)';
   const catIcon   = CAT_ICON[r.category] || '⚙️';
   const oosTag    = boolVal(r.markOos) && r.category==='boat' && !boolVal(r.resolved)
-    ? '<span style="background:#e74c3c;color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;white-space:nowrap;flex-shrink:0">'+s('maint.oosTag')+'</span>' : '';
+    ? '<span style="background:var(--red);color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;white-space:nowrap;flex-shrink:0">'+s('maint.oosTag')+'</span>' : '';
   const saumaTag = boolVal(r.saumaklubbur)
     ? '<span style="font-size:10px;background:var(--brass)22;color:var(--brass);border:1px solid var(--brass)44;padding:1px 6px;border-radius:10px;white-space:nowrap;flex-shrink:0">🧵</span>' : '';
   const subject = r.category==='boat' ? esc(r.boatName||r.boatId||'') : '';
@@ -154,7 +154,7 @@ function maintOpenDetail(r, currentUser) {
 
     // OOS: "OOS" when active, "In service" when inactive
     const oosBtn = (r.category==='boat' && !resolved)
-      ? `<button id="mdOosBtn" style="padding:3px 11px;border-radius:14px;border:none;font-size:11px;font-weight:600;cursor:pointer;background:${isOos?'#e74c3c':'var(--surface)'};color:${isOos?'#fff':'var(--muted)'};">${isOos?s('maint.oosTag'):s('maint.inService')}</button>`
+      ? `<button id="mdOosBtn" style="padding:3px 11px;border-radius:14px;border:none;font-size:11px;font-weight:600;cursor:pointer;background:${isOos?'var(--red)':'var(--surface)'};color:${isOos?'#fff':'var(--muted)'};">${isOos?s('maint.oosTag'):s('maint.inService')}</button>`
       : '';
 
     // Comments: poster · timestamp on top, then text body
@@ -222,7 +222,7 @@ function maintOpenDetail(r, currentUser) {
       </div>
       ${isSauma && !boolVal(r.approved) ? `<div style="margin-bottom:10px;padding:8px 12px;border-radius:6px;background:var(--brass)11;border:1px solid var(--brass)44;font-size:12px;color:var(--brass)">⏳ ${s('maint.pendingReview')}<button id="mdApproveBtn" class="btn btn-primary" style="font-size:11px;padding:4px 14px;margin-left:12px">${s('maint.approveBtn')}</button></div>` : ''}
       <div class="req-actions" style="margin-top:10px;display:flex;gap:8px;align-items:center">
-        <button id="mdDeleteBtn" class="btn btn-secondary" style="font-size:12px;color:#e74c3c">${s('maint.deleteBtn')}</button>
+        <button id="mdDeleteBtn" class="btn btn-secondary" style="font-size:12px;color:var(--red)">${s('maint.deleteBtn')}</button>
         ${typeof window.maintOpenEdit === 'function' ? `<button id="mdEditBtn" class="btn btn-secondary" style="font-size:12px;padding:7px 14px">${s('btn.edit')}</button>` : ''}
         ${isSauma && boolVal(r.approved) ? `<button id="mdHoldBtn" class="btn btn-secondary" style="font-size:12px;padding:7px 14px;margin-left:auto">${isOnHold ? '▶ '+s('maint.resumeBtn') : '⏸ '+s('maint.putOnHold')}</button>` : ''}
         <button id="mdResolveBtn" class="btn btn-primary" style="font-size:12px;padding:7px 16px${isSauma && boolVal(r.approved) ? '' : ';margin-left:auto'}">${isSauma ? s('maint.markCompleted') : s('maint.markResolved2')}</button>

--- a/shared/style.css
+++ b/shared/style.css
@@ -46,78 +46,96 @@
 
 :root,
 [data-theme="dark"] {
-  --bg:       #0b1f38;
-  --surface:  #0f2847;
-  --card:     #132d50;
-  --border:   #1e3f6e;
-  --border-l: #2a5490;
-  --text:     #d6e4f0;
-  --muted:    #6b92b8;
-  --faint:    #2a4a6e;
-  --brass:    #d4af37;
+  --bg:       #0a1a33;
+  --surface:  #11264a;
+  --card:     #15305a;
+  --border:   #23457a;
+  --border-l: #365f9e;
+  --text:     #dce7f5;
+  --muted:    #7a9bc2;
+  --faint:    #1a3863;
+  --navy:     #3a5ea8;
+  --navy-d:   #274484;
+  --navy-l:   #5b83cf;
+  --moss:     #4fa55e;
+  --moss-d:   #34783b;
+  --moss-l:   #6fc27f;
+  --brass:    #d9b441;
   --brass-d:  #b8941f;
   --brass-l:  #e8c84a;
-  --green:    #27ae60;
+  --green:    var(--moss);
   --yellow:   #f1c40f;
   --orange:   #e67e22;
   --red:      #e74c3c;
-  --blue:     #2980b9;
+  --blue:     var(--navy);
   --purple:   #a78bfa;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono: 'DM Mono', 'Courier New', monospace;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,.18);
-  --shadow-md: 0 2px 8px rgba(0,0,0,.22);
-  --shadow-lg: 0 8px 30px rgba(0,0,0,.35);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.22);
+  --shadow-md: 0 2px 10px rgba(0,0,0,.28);
+  --shadow-lg: 0 10px 32px rgba(0,0,0,.40);
   --radius-sm: 8px;
   --radius-md: 10px;
   --radius-lg: 14px;
 }
 
 [data-theme="light"] {
-  --bg:       #f0f4f8;
+  --bg:       #f6f4ee;
   --surface:  #ffffff;
   --card:     #ffffff;
-  --border:   #c8d6e5;
-  --border-l: #a0b4c8;
-  --text:     #1a2a3a;
-  --muted:    #5a7a96;
-  --faint:    #dce4ec;
-  --brass:    #b8941f;
-  --brass-d:  #a07e10;
-  --brass-l:  #d4af37;
-  --green:    #1e8e4e;
-  --yellow:   #d4a80c;
-  --orange:   #c46a1a;
-  --red:      #c53030;
-  --blue:     #2070a8;
-  --purple:   #7c5fcf;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,.08);
-  --shadow-md: 0 2px 8px rgba(0,0,0,.1);
-  --shadow-lg: 0 8px 30px rgba(0,0,0,.15);
+  --border:   #c9d3e4;
+  --border-l: #9fb0cc;
+  --text:     #0f2045;
+  --muted:    #5b6e8a;
+  --faint:    #eceff5;
+  --navy:     #274484;
+  --navy-d:   #1b3168;
+  --navy-l:   #3a5ea8;
+  --moss:     #34783b;
+  --moss-d:   #265a2c;
+  --moss-l:   #4a9152;
+  --brass:    #a07b10;
+  --brass-d:  #7d5f08;
+  --brass-l:  #c99820;
+  --green:    var(--moss);
+  --yellow:   #c98a0c;
+  --orange:   #b85a14;
+  --red:      #b52a2a;
+  --blue:     var(--navy);
+  --purple:   #6a4fb8;
+  --shadow-sm: 0 1px 3px rgba(15,32,69,.08);
+  --shadow-md: 0 2px 10px rgba(15,32,69,.10);
+  --shadow-lg: 0 12px 32px rgba(15,32,69,.16);
 }
 
 @media (prefers-color-scheme: light) {
   [data-theme="auto"] {
-    --bg:       #f0f4f8;
+    --bg:       #f6f4ee;
     --surface:  #ffffff;
     --card:     #ffffff;
-    --border:   #c8d6e5;
-    --border-l: #a0b4c8;
-    --text:     #1a2a3a;
-    --muted:    #5a7a96;
-    --faint:    #dce4ec;
-    --brass:    #b8941f;
-    --brass-d:  #a07e10;
-    --brass-l:  #d4af37;
-    --green:    #1e8e4e;
-    --yellow:   #d4a80c;
-    --orange:   #c46a1a;
-    --red:      #c53030;
-    --blue:     #2070a8;
-    --purple:   #7c5fcf;
-    --shadow-sm: 0 1px 3px rgba(0,0,0,.08);
-    --shadow-md: 0 2px 8px rgba(0,0,0,.1);
-    --shadow-lg: 0 8px 30px rgba(0,0,0,.15);
+    --border:   #c9d3e4;
+    --border-l: #9fb0cc;
+    --text:     #0f2045;
+    --muted:    #5b6e8a;
+    --faint:    #eceff5;
+    --navy:     #274484;
+    --navy-d:   #1b3168;
+    --navy-l:   #3a5ea8;
+    --moss:     #34783b;
+    --moss-d:   #265a2c;
+    --moss-l:   #4a9152;
+    --brass:    #a07b10;
+    --brass-d:  #7d5f08;
+    --brass-l:  #c99820;
+    --green:    var(--moss);
+    --yellow:   #c98a0c;
+    --orange:   #b85a14;
+    --red:      #b52a2a;
+    --blue:     var(--navy);
+    --purple:   #6a4fb8;
+    --shadow-sm: 0 1px 3px rgba(15,32,69,.08);
+    --shadow-md: 0 2px 10px rgba(15,32,69,.10);
+    --shadow-lg: 0 12px 32px rgba(15,32,69,.16);
   }
 }
 
@@ -295,8 +313,8 @@ input[type=number]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
 input[type=number]{-moz-appearance:textfield}
 
 input:focus, select:focus, textarea:focus {
-  border-color: var(--brass);
-  box-shadow: 0 0 0 3px rgba(212,175,55,.15);
+  border-color: var(--navy);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--navy) 18%, transparent);
 }
 
 textarea { min-height: 70px; }
@@ -323,14 +341,14 @@ textarea { min-height: 70px; }
 }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
 
-.btn-primary  { background: var(--brass);   color: #0b1f38; }
-.btn-primary:hover:not(:disabled)  { background: var(--brass-l); box-shadow: 0 2px 8px rgba(212,175,55,.35); transform: translateY(-1px); }
+.btn-primary  { background: var(--moss);   color: #ffffff; }
+.btn-primary:hover:not(:disabled)  { background: var(--moss-l); box-shadow: 0 2px 8px color-mix(in srgb, var(--brass) 35%, transparent); transform: translateY(-1px); }
 
 .btn-secondary { background: var(--faint);  color: var(--text); }
 .btn-secondary:hover:not(:disabled) { background: var(--border); box-shadow: var(--shadow-sm); }
 
 .btn-danger   { background: var(--red);     color: #fff; }
-.btn-danger:hover:not(:disabled)   { opacity: .85; box-shadow: 0 2px 8px rgba(231,76,60,.3); }
+.btn-danger:hover:not(:disabled)   { opacity: .85; box-shadow: 0 2px 8px color-mix(in srgb, var(--red) 30%, transparent); }
 
 .btn-ghost {
   background: none;
@@ -343,8 +361,8 @@ textarea { min-height: 70px; }
   cursor: pointer;
   transition: color .2s, border-color .2s, background .2s;
 }
-.btn-ghost:hover        { color: var(--brass); border-color: var(--brass); background: var(--brass)08; }
-.btn-ghost.danger:hover { color: var(--red);   border-color: var(--red); background: var(--red)08; }
+.btn-ghost:hover        { color: var(--navy); border-color: var(--navy); background: color-mix(in srgb, var(--navy) 8%, transparent); }
+.btn-ghost.danger:hover { color: var(--red);  border-color: var(--red);  background: color-mix(in srgb, var(--red) 8%, transparent); }
 
 .btn-row { display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap; }
 .btn-row .btn { flex: 1; text-align: center; }
@@ -361,12 +379,12 @@ textarea { min-height: 70px; }
   border-radius: 20px;
   border: 1px solid;
 }
-.badge-green  { color: var(--green);  border-color: #27ae6050; background: #27ae6012; }
-.badge-yellow { color: var(--yellow); border-color: #f1c40f50; background: #f1c40f12; }
-.badge-orange { color: var(--orange); border-color: #e67e2250; background: #e67e2212; }
-.badge-red    { color: var(--red);    border-color: #e74c3c50; background: #e74c3c12; }
-.badge-blue   { color: var(--blue);   border-color: #2980b950; background: #2980b912; }
-.badge-brass  { color: var(--brass);  border-color: #d4af3750; background: #d4af3712; }
+.badge-green  { color: var(--green);  border-color: color-mix(in srgb, var(--green)  30%, transparent); background: color-mix(in srgb, var(--green)  8%, transparent); }
+.badge-yellow { color: var(--yellow); border-color: color-mix(in srgb, var(--yellow) 30%, transparent); background: color-mix(in srgb, var(--yellow) 8%, transparent); }
+.badge-orange { color: var(--orange); border-color: color-mix(in srgb, var(--orange) 30%, transparent); background: color-mix(in srgb, var(--orange) 8%, transparent); }
+.badge-red    { color: var(--red);    border-color: color-mix(in srgb, var(--red)    30%, transparent); background: color-mix(in srgb, var(--red)    8%, transparent); }
+.badge-blue   { color: var(--blue);   border-color: color-mix(in srgb, var(--blue)   30%, transparent); background: color-mix(in srgb, var(--blue)   8%, transparent); }
+.badge-brass  { color: var(--brass);  border-color: color-mix(in srgb, var(--brass)  30%, transparent); background: color-mix(in srgb, var(--brass)  8%, transparent); }
 .badge-muted  { color: var(--muted);  border-color: var(--border); background: var(--faint); }
 
 /* ── TABLE ────────────────────────────────────────────────────────────────────── */
@@ -388,7 +406,7 @@ textarea { min-height: 70px; }
   vertical-align: middle;
 }
 .tbl tr:last-child td { border-bottom: none; }
-.tbl tr:hover td      { background: #ffffff0a; }
+.tbl tr:hover td      { background: var(--faint); }
 .tbl-wrap { overflow-x: auto; border-radius: var(--radius-md); border: 1px solid var(--border); box-shadow: var(--shadow-sm); }
 
 /* ── MESSAGES ─────────────────────────────────────────────────────────────────── */
@@ -399,9 +417,9 @@ textarea { min-height: 70px; }
   font-size: 13px;
   margin-top: 10px;
 }
-.msg-ok   { background: #27ae6018; color: var(--green); border: 1px solid #27ae6040; }
-.msg-err  { background: #e74c3c18; color: var(--red);   border: 1px solid #e74c3c40; }
-.msg-warn { background: #e67e2218; color: var(--orange); border: 1px solid #e67e2240; }
+.msg-ok   { background: color-mix(in srgb, var(--green)  10%, transparent); color: var(--green);  border: 1px solid color-mix(in srgb, var(--green)  25%, transparent); }
+.msg-err  { background: color-mix(in srgb, var(--red)    10%, transparent); color: var(--red);    border: 1px solid color-mix(in srgb, var(--red)    25%, transparent); }
+.msg-warn { background: color-mix(in srgb, var(--orange) 10%, transparent); color: var(--orange); border: 1px solid color-mix(in srgb, var(--orange) 25%, transparent); }
 
 /* ── MODAL ────────────────────────────────────────────────────────────────────── */
 
@@ -463,7 +481,7 @@ textarea { min-height: 70px; }
   display: inline-block;
   width: 14px; height: 14px;
   border: 2px solid var(--border);
-  border-top-color: var(--brass);
+  border-top-color: var(--moss);
   border-radius: 50%;
   animation: spin .7s linear infinite;
   vertical-align: middle;
@@ -488,7 +506,7 @@ textarea { min-height: 70px; }
 .check-row:last-child { border-bottom: none; }
 .check-row input[type=checkbox] {
   width: 16px; height: 16px;
-  accent-color: var(--brass);
+  accent-color: var(--moss);
   flex-shrink: 0;
 }
 
@@ -709,8 +727,8 @@ textarea { min-height: 70px; }
 
 .pr-tabs{display:flex;gap:4px;margin-bottom:16px;border-bottom:1px solid var(--border);padding-bottom:10px;flex-wrap:wrap}
 .pr-tab{padding:6px 16px;border:1px solid var(--border);border-radius:16px;background:none;cursor:pointer;font-size:12px;font-weight:600;color:var(--muted);font-family:inherit;transition:all .2s}
-.pr-tab.active{background:var(--brass);color:#fff;border-color:var(--brass)}
-.pr-tab:hover:not(.active){border-color:var(--brass);color:var(--brass)}
+.pr-tab.active{background:var(--navy);color:#fff;border-color:var(--navy)}
+.pr-tab:hover:not(.active){border-color:var(--navy);color:var(--navy)}
 .emp-row{display:flex;align-items:center;gap:12px;padding:10px 0;border-bottom:1px solid var(--border)44;flex-wrap:wrap}
 .emp-row:last-child{border-bottom:none}
 .emp-name{font-weight:600;font-size:13px;flex:1;min-width:120px}
@@ -722,7 +740,7 @@ textarea { min-height: 70px; }
 .emp-fields label{font-size:10px}
 .cal-nav{display:flex;align-items:center;gap:12px;margin-bottom:12px}
 .cal-nav button{background:none;border:1px solid var(--border);border-radius:var(--radius-sm);padding:4px 12px;cursor:pointer;font-size:16px;color:var(--text);line-height:1.2;font-family:inherit;transition:color .2s,border-color .2s}
-.cal-nav button:hover{border-color:var(--brass);color:var(--brass)}
+.cal-nav button:hover{border-color:var(--navy);color:var(--navy)}
 .cal-month{font-weight:700;font-size:15px;min-width:160px;text-align:center}
 .cal-dows{display:grid;grid-template-columns:repeat(7,1fr);gap:2px;margin-bottom:2px}
 .cal-dow{text-align:center;font-size:10px;font-weight:700;color:var(--muted);padding:4px 0;letter-spacing:.5px}
@@ -738,7 +756,7 @@ textarea { min-height: 70px; }
 .cal-more{font-size:9px;color:var(--muted);margin-top:1px;padding-left:2px}
 .view-toggle{display:flex;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden}
 .view-toggle button{background:none;border:none;padding:5px 14px;cursor:pointer;font-size:12px;font-weight:600;color:var(--muted);font-family:inherit;transition:all .2s}
-.view-toggle button.active{background:var(--brass);color:#fff}
+.view-toggle button.active{background:var(--navy);color:#fff}
 .ts-table{width:100%;border-collapse:collapse;font-size:12px;margin-bottom:22px}
 .ts-table th{text-align:left;padding:5px 8px;font-size:10px;color:var(--muted);border-bottom:2px solid var(--border);font-weight:600;letter-spacing:.4px}
 .ts-table td{padding:5px 8px;border-bottom:1px solid var(--border)44;vertical-align:middle}
@@ -1137,6 +1155,6 @@ textarea { min-height: 70px; }
   color:var(--text); font-family:inherit; font-size:10px; cursor:pointer;
   transition:border-color .15s,background .15s; white-space:nowrap; }
 .vp-btn:hover { border-color:var(--brass); }
-.vp-btn.signed-up { background:var(--brass); color:#000; border-color:var(--brass); }
+.vp-btn.signed-up { background:var(--moss); color:#fff; border-color:var(--moss); }
 .vp-role-note { font-size:9px; color:var(--muted); font-style:italic; }
 .vp-role-note.full { color:var(--red); font-style:normal; font-weight:500; }

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -12,7 +12,7 @@
 .trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
 .badge-skipper{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
 .badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}
-.badge-verified{color:#2ecc71;border-color:#2ecc7155;background:#2ecc7111}
+.badge-verified{color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)}
 .badge-helm{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
 .trip-arrow{padding:10px 14px 10px 4px;display:flex;align-items:center;color:var(--muted);font-size:11px;transition:transform .2s;flex-shrink:0}
 .trip-card.open .trip-arrow{transform:rotate(180deg)}
@@ -33,9 +33,9 @@
 .exp-section .trip-expand-grid{border-top:none;padding-top:2px;margin-top:0}
 .exp-boat{background:var(--card)}
 .exp-logistics{background:var(--card)}
-.exp-weather{background:rgba(41,128,185,.08)}
+.exp-weather{background:color-mix(in srgb, var(--navy) 8%, transparent)}
 .exp-weather .trip-expand-grid{padding-top:4px}
-.exp-notes{background:rgba(255,255,255,.02)}
+.exp-notes{background:var(--faint)}
 .exp-section-hdr{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px;font-weight:500}
 .exp-section-hdr.expandable{cursor:pointer;display:flex;align-items:center;gap:4px}
 .exp-section-hdr.expandable:hover{color:var(--brass)}
@@ -59,7 +59,7 @@
 .upload-thumb-wrap{position:relative;display:inline-block;width:72px;height:72px;flex-shrink:0}
 .upload-thumb-wrap .photo-thumb{width:72px;height:72px}
 .upload-delete-btn{position:absolute;top:-4px;right:-4px;width:20px;height:20px;border-radius:50%;background:var(--red);border:2px solid var(--bg);color:#fff;font-size:12px;line-height:16px;text-align:center;cursor:pointer;z-index:2;display:flex;align-items:center;justify-content:center;padding:0}
-.upload-delete-btn:hover{background:#c0392b}
+.upload-delete-btn:hover{background:var(--red);filter:brightness(.85)}
 .photo-sharing-badge{font-size:8px;letter-spacing:.4px;padding:1px 5px;border-radius:4px;text-transform:uppercase;margin-left:4px}
 .photo-sharing-badge.shared{color:var(--green);border:1px solid var(--green)55;background:var(--green)11}
 .photo-sharing-badge.private{color:var(--muted);border:1px solid var(--border);background:var(--surface)}

--- a/shared/weather.js
+++ b/shared/weather.js
@@ -97,25 +97,25 @@ const SCORE_CONFIG = {
   // would be redundant (issue #376).
   // ─────────────────────────────────────────────────────────────────────────────
   flags: {
-    green:  { color:'#27ae60', bg:'#27ae6018', border:'#27ae6044', icon:'🟢',
+    green:  { color:'var(--green)', bg:'color-mix(in srgb, var(--green) 10%, transparent)', border:'color-mix(in srgb, var(--green) 27%, transparent)', icon:'🟢',
               advice:'Good conditions  —  open to all qualified members.',
               adviceIS:'Góðar aðstæður — opið öllum hæfum félögum.',
               description:'Conditions are suitable for sailing. All qualified members may use boats according to their credential level.',
               descriptionIS:'Aðstæður eru hæfar fyrir siglingar. Allir hæfir félagar mega taka báta út samkvæmt skírteinastigi.' },
-    yellow: { color:'#f1c40f', bg:'#f1c40f18', border:'#f1c40f44', icon:'🟡',
+    yellow: { color:'var(--yellow)', bg:'color-mix(in srgb, var(--yellow) 10%, transparent)', border:'color-mix(in srgb, var(--yellow) 27%, transparent)', icon:'🟡',
               advice:'Marginal  —  experienced sailors only.',
               adviceIS:'Jaðaraðstæður — aðeins reyndir siglingar.',
               description:'Conditions are marginal. Only experienced sailors with strong boat-handling skills should go out. Ensure someone ashore knows your plans and expected return time.',
               descriptionIS:'Aðstæður eru á mörkum. Aðeins reyndir siglingar áttu að fara út. Gerið ráð fyrir óvæntum breytingum og tryggist að einhver á landi viti af áætlunum ykkar.' },
-    orange: { color:'#e67e22', bg:'#e67e2218', border:'#e67e2244', icon:'🟠',
+    orange: { color:'var(--orange)', bg:'color-mix(in srgb, var(--orange) 10%, transparent)', border:'color-mix(in srgb, var(--orange) 27%, transparent)', icon:'🟠',
               advice:'Difficult  —  keelboats only; staff auth required for dinghies.',
               adviceIS:'Erfiðar aðstæður — kjólbátar einungis; starfsmaður ¾arfnast heimildar.' },
-    red:    { color:'#e74c3c', bg:'#e74c3c18', border:'#e74c3c44', icon:'🔴',
+    red:    { color:'var(--red)', bg:'color-mix(in srgb, var(--red) 10%, transparent)', border:'color-mix(in srgb, var(--red) 27%, transparent)', icon:'🔴',
               advice:'No self-service sailing  —  staff must approve each checkout.',
               adviceIS:'Engin sjálfsafgreiðsla — starfsmaður verður að samþykkja hverja útskráningu.',
               description:'Hazardous conditions. No self-service sailing. Staff must personally assess and authorise every checkout. Experienced keelboat sailors only with direct staff supervision.',
               descriptionIS:'Hættuleg aðstæður. Engin sjálfsafgreiðsla. Starfsmaður verður að meta og samþykkja hverja útlágingu persónulega.' },
-    black:  { color:'#999',    bg:'#99999918', border:'#99999944', icon:'⚫️',
+    black:  { color:'var(--muted)', bg:'color-mix(in srgb, var(--muted) 10%, transparent)', border:'color-mix(in srgb, var(--muted) 27%, transparent)', icon:'⚫️',
               advice:'Water closed  —  all sailing suspended.',
               adviceIS:'Sjór lokaður — allar siglingar stöðvaðar.',
               description:'The water is closed to all sailing. All boats must remain ashore or return to harbour immediately. Check back later for updated conditions.',
@@ -252,8 +252,8 @@ function wxScoreFlag(ws, wDir, waveH, airT, sst, wg, visKey) {
 function wxStaffStatusHtml(status) {
   if (!status) return '';
   const badges = [];
-  if (status.onDuty)      badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:#27ae6018;border:1px solid #27ae6044;color:#27ae60;border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.lifebuoy+s('wx.staffOnDuty')+'</span>');
-  if (status.supportBoat) badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:#2980b918;border:1px solid #2980b944;color:#5dade2;border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.ship+s('wx.supportBoatOut')+'</span>');
+  if (status.onDuty)      badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:color-mix(in srgb, var(--moss) 10%, transparent);border:1px solid color-mix(in srgb, var(--moss) 27%, transparent);color:var(--moss);border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.lifebuoy+s('wx.staffOnDuty')+'</span>');
+  if (status.supportBoat) badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:color-mix(in srgb, var(--navy) 10%, transparent);border:1px solid color-mix(in srgb, var(--navy) 27%, transparent);color:var(--navy);border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.ship+s('wx.supportBoatOut')+'</span>');
   if (!badges.length) return '';
   let ago = '';
   if (status.updatedAt) {
@@ -281,7 +281,7 @@ function wxFlagDetailHtml(result, staffStatus, lang) {
     { pct: Math.round(t.black /maxScore*100), key:'black'  },
   ];
   const markerHtml = markers.map(m =>
-    '<div style="position:absolute;left:'+m.pct+'%;top:0;bottom:0;width:1px;background:'+SCORE_CONFIG.flags[m.key].color+'55"></div>'
+    '<div style="position:absolute;left:'+m.pct+'%;top:0;bottom:0;width:1px;background:color-mix(in srgb, '+SCORE_CONFIG.flags[m.key].color+' 33%, transparent)"></div>'
   ).join('');
   const barHtml =
     '<div style="position:relative;height:10px;background:var(--border);border-radius:5px;margin:12px 0 4px;overflow:hidden">'
@@ -308,10 +308,10 @@ function wxFlagDetailHtml(result, staffStatus, lang) {
   const _ssBadgesHtml = (() => {
     if (!staffStatus) return '';
     const bst   = 'display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;white-space:nowrap;margin-bottom:10px;';
-    const dCol  = staffStatus.onDuty      ? '#27ae60' : '#e74c3c';
-    const bCol  = staffStatus.supportBoat ? '#27ae60' : '#e74c3c';
-    const dBg   = staffStatus.onDuty      ? '#27ae6015;border-color:#27ae6040' : '#e74c3c15;border-color:#e74c3c40';
-    const bBg   = staffStatus.supportBoat ? '#27ae6015;border-color:#27ae6040' : '#e74c3c15;border-color:#e74c3c40';
+    const dCol  = staffStatus.onDuty      ? 'var(--moss)' : 'var(--red)';
+    const bCol  = staffStatus.supportBoat ? 'var(--moss)' : 'var(--red)';
+    const dBg   = staffStatus.onDuty      ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
+    const bBg   = staffStatus.supportBoat ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
     const dTx   = s(staffStatus.onDuty      ? 'wx.staffOnDuty'    : 'wx.noStaffOnDuty');
     const bTx   = s(staffStatus.supportBoat ? 'wx.supportBoatOut' : 'wx.noSupportBoat');
     return '<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px">'
@@ -553,12 +553,12 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
           </div>
           <div class="wx-cell" style="border-top:1px solid var(--border);padding-top:8px;margin-top:2px">
             <div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:4px">${s('wx.waves')}</div>
-            <div style="font-size:17px;color:#4a9eca">${waveH != null ? waveH.toFixed(1)+'m' : ''}</div>
+            <div style="font-size:17px;color:var(--navy-l)">${waveH != null ? waveH.toFixed(1)+'m' : ''}</div>
             <div style="font-size:10px;color:var(--muted)">${mc?.wave_direction != null ? wxDirArrow(mc.wave_direction)+' '+wxDirLabel(mc.wave_direction) : ''}</div>
           </div>
           <div class="wx-cell" style="border-top:1px solid var(--border);padding-top:8px;margin-top:2px">
             <div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:4px">${s('wx.sea')}</div>
-            <div style="font-size:17px;color:#4a9eca">${sst != null ? sst.toFixed(1)+'°C' : ''}</div>
+            <div style="font-size:17px;color:var(--navy-l)">${sst != null ? sst.toFixed(1)+'°C' : ''}</div>
             <div style="font-size:10px;color:var(--muted)">${s('wx.surface')}</div>
           </div>
           <div class="wx-cell" style="border-top:1px solid var(--border);padding-top:8px;margin-top:2px">
@@ -612,10 +612,10 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
         const _ss = typeof getStaffStatus === 'function' ? getStaffStatus() : null;
         if (!_ss) { container.innerHTML = ''; return; }
         const _bst = 'display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;white-space:nowrap;';
-        const _dc  = _ss.onDuty      ? '#27ae60' : '#e74c3c';
-        const _bc  = _ss.supportBoat ? '#27ae60' : '#e74c3c';
-        const _dbg = _ss.onDuty      ? '#27ae6015;border-color:#27ae6040' : '#e74c3c15;border-color:#e74c3c40';
-        const _bbg = _ss.supportBoat ? '#27ae6015;border-color:#27ae6040' : '#e74c3c15;border-color:#e74c3c40';
+        const _dc  = _ss.onDuty      ? 'var(--moss)' : 'var(--red)';
+        const _bc  = _ss.supportBoat ? 'var(--moss)' : 'var(--red)';
+        const _dbg = _ss.onDuty      ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
+        const _bbg = _ss.supportBoat ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
         const _dtx = s(_ss.onDuty      ? 'wx.staffOnDuty'    : 'wx.noStaffOnDuty');
         const _btx = s(_ss.supportBoat ? 'wx.supportBoatOut' : 'wx.noSupportBoat');
         container.innerHTML =

--- a/staff/index.html
+++ b/staff/index.html
@@ -149,8 +149,8 @@
   padding:6px 14px; border:none; border-radius:var(--radius-sm); font-size:12px;
   font-weight:bold; cursor:pointer; font-family:inherit;
 }
-.ob-btn-checkin  { background:#27ae60; color:#fff; }
-.ob-btn-snooze   { background:#e67e22; color:#fff; }
+.ob-btn-checkin  { background:var(--moss); color:#fff; }
+.ob-btn-snooze   { background:var(--orange); color:#fff; }
 .ob-btn-silence  { background:#444; color:#ccc; }
 .ob-btn:disabled { opacity:0.5; cursor:default; }
 
@@ -161,7 +161,7 @@
   padding:8px 12px; cursor:pointer; border-radius:var(--radius-sm);
   background:var(--surface); transition:background .2s;
 }
-.fsb-header:hover { background:var(--surface2,#132233); }
+.fsb-header:hover { background:var(--faint); }
 .fsb-label { font-size:12px; color:var(--muted); min-width:80px; text-transform:uppercase; letter-spacing:.04em; }
 .fsb-bar-wrap { flex:1; height:6px; background:var(--border); border-radius:3px; overflow:hidden; }
 .fsb-bar { height:100%; background:var(--green); border-radius:3px; transition:width .3s; }
@@ -177,10 +177,10 @@
   border-radius:var(--radius-sm); padding:7px 10px; min-width:90px; border:1px solid transparent;
   font-size:12px; transition:all .2s;
 }
-.bc-boat-card.status-avail { background:#0d2e1a; border-color:var(--green); }
-.bc-boat-card.status-avail:hover { background:#143d22; transform:translateY(-1px); }
-.bc-boat-card.status-out { background:#1a1f0d; border-color:var(--brass,#c8a84b); }
-.bc-boat-card.status-overdue { background:#2e0d0d; border-color:var(--red); }
+.bc-boat-card.status-avail { background:color-mix(in srgb, var(--moss) 12%, transparent); border-color:var(--moss); }
+.bc-boat-card.status-avail:hover { background:color-mix(in srgb, var(--moss) 22%, transparent); transform:translateY(-1px); }
+.bc-boat-card.status-out { background:color-mix(in srgb, var(--brass) 12%, transparent); border-color:var(--brass); }
+.bc-boat-card.status-overdue { background:color-mix(in srgb, var(--red) 12%, transparent); border-color:var(--red); }
 .bc-boat-card.status-oos { background:var(--surface); border-color:var(--border); opacity:.5; }
 .bc-boat-name { font-weight:600; color:var(--text); margin-bottom:2px; }
 .bc-boat-status { font-size:11px; color:var(--muted); }
@@ -230,7 +230,7 @@
 .gm-activity-link{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;margin-bottom:10px}
 .gm-activity-link .link-label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;margin-bottom:6px}
 /* Group card in active checkouts */
-.bc-group-card{background:#0a1e2e;border:1px solid var(--border);border-left:4px solid #2e86c1;border-radius:var(--radius-md);padding:12px 14px;margin-bottom:8px;cursor:pointer;box-shadow:var(--shadow-sm)}
+.bc-group-card{background:color-mix(in srgb, var(--navy) 10%, transparent);border:1px solid var(--border);border-left:4px solid var(--navy);border-radius:var(--radius-md);padding:12px 14px;margin-bottom:8px;cursor:pointer;box-shadow:var(--shadow-sm)}
 .bc-group-card.overdue{border-color:var(--red);border-left-color:var(--red)}
 .gc-header{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:6px}
 .gc-boats{font-size:13px;font-weight:500;color:var(--text)}
@@ -251,8 +251,8 @@
 .guest-add-hint{font-size:10px;color:var(--brass);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
 .guest-add-hint:hover{background:var(--card)}
 
-#groupCheckOutBtn{background:#2e86c1;border-color:#2e86c1;color:#fff}
-#groupCheckOutBtn:hover{background:#1a6fa8;border-color:#1a6fa8}
+#groupCheckOutBtn{background:var(--navy);border-color:var(--navy);color:#fff}
+#groupCheckOutBtn:hover{background:var(--navy-d);border-color:var(--navy-d)}
 .dl-link-overlay{position:fixed;inset:0;background:#00000099;z-index:500;display:flex;align-items:flex-end;justify-content:center}
 .dl-link-overlay.hidden{display:none}
 .dl-link-sheet{background:var(--bg);border-radius:16px 16px 0 0;padding:20px 20px 36px;width:100%;max-width:680px;max-height:80vh;overflow-y:auto}
@@ -316,8 +316,8 @@
   <div id="staffStatusStrip" class="mb-12">
     <div class="section-label mb-8">DUTY STATUS</div>
     <div class="flex-center flex-wrap gap-8">
-      <button id="btnStaffOnDuty" onclick="toggleStaffStatus('onDuty')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:#e74c3c;color:#fff;">No staff on duty</button>
-      <button id="btnSupportBoat" onclick="toggleStaffStatus('supportBoat')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:#e74c3c;color:#fff;">No support boat</button>
+      <button id="btnStaffOnDuty" onclick="toggleStaffStatus('onDuty')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:var(--red);color:#fff;">No staff on duty</button>
+      <button id="btnSupportBoat" onclick="toggleStaffStatus('supportBoat')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:var(--red);color:#fff;">No support boat</button>
       <span id="staffStatusUpdated" class="text-xs text-muted"></span>
     </div>
   </div>
@@ -1527,8 +1527,8 @@ function renderStaffStatusStrip() {
   const upd     = document.getElementById('staffStatusUpdated');
   if (!btnDuty || !btnBoat) return;
   const base = 'display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;';
-  const on   = 'background:#27ae60;color:#fff;';
-  const off  = 'background:#e74c3c;color:#fff;';
+  const on   = 'background:var(--moss);color:#fff;';
+  const off  = 'background:var(--red);color:#fff;';
   btnDuty.setAttribute('style', base + (_staffStatus.onDuty      ? on : off));
   btnBoat.setAttribute('style', base + (_staffStatus.supportBoat ? on : off));
   btnDuty.innerHTML = DUTY_ICONS[_staffStatus.onDuty ? 'lifebuoy' : 'lifebuoyOff'] + (_staffStatus.onDuty ? s('staff.staffOnDuty') : s('staff.noStaffOnDuty'));

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -24,7 +24,7 @@
     .trip-meta { font-size:11px; color:var(--muted); margin-top:4px; display:flex; gap:8px; flex-wrap:wrap; }
     .trip-notes { font-size:11px; color:var(--muted); margin-top:8px; padding-top:8px; border-top:1px solid var(--border)44; line-height:1.5; }
     .badge { font-size:10px; padding:2px 7px; border-radius:10px; border:1px solid; flex-shrink:0; }
-    .badge-verified { color:#2ecc71; border-color:#2ecc7155; background:#2ecc7111; }
+    .badge-verified { color:var(--moss); border-color:color-mix(in srgb, var(--moss) 33%, transparent); background:color-mix(in srgb, var(--moss) 8%, transparent); }
     .badge-pending  { color:var(--muted); border-color:var(--border); background:var(--surface); }
     .badge-linked   { color:var(--brass); border-color:var(--brass)55; background:var(--brass)11; }
     .verify-row { display:flex; align-items:center; gap:8px; margin-top:10px; padding-top:10px; border-top:1px solid var(--border)44; flex-wrap:wrap; }
@@ -392,7 +392,7 @@ function renderTrips() {
             ${isVer ? ('✓ ' + s('logrev.verified')) : s('logrev.pending')}
           </span>
           ${isLinked ? `<span class="badge badge-linked">LINKED</span>` : ''}
-          ${hasVerifyReq && !isVer ? `<span class="badge" style="color:#2e86c1;border-color:#2e86c155;background:#2e86c111">${s('logrev.verifyRequest')}</span>` : ''}
+          ${hasVerifyReq && !isVer ? `<span class="badge" style="color:var(--navy-l);border-color:color-mix(in srgb, var(--navy-l) 33%, transparent);background:color-mix(in srgb, var(--navy-l) 8%, transparent)">${s('logrev.verifyRequest')}</span>` : ''}
         </div>
       </div>
       ${t.skipperNote ? `<div class="trip-notes text-brass">📋 ${esc(t.skipperNote)}</div>` : ''}

--- a/weather/index.html
+++ b/weather/index.html
@@ -90,7 +90,7 @@ svg.chart { width:100%; overflow:visible; display:block; }
 .h-unit  { font-size:9px; color:var(--muted); }
 .h-kt    { font-size:10px; color:var(--muted); line-height:1; }
 .h-gust  { font-size:10px; color:var(--muted); margin-top:1px; }
-.h-wave  { font-size:11px; color:#4a9eca; margin-top:4px; }
+.h-wave  { font-size:11px; color:var(--navy-l); margin-top:4px; }
 .h-pres  { font-size:10px; color:var(--muted); margin-top:3px; }
 .h-flag  { width:8px; height:8px; border-radius:50%; margin:6px auto 0; }
 
@@ -323,7 +323,7 @@ ${staffStatus ? wxStaffStatusHtml(staffStatus) : ''}
   </div>
   <div class="info-card">
     <div class="info-lbl">SEA TEMPERATURE</div>
-    <div class="info-val" style="color:#4a9eca">${sst != null ? sst.toFixed(1) : '–'}<span class="unit">°C</span></div>
+    <div class="info-val" style="color:var(--navy-l)">${sst != null ? sst.toFixed(1) : '–'}<span class="unit">°C</span></div>
     <div class="info-sub">${sst != null ? 'Surface water' : marine ? 'No SST for this cell' : 'Marine unavailable'}</div>
   </div>
 </div>
@@ -333,18 +333,18 @@ ${staffStatus ? wxStaffStatusHtml(staffStatus) : ''}
   <div class="info-lbl">WAVES</div>
   <div style="display:grid;grid-template-columns:1fr 1px 1fr 1px 1fr;gap:0;align-items:center">
     <div style="text-align:center;padding:4px 8px">
-      <div style="font-size:28px;color:#4a9eca;font-weight:500;line-height:1">${waveH != null ? waveH.toFixed(1) : '–'}</div>
+      <div style="font-size:28px;color:var(--navy-l);font-weight:500;line-height:1">${waveH != null ? waveH.toFixed(1) : '–'}</div>
       <div style="font-size:12px;color:var(--muted);margin-top:3px">m height</div>
       ${marineNote ? `<div style="font-size:9px;color:var(--muted);margin-top:3px">${marineNote.replace(/<[^>]+>/g,'')}</div>` : ''}
     </div>
     <div style="background:var(--border);height:40px;align-self:center"></div>
     <div style="text-align:center;padding:4px 8px">
-      <div style="font-size:28px;color:#4a9eca;line-height:1">${mc?.wave_direction != null ? wxDirArrow(mc.wave_direction) : '–'}</div>
+      <div style="font-size:28px;color:var(--navy-l);line-height:1">${mc?.wave_direction != null ? wxDirArrow(mc.wave_direction) : '–'}</div>
       <div style="font-size:12px;color:var(--muted);margin-top:3px">${mc?.wave_direction != null ? wxDirLabel(mc.wave_direction)+' · '+Math.round(mc.wave_direction)+'°' : 'direction'}</div>
     </div>
     <div style="background:var(--border);height:40px;align-self:center"></div>
     <div style="text-align:center;padding:4px 8px">
-      <div style="font-size:28px;color:#4a9eca;font-weight:500;line-height:1">${mc?.wave_period != null ? mc.wave_period.toFixed(0) : '–'}</div>
+      <div style="font-size:28px;color:var(--navy-l);font-weight:500;line-height:1">${mc?.wave_period != null ? mc.wave_period.toFixed(0) : '–'}</div>
       <div style="font-size:12px;color:var(--muted);margin-top:3px">s period</div>
     </div>
   </div>
@@ -367,7 +367,7 @@ ${staffStatus ? wxStaffStatusHtml(staffStatus) : ''}
     <div class="chart-legend">
       <span class="leg-item"><span class="leg-dot" style="background:var(--brass)"></span>Wind m/s</span>
       <span class="leg-item" style="opacity:.55;font-style:italic">— — Gusts</span>
-      ${marine ? `<span class="leg-item"><span class="leg-dot" style="background:#4a9eca"></span>Waves m</span>` : ''}
+      ${marine ? `<span class="leg-item"><span class="leg-dot" style="background:var(--navy-l)"></span>Waves m</span>` : ''}
     </div>
   </div>
   <svg class="chart" id="windChart" height="120"></svg>
@@ -378,7 +378,7 @@ ${staffStatus ? wxStaffStatusHtml(staffStatus) : ''}
   <div class="chart-header">
     <span class="chart-title-txt">PRESSURE TREND · 3H HISTORY + 6H FORECAST</span>
     <div class="chart-legend">
-      <span class="leg-item"><span class="leg-dot" style="background:#a78bfa"></span>hPa</span>
+      <span class="leg-item"><span class="leg-dot" style="background:var(--purple)"></span>hPa</span>
     </div>
   </div>
   <svg class="chart" id="presChart" height="80"></svg>
@@ -399,7 +399,7 @@ ${staffStatus ? wxStaffStatusHtml(staffStatus) : ''}
 
 // ─── Hourly strip ─────────────────────────────────────────────────────────────
 function renderHourStrip(pts) {
-  const FLAG_COLORS = { green:'#27ae60', yellow:'#f1c40f', orange:'#e67e22', red:'#e74c3c' };
+  const FLAG_COLORS = { green:'var(--green)', yellow:'var(--yellow)', orange:'var(--orange)', red:'var(--red)' };
   document.getElementById('hourStrip').innerHTML = pts.map(p => {
     const { flagKey } = wxScoreFlag(p.ws, wxDirLabel(p.wd), p.mWH ?? 0, null, null, null, 'good');
     return `<div class="h-slot${p.isNow?' now':p.isPast?' past':''}">


### PR DESCRIPTION
Closes #576. The light mode was washed out because brass (gold) was the only chromatic anchor sitting on a white/pale-gray shell. Rebuild both themes around the official club colors (navy #274484, moss green #34783b) as the dual-brand lead — navy anchors structure (headers, links, focus, active nav), moss drives positive/CTA (primary button, on-duty, verified), brass becomes a supporting ornament instead of carrying every affordance.

- shared/style.css: add --navy{,-d,-l} and --moss{,-d,-l} to all three theme blocks, retune neutrals (warm pearl in light, deeper navy in dark), alias --green → --moss and --blue → --navy so legacy badge/ chart consumers pick up the new palette automatically.
- Primary button is now moss on white; ghost-hover, focus ring, active tabs (pr-tab, view-toggle), and cal-nav hover go navy; spinner and checkbox accent go moss.
- Replace hardcoded hex+alpha (#27ae60XX, #e74c3cXX, #2ecc71, #2980b9, #2e86c1, #4a9eca, #c0392b, etc.) across style.css, tripcard.css, weather.js, logbook.js, boats.js, maintenance.js, and all portal HTML with color-mix(var(--X) NN%, transparent) so alpha tints respect the theme.
- Fix light-mode-breaking leftovers: invisible table-hover row, invisible trip-card notes bg, dark-only surface2 fallback, dark-only boat-status card backgrounds in staff view.
- public/index.html had its own :root override locking it to dark mode; sync to the new dark palette so the public dashboard stays on-brand.

Leaflet map markers/polylines (shared/logbook.js, public/index.html map code) and the print-only payslip HTML (shared/payroll.js) keep their hex literals on purpose — Leaflet options don't accept CSS vars and payslips print on white paper. Backend-generated email HTML in code.gs is untouched per project rules.

https://claude.ai/code/session_015cLukzJN5peB7oHNzdAqit