### PR TITLE
Echo the navy+moss racing stripes across the UI chrome

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -168,7 +168,8 @@ html, body {
 header {
   background: var(--header-bg);
   color: var(--header-text);
-  border-bottom: 1px solid var(--header-border);
+  /* Racing stripe: 3px moss below the navy bar — echo of club racing colours */
+  border-bottom: 3px solid var(--moss);
   box-shadow: var(--shadow-md);
   padding: 8px 20px;
   display: flex;
@@ -240,7 +241,7 @@ main.wide { max-width: 1100px; }
 .hbtn     { color: var(--header-muted); }
 .back-btn { color: var(--header-text); font-weight: 500; }
 .hbtn:hover, .back-btn:hover { color: var(--brass); border-color: var(--brass); background: color-mix(in srgb, var(--brass) 12%, transparent); }
-.hbtn.active { color: var(--brass); border-color: var(--brass); }
+.hbtn.active { color: var(--moss-l); border-color: var(--moss-l); background: color-mix(in srgb, var(--moss) 15%, transparent); }
 
 .hbtn.icon-only {
   padding: 0 8px;
@@ -264,7 +265,13 @@ main.wide { max-width: 1100px; }
   letter-spacing: 1px;
   color: var(--muted);
   margin-bottom: 14px;
+  padding-bottom: 8px;
   font-weight: bold;
+  /* Navy→moss racing-stripe hint below every card title */
+  background-image: linear-gradient(to right, var(--navy) 0%, var(--moss) 70%, transparent 100%);
+  background-repeat: no-repeat;
+  background-size: 52px 2px;
+  background-position: 0 100%;
 }
 
 .section-heading {
@@ -327,7 +334,7 @@ input[type=number]{-moz-appearance:textfield}
 
 input:focus, select:focus, textarea:focus {
   border-color: var(--navy);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--navy) 18%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--moss) 30%, transparent);
 }
 
 textarea { min-height: 70px; }


### PR DESCRIPTION
Moss was only showing up as a positive-status tint (on-duty, verified, fleet-status bars). Push it into the always-visible chrome so the pairing reads like the club's racing stripes:

- Navy header now carries a 3px moss border-bottom — the literal racing stripe runs under the nav bar on every page
- .hbtn.active: brass → moss with a light moss wash background, so the current section ("Staff", "Admin", "Member") is called out in moss while idle tabs stay navy-chrome
- .card-title: 52px navy→moss gradient underline, so every card shows the two-colour signature
- Input focus: navy border + moss glow, echoing the stripes whenever a field is active

Logo stays brass (gold on navy is the right look and the SVG is a single-path mask — no recolour needed).

https://claude.ai/code/session_015cLukzJN5peB7oHNzdAqit