### PR TITLE
Saturate moss across cards + nav hover + checkboxes

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -163,7 +163,7 @@
 .bc-oos { opacity:.5; }
 
 /* ── Pending confirmations ── */
-.conf-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); box-shadow:var(--shadow-sm);
+.conf-card { background:var(--card); border:1px solid var(--border); border-left:3px solid var(--moss); border-radius:var(--radius-md); box-shadow:var(--shadow-sm);
   padding:12px 14px; margin-bottom:8px; }
 .conf-card .conf-from { font-size:12px; font-weight:500; color:var(--text); }
 .conf-card .conf-detail { font-size:11px; color:var(--muted); margin-top:3px; }

--- a/shared/style.css
+++ b/shared/style.css
@@ -240,8 +240,8 @@ main.wide { max-width: 1100px; }
 }
 .hbtn     { color: var(--header-muted); }
 .back-btn { color: var(--header-text); font-weight: 500; }
-.hbtn:hover, .back-btn:hover { color: var(--brass); border-color: var(--brass); background: color-mix(in srgb, var(--brass) 12%, transparent); }
-.hbtn.active { color: var(--moss-l); border-color: var(--moss-l); background: color-mix(in srgb, var(--moss) 15%, transparent); }
+.hbtn:hover, .back-btn:hover { color: var(--moss-l); border-color: var(--moss-l); background: color-mix(in srgb, var(--moss) 14%, transparent); }
+.hbtn.active { color: var(--moss-l); border-color: var(--moss-l); background: color-mix(in srgb, var(--moss) 22%, transparent); font-weight: 600; }
 
 .hbtn.icon-only {
   padding: 0 8px;
@@ -528,7 +528,7 @@ textarea { min-height: 70px; }
 .check-row:last-child { border-bottom: none; }
 .check-row input[type=checkbox] {
   width: 16px; height: 16px;
-  accent-color: var(--navy);
+  accent-color: var(--moss);
   flex-shrink: 0;
 }
 
@@ -538,6 +538,7 @@ textarea { min-height: 70px; }
 .bc-card {
   background: var(--surface);
   border: 1px solid var(--border);
+  border-left: 3px solid var(--moss);
   border-radius: var(--radius-md);
   padding: 12px 14px;
   transition: border-color .2s, box-shadow .2s;
@@ -552,6 +553,7 @@ textarea { min-height: 70px; }
 .bc-checkout-card {
   background: var(--surface);
   border: 1px solid var(--border);
+  border-left: 3px solid var(--moss);
   border-radius: var(--radius-md);
   padding: 12px 14px;
   margin-bottom: 8px;
@@ -789,7 +791,7 @@ textarea { min-height: 70px; }
 .modal-title{margin:0 0 16px;font-size:15px;font-weight:700}
 .modal-err{font-size:11px;color:var(--red);min-height:14px;margin-bottom:2px}
 .modal-actions{display:flex;gap:8px;margin-top:16px;align-items:center}
-.period-card{border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:12px;overflow:hidden;box-shadow:var(--shadow-sm)}
+.period-card{border:1px solid var(--border);border-left:3px solid var(--moss);border-radius:var(--radius-md);margin-bottom:12px;overflow:hidden;box-shadow:var(--shadow-sm)}
 .period-head{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;background:var(--surface);cursor:pointer}
 .period-title{font-weight:600;font-size:13px}
 .period-meta{font-size:11px;color:var(--muted)}
@@ -816,7 +818,7 @@ textarea { min-height: 70px; }
 .btn-del{font-size:10px;padding:2px 8px;background:var(--red)22;color:var(--red);border:1px solid var(--red)44;border-radius:var(--radius-sm);cursor:pointer}
 .edited-badge{font-size:9px;color:var(--muted);margin-left:3px}
 /* Payslip cards */
-.payslip-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:16px;overflow:hidden;box-shadow:var(--shadow-sm)}
+.payslip-card{background:var(--card);border:1px solid var(--border);border-left:3px solid var(--moss);border-radius:var(--radius-md);margin-bottom:16px;overflow:hidden;box-shadow:var(--shadow-sm)}
 .psc-header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;padding:12px 14px;border-bottom:2px solid var(--border);background:var(--surface)}
 .psc-identity .psc-name{font-weight:700;font-size:14px}
 .psc-identity .psc-sub{font-size:11px;color:var(--muted);margin-top:1px}

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -1,6 +1,6 @@
 /* ── Trip card (shared between logbook & captain) ── */
-.trip-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
-.trip-card:hover{border-color:var(--brass)}
+.trip-card{background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--moss);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
+.trip-card:hover{border-color:var(--moss-l)}
 .trip-card-main{display:grid;grid-template-columns:52px 1fr auto;align-items:stretch;cursor:pointer}
 .trip-date-col{background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}
 .trip-date-day{font-size:16px;font-weight:500;color:var(--text);line-height:1}


### PR DESCRIPTION
Another pass pushing moss wherever it can share chrome with navy:

- 3px moss left-rail now on every card variant, not just .card: .trip-card, .bc-card (base), .bc-checkout-card, .conf-card, .period-card, .payslip-card. Semantic overrides still win — bc-out stays brass, bc-overdue stays red — but every otherwise- neutral card shows moss down its left edge
- .trip-card:hover border shifts from brass → moss-light so hover glow matches the rail
- .hbtn:hover & .hbtn.active flipped from brass → moss-light with a moss wash. Brass now only shows on the logo in the header; every interaction in the nav bar is moss
- .check-row checkbox accent: navy → moss (matches the focus-ring glow which is already moss)

Result: scrolling any list of trips/boats/confirmations/pay periods reads as a stack of moss-rail cards on a navy-tinted sea. Every hover in the header lights up moss. The logo remains the lone brass point in the header, as you'd expect from a yacht club.

https://claude.ai/code/session_015cLukzJN5peB7oHNzdAqit