### PR TITLE
Deepen light-mode moss surfaces

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -85,13 +85,13 @@
 
 [data-theme="light"] {
   --bg:       #eef2f8;
-  --surface:  #f6f9f1;
-  --card:     #f2f6ea;
+  --surface:  #f1f4e8;
+  --card:     #e6ecdd;
   --border:   #c9d3e4;
   --border-l: #9fb0cc;
   --text:     #0f2045;
   --muted:    #5b6e8a;
-  --faint:    #e4ecdb;
+  --faint:    #d3dbc3;
   --navy:     #274484;
   --navy-d:   #1b3168;
   --navy-l:   #3a5ea8;
@@ -119,13 +119,13 @@
 @media (prefers-color-scheme: light) {
   [data-theme="auto"] {
     --bg:       #eef2f8;
-    --surface:  #f6f9f1;
-    --card:     #f2f6ea;
+    --surface:  #f1f4e8;
+    --card:     #e6ecdd;
     --border:   #c9d3e4;
     --border-l: #9fb0cc;
     --text:     #0f2045;
     --muted:    #5b6e8a;
-    --faint:    #e4ecdb;
+    --faint:    #d3dbc3;
     --navy:     #274484;
     --navy-d:   #1b3168;
     --navy-l:   #3a5ea8;


### PR DESCRIPTION
Use #e6ecdd for --card as requested — a noticeably more saturated sage than the previous #f2f6ea. Adjust the surrounding levels so the three-tier surface hierarchy stays readable:

- --card:    #f2f6ea → #e6ecdd  (the main request; deeper sage paper)
- --surface: #f6f9f1 → #f1f4e8  (still above card, hosts inputs,
                                 table heads, trip/boat card bg)
- --faint:   #e4ecdb → #d3dbc3  (pushed darker so hover rows / muted
                                 backgrounds stay visible against the
                                 now-deeper card bg)

https://claude.ai/code/session_015cLukzJN5peB7oHNzdAqit