### PR TITLE
Unify slot booking icons and prevent overlapping slots

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -178,8 +178,8 @@
         <span id="cqWeekLabel" class="week-label"></span>
         <button class="btn btn-secondary" onclick="shiftCqWeek(1)">&rarr;</button>
         <button class="btn btn-secondary" onclick="cqWeekToday()" data-s="slot.today">Today</button>
-        <button class="btn btn-primary" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" onclick="openCqCreateSlotModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
-        <button class="btn btn-primary" data-s="slot.bulkBook" data-s-attr="title" onclick="openCqBulkBookModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5l2 2 4-4"/><path d="M13 6h8"/><path d="M3 13l2 2 4-4"/><path d="M13 14h8"/><path d="M3 21l2 2 4-4"/><path d="M13 22h8"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
+        <button class="btn btn-primary" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" onclick="openCqCreateSlotModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
+        <button class="btn btn-primary" data-s="slot.bulkBook" data-s-attr="title" onclick="openCqBulkBookModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
       </div>
       <div style="display:flex;align-items:center;gap:6px;margin-left:auto">
         <label for="cqBookingColor" style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px" data-s="cq.bookingColor">My booking color</label>
@@ -1239,6 +1239,17 @@ async function submitCqCreateSlot() {
   var endTime = document.getElementById('cqCsEnd').value;
   if (!date || !startTime || !endTime) { toast(s('slot.missingFields'), 'err'); return; }
   if (endTime <= startTime) { toast(s('slot.missingFields'), 'err'); return; }
+  // Pre-flight: check loaded slots for overlaps on this boat/date so captains
+  // get instant feedback instead of a round-trip. The backend also enforces
+  // this, so out-of-view slots (e.g. not in the current week) are still caught.
+  try {
+    var pre = await apiGet('getSlots', { boatId: boatId, fromDate: date, toDate: date });
+    var existing = pre.slots || [];
+    var conflict = existing.some(function(sl) {
+      return sl.date === date && startTime < sl.endTime && endTime > sl.startTime;
+    });
+    if (conflict) { toast(s('slot.conflict'), 'err'); return; }
+  } catch(e) { /* fall through — backend will still validate */ }
   try {
     // Create the slot
     var res = await apiPost('saveSlot', { boatId: boatId, date: date, startTime: startTime, endTime: endTime });

--- a/code.gs
+++ b/code.gs
@@ -2546,11 +2546,31 @@ function syncDailyLogActivities_(date, oldActs, newActs) {
   } catch (e) { console.error('syncDailyLogActivities_ failed: ' + e); }
 }
 
+// Returns true if [startTime, endTime) overlaps any existing slot on the same
+// boat/date (excluding a specific slotId if provided). Times are "HH:MM" — pure
+// string comparison is safe because the format is zero-padded.
+function hasSlotConflict_(boatId, date, startTime, endTime, excludeSlotId) {
+  if (endTime <= startTime) return false;
+  var all = readAll_('reservationSlots');
+  for (var i = 0; i < all.length; i++) {
+    var sl = all[i];
+    if (excludeSlotId && sl.id === excludeSlotId) continue;
+    if (String(sl.boatId) !== String(boatId)) continue;
+    if (String(sl.date) !== String(date)) continue;
+    if (startTime < sl.endTime && endTime > sl.startTime) return true;
+  }
+  return false;
+}
+
 function saveSlot_(b) {
   if (!b.boatId) return failJ('boatId required');
   if (!b.date || !b.startTime || !b.endTime) return failJ('date, startTime, endTime required');
+  if (String(b.endTime) <= String(b.startTime)) return failJ('endTime must be after startTime');
   var id = b.slotId || ('slot_' + uid_());
   var existing = findOne_('reservationSlots', 'id', id);
+  if (hasSlotConflict_(b.boatId, b.date, String(b.startTime), String(b.endTime), existing ? id : null)) {
+    return failJ('Slot conflicts with an existing slot on this boat');
+  }
   if (existing) {
     updateRow_('reservationSlots', 'id', id, {
       date: String(b.date), startTime: String(b.startTime), endTime: String(b.endTime),
@@ -2573,29 +2593,35 @@ function saveRecurringSlots_(b) {
   if (!b.boatId) return failJ('boatId required');
   if (!b.startTime || !b.endTime) return failJ('startTime and endTime required');
   if (!b.fromDate || !b.toDate) return failJ('fromDate and toDate required');
+  if (String(b.endTime) <= String(b.startTime)) return failJ('endTime must be after startTime');
   if (!b.daysOfWeek || !Array.isArray(b.daysOfWeek) || !b.daysOfWeek.length) return failJ('daysOfWeek required (array of 0-6)');
   var recId = 'recur_' + uid_();
   var days = b.daysOfWeek.map(Number);
   var created = [];
+  var skipped = 0;
   var d = new Date(b.fromDate + 'T00:00:00');
   var end = new Date(b.toDate + 'T00:00:00');
   while (d <= end) {
     if (days.indexOf(d.getDay()) !== -1) {
       var dateStr = d.toISOString().slice(0, 10);
-      var slotId = 'slot_' + uid_();
-      insertRow_('reservationSlots', {
-        id: slotId, boatId: String(b.boatId), date: dateStr,
-        startTime: String(b.startTime), endTime: String(b.endTime),
-        recurrenceGroupId: recId,
-        bookedByKennitala: '', bookedByName: '', bookedByCrewId: '',
-        note: String(b.note || ''), createdAt: now_(),
-      });
-      created.push(slotId);
+      if (hasSlotConflict_(b.boatId, dateStr, String(b.startTime), String(b.endTime), null)) {
+        skipped++;
+      } else {
+        var slotId = 'slot_' + uid_();
+        insertRow_('reservationSlots', {
+          id: slotId, boatId: String(b.boatId), date: dateStr,
+          startTime: String(b.startTime), endTime: String(b.endTime),
+          recurrenceGroupId: recId,
+          bookedByKennitala: '', bookedByName: '', bookedByCrewId: '',
+          note: String(b.note || ''), createdAt: now_(),
+        });
+        created.push(slotId);
+      }
     }
     d.setDate(d.getDate() + 1);
   }
   created.forEach(function (sid) { syncSlotToCalendar_(sid, 'upsert'); });
-  return okJ({ saved: true, recurrenceGroupId: recId, count: created.length, slotIds: created });
+  return okJ({ saved: true, recurrenceGroupId: recId, count: created.length, skipped: skipped, slotIds: created });
 }
 
 function deleteSlot_(b) {

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -176,7 +176,7 @@
           <span id="cxWeekLabel" class="week-label"></span>
           <button class="btn btn-secondary" onclick="shiftCxWeek(1)">&rarr;</button>
           <button class="btn btn-secondary" onclick="cxWeekToday()" data-s="slot.today">Today</button>
-          <button class="btn btn-primary" data-s="slot.bulkBook" data-s-attr="title" onclick="openCxBulkBookModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5l2 2 4-4"/><path d="M13 6h8"/><path d="M3 13l2 2 4-4"/><path d="M13 14h8"/><path d="M3 21l2 2 4-4"/><path d="M13 22h8"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
+          <button class="btn btn-primary" data-s="slot.bulkBook" data-s-attr="title" onclick="openCxBulkBookModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
         </div>
       </div>
       <div id="cxSlotGrid" style="overflow-x:auto"></div>

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -624,6 +624,7 @@ var _STRINGS_FLAT = {
   "slot.createAndBook": "+ New Booking",
   "slot.createAndBookTitle": "Create & Book Slot",
   "slot.createdAndBooked": "Slot created and booked!",
+  "slot.conflict": "That time overlaps an existing slot for this boat",
   "cq.reservationsTitle": "CHARTERS",
   "nav.coxswainSeat": "Rowing Division",
   "cox.title": "Rowing Division",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -624,6 +624,7 @@ var _STRINGS_FLAT = {
   "slot.createAndBook": "+ Ný bókun",
   "slot.createAndBookTitle": "Búa til og bóka tíma",
   "slot.createdAndBooked": "Tími búinn til og bókaður!",
+  "slot.conflict": "Þessi tími skarast við annan tíma á þessum báti",
   "cq.reservationsTitle": "LEIGUR",
   "nav.coxswainSeat": "Róðrardeild",
   "cox.title": "Róðrardeild",


### PR DESCRIPTION
Closes #574

- Captain "+ New Booking" and Bulk Book, and coxswain Bulk Book, now use the same calendar-with-dot / calendar-grid SVG icons as the admin "+ Single" and "+ Recurring" buttons for a consistent visual language.
- Backend saveSlot_ now rejects slots that overlap an existing slot on the same boat/date (new hasSlotConflict_ helper). saveRecurringSlots_ skips conflicting dates instead of creating duplicates and returns the skip count. Both also validate that endTime > startTime up front.
- Captain's "+ New Booking" does a client-side preflight against the loaded slots on the chosen date so conflicts surface instantly; the backend is still the authority for cases the UI hasn't loaded.
- New bilingual "slot.conflict" string (EN/IS).

https://claude.ai/code/session_01PMthjtQiKctWY5BCSp1vqQ