### PR TITLE
Tint backgrounds toward navy + put navy on the header

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -46,7 +46,7 @@
 
 :root,
 [data-theme="dark"] {
-  --bg:       #0a1a33;
+  --bg:       #081428;
   --surface:  #11264a;
   --card:     #15305a;
   --border:   #23457a;
@@ -69,6 +69,10 @@
   --red:      #e74c3c;
   --blue:     var(--navy);
   --purple:   #a78bfa;
+  --header-bg:     #1b3168;
+  --header-text:   #f4f7fc;
+  --header-muted:  #b6c5de;
+  --header-border: #2d4d8f;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono: 'DM Mono', 'Courier New', monospace;
   --shadow-sm: 0 1px 2px rgba(0,0,0,.22);
@@ -80,14 +84,14 @@
 }
 
 [data-theme="light"] {
-  --bg:       #f6f4ee;
+  --bg:       #eef2f8;
   --surface:  #ffffff;
   --card:     #ffffff;
   --border:   #c9d3e4;
   --border-l: #9fb0cc;
   --text:     #0f2045;
   --muted:    #5b6e8a;
-  --faint:    #eceff5;
+  --faint:    #e4ebf5;
   --navy:     #274484;
   --navy-d:   #1b3168;
   --navy-l:   #3a5ea8;
@@ -103,6 +107,10 @@
   --red:      #b52a2a;
   --blue:     var(--navy);
   --purple:   #6a4fb8;
+  --header-bg:     #274484;
+  --header-text:   #f4f7fc;
+  --header-muted:  #c2d0e8;
+  --header-border: #3a5ea8;
   --shadow-sm: 0 1px 3px rgba(15,32,69,.08);
   --shadow-md: 0 2px 10px rgba(15,32,69,.10);
   --shadow-lg: 0 12px 32px rgba(15,32,69,.16);
@@ -110,14 +118,14 @@
 
 @media (prefers-color-scheme: light) {
   [data-theme="auto"] {
-    --bg:       #f6f4ee;
+    --bg:       #eef2f8;
     --surface:  #ffffff;
     --card:     #ffffff;
     --border:   #c9d3e4;
     --border-l: #9fb0cc;
     --text:     #0f2045;
     --muted:    #5b6e8a;
-    --faint:    #eceff5;
+    --faint:    #e4ebf5;
     --navy:     #274484;
     --navy-d:   #1b3168;
     --navy-l:   #3a5ea8;
@@ -133,6 +141,10 @@
     --red:      #b52a2a;
     --blue:     var(--navy);
     --purple:   #6a4fb8;
+    --header-bg:     #274484;
+    --header-text:   #f4f7fc;
+    --header-muted:  #c2d0e8;
+    --header-border: #3a5ea8;
     --shadow-sm: 0 1px 3px rgba(15,32,69,.08);
     --shadow-md: 0 2px 10px rgba(15,32,69,.10);
     --shadow-lg: 0 12px 32px rgba(15,32,69,.16);
@@ -154,8 +166,9 @@ html, body {
 .page { min-height: 100vh; display: flex; flex-direction: column; }
 
 header {
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
+  background: var(--header-bg);
+  color: var(--header-text);
+  border-bottom: 1px solid var(--header-border);
   box-shadow: var(--shadow-md);
   padding: 8px 20px;
   display: flex;
@@ -188,10 +201,10 @@ header {
 }
 
 .page-title {
-  color: var(--muted);
+  color: var(--header-muted);
   font-size: 13px;
   padding-left: 12px;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--header-border);
 }
 
 main {
@@ -208,7 +221,7 @@ main.wide { max-width: 1100px; }
 
 .hbtn, .back-btn {
   background: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--header-border);
   border-radius: var(--radius-sm);
   height: 30px;
   padding: 0 12px;
@@ -224,9 +237,9 @@ main.wide { max-width: 1100px; }
   box-sizing: border-box;
   transition: color .2s, border-color .2s, background .2s;
 }
-.hbtn     { color: var(--muted); }
-.back-btn { color: var(--text); font-weight: 500; }
-.hbtn:hover, .back-btn:hover { color: var(--brass); border-color: var(--brass); background: var(--brass)08; }
+.hbtn     { color: var(--header-muted); }
+.back-btn { color: var(--header-text); font-weight: 500; }
+.hbtn:hover, .back-btn:hover { color: var(--brass); border-color: var(--brass); background: color-mix(in srgb, var(--brass) 12%, transparent); }
 .hbtn.active { color: var(--brass); border-color: var(--brass); }
 
 .hbtn.icon-only {


### PR DESCRIPTION
- Light bg: warm cream (#f6f4ee) → pale navy (#eef2f8) so the body reads as the same family as the navy brand, not a beige office form
- Light faint: #eceff5 → #e4ebf5 (matching tint)
- Dark bg: #0a1a33 → #081428 (slightly deeper so the new navy header has room to sit above it)
- Introduce --header-bg / --header-text / --header-muted / --header-border per theme. Light uses the club navy #274484; dark uses #1b3168 so the header reads clearly against the even-darker bg
- Header rule, .page-title, .hbtn/.back-btn scoped to the header-* vars: navy bar with light text, brass glint on hover
- Logo mask stays brass on purpose — gold on navy is the classic yacht-club pairing and works in both themes without a recolor

https://claude.ai/code/session_015cLukzJN5peB7oHNzdAqit