### PR TITLE
Flush sheet write in addColIfMissing_ before cache invalidation

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -344,6 +344,10 @@ function addColIfMissing_(tabKey, colName) {
   const c = getSheetData_(tabKey);
   if (!c.headers.includes(colName)) {
     c.sheet.getRange(1, c.headers.length + 1).setValue(colName);
+    // Force the pending write to be committed before we re-read the sheet,
+    // otherwise getDataRange().getValues() in the next getSheetData_ call
+    // may return stale data that doesn't include the new column header.
+    SpreadsheetApp.flush();
     // Header shape changed — drop the cache so the new column is picked up.
     invalidateSheetCache_(tabKey);
   }


### PR DESCRIPTION
Apps Script batches setValue calls. Without an explicit flush, the subsequent getSheetData_ re-read can miss the just-added column header, causing updateRow_ to silently skip the field. This is the root cause of passwordHash never appearing after setPassword.

https://claude.ai/code/session_01UzDi87d8LPC4tRiQSAGvJ2