### PR TITLE
Switch primary CTAs from moss to navy (Option 1 / Navy-led)

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -341,8 +341,8 @@ textarea { min-height: 70px; }
 }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
 
-.btn-primary  { background: var(--moss);   color: #ffffff; }
-.btn-primary:hover:not(:disabled)  { background: var(--moss-l); box-shadow: 0 2px 8px color-mix(in srgb, var(--brass) 35%, transparent); transform: translateY(-1px); }
+.btn-primary  { background: var(--navy);   color: #ffffff; }
+.btn-primary:hover:not(:disabled)  { background: var(--navy-l); box-shadow: 0 2px 8px color-mix(in srgb, var(--brass) 40%, transparent); transform: translateY(-1px); }
 
 .btn-secondary { background: var(--faint);  color: var(--text); }
 .btn-secondary:hover:not(:disabled) { background: var(--border); box-shadow: var(--shadow-sm); }
@@ -481,7 +481,7 @@ textarea { min-height: 70px; }
   display: inline-block;
   width: 14px; height: 14px;
   border: 2px solid var(--border);
-  border-top-color: var(--moss);
+  border-top-color: var(--navy);
   border-radius: 50%;
   animation: spin .7s linear infinite;
   vertical-align: middle;
@@ -506,7 +506,7 @@ textarea { min-height: 70px; }
 .check-row:last-child { border-bottom: none; }
 .check-row input[type=checkbox] {
   width: 16px; height: 16px;
-  accent-color: var(--moss);
+  accent-color: var(--navy);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
Try the "Maritime Authority" direction from #576: navy is the brand color, so CTAs should carry navy, not moss. Moss keeps its role as the positive-status color (on-duty, verified, available boats) but stops pulling double duty as the CTA.

- .btn-primary: moss → navy, white text, brass glint shadow on hover (bumped 35% → 40% so the gold reads against the deeper navy)
- .spinner: moss → navy (loading is primary-action feedback)
- .check-row checkbox accent: moss → navy (interaction feedback matches primary)

Status indicators (.bc-avail, .signed-up, on-duty badges, success messages, fleet-status bars, verified trip badge) stay on moss on purpose — those communicate "positive state", not "clickable action".

https://claude.ai/code/session_015cLukzJN5peB7oHNzdAqit