### PR TITLE
Light mode: white logo, green icons via --brass-fg variable

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -25,7 +25,7 @@
     .tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
       font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
       margin-bottom:-1px; transition:color .2s,border-color .2s; white-space:nowrap; }
-    .tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
+    .tab-btn.active { color:var(--brass-fg); border-bottom-color:var(--brass); }
     .tab-btn:hover:not(.active) { color:var(--text); }
 
     /* ── Tab dropdown (mobile) ── */
@@ -71,7 +71,7 @@
     .cl-row { display:flex; align-items:center; gap:8px; padding:7px 0;
       border-bottom:1px solid var(--border)44; font-size:12px; }
     .cl-row:last-child { border-bottom:none; }
-    .cl-phase { width:50px; font-size:10px; color:var(--brass); font-weight:bold; letter-spacing:.5px; flex-shrink:0; }
+    .cl-phase { width:50px; font-size:10px; color:var(--brass-fg); font-weight:bold; letter-spacing:.5px; flex-shrink:0; }
     .cl-sort-input { width: 42px !important; max-width: 42px; min-width: 42px; text-align:center; font-size:11px; padding: 2px 4px !important; border:1px solid var(--border);
       border-radius:4px; background:var(--surface); color:var(--text); font-family:inherit; flex-shrink:0;
       -moz-appearance:textfield; appearance:textfield; }
@@ -83,7 +83,7 @@
     /* ── Action buttons ── */
     .row-edit { background:none; border:1px solid transparent; color:var(--muted); cursor:pointer;
       font-size:11px; font-family:inherit; padding:3px 8px; border-radius:var(--radius-sm); transition:all .2s; }
-    .row-edit:hover { color:var(--brass); border-color:var(--brass)55; }
+    .row-edit:hover { color:var(--brass-fg); border-color:var(--brass)55; }
     .row-del  { background:none; border:none; color:var(--border); cursor:pointer;
       font-size:16px; padding:2px 4px; line-height:1; transition:color .2s; }
     .row-del:hover { color:var(--red); }
@@ -102,12 +102,12 @@
     .upload-zone:hover { border-color:var(--brass); }
     .col-hint { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px 16px; margin-bottom:16px; }
     .col-hint-row { display:flex; gap:8px; margin-bottom:4px; font-size:11px; align-items:flex-start; }
-    .col-hint-field { color:var(--brass); width:120px; flex-shrink:0; }
+    .col-hint-field { color:var(--brass-fg); width:120px; flex-shrink:0; }
     .col-hint-vals  { color:var(--muted); }
     .import-summary { display:flex; gap:8px; flex-wrap:wrap; margin:12px 0; }
     .import-chip { padding:5px 11px; border-radius:20px; font-size:11px; font-weight:500; }
     .chip-green  { background:color-mix(in srgb, var(--green) 15%, transparent);  color:var(--green);  border:1px solid color-mix(in srgb, var(--green) 30%, transparent); }
-    .chip-brass  { background:color-mix(in srgb, var(--brass) 15%, transparent);  color:var(--brass);  border:1px solid color-mix(in srgb, var(--brass) 30%, transparent); }
+    .chip-brass  { background:color-mix(in srgb, var(--brass) 15%, transparent);  color:var(--brass-fg);  border:1px solid color-mix(in srgb, var(--brass) 30%, transparent); }
     .chip-orange { background:color-mix(in srgb, var(--orange) 15%, transparent); color:var(--orange); border:1px solid color-mix(in srgb, var(--orange) 30%, transparent); }
     .chip-muted  { background:var(--surface); color:var(--muted); border:1px solid var(--border); }
     .chip-red    { background:color-mix(in srgb, var(--red) 15%, transparent);    color:var(--red);    border:1px solid color-mix(in srgb, var(--red) 30%, transparent); }
@@ -1834,7 +1834,7 @@ function renderBoats() {
           <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:6px;margin-bottom:4px">
             <div class="boat-card-name">${cat.emoji || boatEmoji(cat.key)} ${esc(b.name)}</div>
             <div style="display:flex;gap:4px;flex-shrink:0">
-              ${b.accessMode === 'controlled' ? `<span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass)">${esc(s('fleet.badgeControlled'))}</span>` : ""}
+              ${b.accessMode === 'controlled' ? `<span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass-fg)">${esc(s('fleet.badgeControlled'))}</span>` : ""}
               ${bool(b.oos) ? `<span class="oos-badge">OOS</span>` : ""}
               ${boatCatBadge(cat.key)}
             </div>
@@ -2271,7 +2271,7 @@ function renderLocations() {
   if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noLocations')}</div>`; return; }
   card.innerHTML = active.map(l => `
     <div class="list-row">
-      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓️ PORT</span>' : ' <span style="font-size:9px;color:var(--ice);border:1px solid var(--ice)44;border-radius:4px;padding:1px 5px;margin-left:4px">⛵ SAILING AREA</span>'}</span>
+      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass-fg);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓️ PORT</span>' : ' <span style="font-size:9px;color:var(--ice);border:1px solid var(--ice)44;border-radius:4px;padding:1px 5px;margin-left:4px">⛵ SAILING AREA</span>'}</span>
       <button class="row-edit" onclick="openLocationModal('${l.id}')">Edit</button>
       <button class="row-del"  onclick="deleteLocation('${l.id}')">×</button>
     </div>`).join("");
@@ -2555,12 +2555,12 @@ function renderActTypes() {
       <div style="display:flex;align-items:center;gap:10px">
         <span class="list-name">${esc(a.name)}${a.nameIS
           ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(a.nameIS)}</span>` : ""}${isVol
-          ? `<span style="color:var(--brass);font-size:9px;margin-left:8px;letter-spacing:.5px">${s('admin.volunteerType').toUpperCase()}</span>` : ""}</span>
+          ? `<span style="color:var(--brass-fg);font-size:9px;margin-left:8px;letter-spacing:.5px">${s('admin.volunteerType').toUpperCase()}</span>` : ""}</span>
         <button class="row-edit" onclick="openActTypeModal('${a.id}')">Edit</button>
         <button class="row-del"  onclick="deleteActType('${a.id}')">×</button>
       </div>
       ${subs.map(st=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">→ ${esc(st.name)}${st.defaultStart?' · '+esc(st.defaultStart)+(st.defaultEnd?'–'+esc(st.defaultEnd):''):''}</div>`).join('')}
-      ${isVol && roles.length ? roles.map(r=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">⚑ ${esc(r.name||'')}${r.slots?' ('+r.slots+')':''}${r.requiredEndorsement?` <span style="color:var(--brass)">[${esc(certDefName((certDefs||[]).find(d=>d.id===r.requiredEndorsement))||r.requiredEndorsement)}]</span>`:''}</div>`).join('') : ''}
+      ${isVol && roles.length ? roles.map(r=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">⚑ ${esc(r.name||'')}${r.slots?' ('+r.slots+')':''}${r.requiredEndorsement?` <span style="color:var(--brass-fg)">[${esc(certDefName((certDefs||[]).find(d=>d.id===r.requiredEndorsement))||r.requiredEndorsement)}]</span>`:''}</div>`).join('') : ''}
     </div>`;
   }).join("");
 }
@@ -3085,7 +3085,7 @@ function renderVolRoles() {
     var endorseLabel = '';
     if (r.requiredEndorsement) {
       var eDef = (certDefs || []).find(function(d){ return d.id === r.requiredEndorsement; });
-      endorseLabel = '<div style="font-size:10px;color:var(--brass);margin-top:4px">' + s('admin.roleEndorsement') + ': ' + esc(eDef ? certDefName(eDef) : r.requiredEndorsement) + '</div>';
+      endorseLabel = '<div style="font-size:10px;color:var(--brass-fg);margin-top:4px">' + s('admin.roleEndorsement') + ': ' + esc(eDef ? certDefName(eDef) : r.requiredEndorsement) + '</div>';
     }
     return '<div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">'
       + '<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">'
@@ -3329,7 +3329,7 @@ function renderCertDefs() {
     const catObj = d.category ? certCategoryByKey(certCategories, d.category) : null;
     const catLabel = catObj ? certCategoryLabel(catObj) : d.category;
     const catStr = d.category
-      ? `<span style="color:var(--brass);font-size:10px">[${esc(catLabel)}]</span> ` : "";
+      ? `<span style="color:var(--brass-fg);font-size:10px">[${esc(catLabel)}]</span> ` : "";
     const expiryStr = d.expires
       ? `<span style="color:var(--muted)"> · expires</span>` : "";
     const nameEN = d.nameEN || d.name || '';
@@ -3820,7 +3820,7 @@ function renderImportPreview(res) {
         </div>`).join("")}</div>`;
   }
   if (res.updated.length) {
-    html += `<div style="font-size:11px;color:var(--brass);margin:10px 0 4px;font-weight:500">UPDATED (${res.updated.length})</div>
+    html += `<div style="font-size:11px;color:var(--brass-fg);margin:10px 0 4px;font-weight:500">UPDATED (${res.updated.length})</div>
       <div class="import-list">${res.updated.map(m => `
         <div class="import-row">
           <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
@@ -4318,7 +4318,7 @@ function _ppRenderItemRow(p, cat, it, pi, ci, ii) {
   const assessmentColor = assessment === 'theory' ? 'var(--brass)' : 'var(--muted)';
   const moduleNum = Number(it.module || 0);
   const moduleBadge = moduleNum > 0
-    ? `<span style="font-size:9px;color:var(--brass);border:1px solid var(--brass);border-radius:3px;padding:1px 4px;margin-left:4px;text-transform:uppercase;letter-spacing:.5px">${esc(s('passport.moduleShort'))} ${moduleNum}</span>`
+    ? `<span style="font-size:9px;color:var(--brass-fg);border:1px solid var(--brass);border-radius:3px;padding:1px 4px;margin-left:4px;text-transform:uppercase;letter-spacing:.5px">${esc(s('passport.moduleShort'))} ${moduleNum}</span>`
     : '';
   return `<div style="border-top:1px solid var(--border);padding:8px 0;display:flex;align-items:flex-start;gap:8px;${retired ? 'opacity:.5' : ''}">
     <div style="flex:1;min-width:0">
@@ -4364,7 +4364,7 @@ function drawPassportEditor() {
     card.innerHTML = `<div style="color:var(--muted);padding:12px 0">No passports configured. Import a CSV to get started.</div>
       <div style="margin-top:12px;display:flex;gap:8px;align-items:center">
         <button class="btn btn-primary" style="font-size:11px" onclick="ppSaveDef()" data-s="passport.save">Save changes</button>
-        <span id="ppDirtyMark" style="font-size:10px;color:var(--brass)">${_passportDirty ? '● unsaved' : ''}</span>
+        <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
       </div>`;
     applyStrings(card);
     return;
@@ -4463,7 +4463,7 @@ function drawPassportEditor() {
           ? `${s('passport.moduleLabel')} ${modNum}`
           : s('passport.unassignedModule');
         html += `<div style="margin-top:10px;border:1px solid var(--border);border-radius:6px;padding:10px;background:var(--surface)">
-          <div style="font-weight:700;font-size:12px;color:var(--brass);letter-spacing:.5px;text-transform:uppercase;margin-bottom:8px">${esc(modLabel)} <span style="color:var(--muted);font-weight:400;font-size:10px">· ${bucket.length}</span></div>`;
+          <div style="font-weight:700;font-size:12px;color:var(--brass-fg);letter-spacing:.5px;text-transform:uppercase;margin-bottom:8px">${esc(modLabel)} <span style="color:var(--muted);font-weight:400;font-size:10px">· ${bucket.length}</span></div>`;
 
         // Sub-group by category (preserving the passport's category order)
         const byCat = {};
@@ -4514,7 +4514,7 @@ function drawPassportEditor() {
 
   html += `<div style="margin-top:14px;display:flex;gap:8px;align-items:center">
     <button class="btn btn-primary" style="font-size:11px" onclick="ppSaveDef()" data-s="passport.save">Save changes</button>
-    <span id="ppDirtyMark" style="font-size:10px;color:var(--brass)">${_passportDirty ? '● unsaved' : ''}</span>
+    <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
   </div>`;
   card.innerHTML = html;
   applyStrings(card);

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -10,7 +10,7 @@
     .tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
       font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
       margin-bottom:-1px; transition:color .2s,border-color .2s; white-space:nowrap; }
-    .tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
+    .tab-btn.active { color:var(--brass-fg); border-bottom-color:var(--brass); }
     .tab-btn:hover:not(.active) { color:var(--text); }
     @media(max-width:600px){ .tab-btn{padding:8px 10px;font-size:10px;letter-spacing:.5px} }
   </style>

--- a/captain/index.html
+++ b/captain/index.html
@@ -23,7 +23,7 @@
 /* ── Stats ── */
 .cq-stats { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }
 .cq-stat { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 12px; text-align:center; box-shadow:var(--shadow-sm); }
-.cq-stat .sn { font-size:24px; color:var(--brass); font-weight:500; }
+.cq-stat .sn { font-size:24px; color:var(--brass-fg); font-weight:500; }
 .cq-stat .sl { font-size:9px; color:var(--muted); margin-top:4px; letter-spacing:.5px; }
 
 /* ── Section headers ── */
@@ -35,7 +35,7 @@
 .cq-pills { display:flex; gap:6px; margin-bottom:10px; flex-wrap:wrap; }
 .cq-pill { padding:5px 12px; border-radius:16px; border:1px solid var(--border); background:var(--surface);
   font-size:10px; font-family:inherit; color:var(--muted); cursor:pointer; transition:all .2s; }
-.cq-pill.active { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
+.cq-pill.active { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)11; }
 
 /* ── Compact filter bar ── */
 .cq-filter-bar { display:grid; grid-template-columns:repeat(auto-fill,minmax(110px,1fr)); gap:6px; margin-bottom:10px; align-items:center; }
@@ -52,7 +52,7 @@
   padding:12px 14px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
 .cq-card-title { font-size:12px; font-weight:500; color:var(--text); }
 .cq-card-sub { font-size:11px; color:var(--muted); margin-top:3px; }
-.cq-card-meta { font-size:10px; color:var(--brass); margin-top:2px; }
+.cq-card-meta { font-size:10px; color:var(--brass-fg); margin-top:2px; }
 .cq-card .conf-actions { display:flex; gap:6px; margin-top:8px; }
 .cq-card .conf-actions button { font-size:11px; font-family:inherit; padding:5px 12px; border-radius:var(--radius-sm); cursor:pointer; border:1px solid; }
 .cq-card .btn-confirm { background:var(--green)18; color:var(--green); border-color:var(--green)55; }
@@ -101,7 +101,7 @@
 .cq-boat-actions { margin-left:auto; display:flex; gap:6px; }
 .cq-boat-actions button { font-size:10px; font-family:inherit; padding:4px 10px; border-radius:var(--radius-sm);
   cursor:pointer; border:1px solid var(--border); background:var(--surface); color:var(--muted); transition:color .2s,border-color .2s,background .2s; }
-.cq-boat-actions button:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)08; }
+.cq-boat-actions button:hover { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)08; }
 
 /* ── Responsive ── */
 @media(max-width:600px){
@@ -791,7 +791,7 @@ function renderBoats() {
     return '<div class="cq-boat">'
       + '<div>'
         + '<div class="cq-boat-name">' + esc(boatEmoji(b.category)) + ' ' + esc(b.name)
-          + (isControlled ? ' <span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass)">' + esc(s('fleet.badgeControlled')) + '</span>' : '')
+          + (isControlled ? ' <span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass-fg)">' + esc(s('fleet.badgeControlled')) + '</span>' : '')
         + '</div>'
         + '<div class="cq-boat-sub">'
           + (isOos ? '<span style="color:var(--red)">OUT OF SERVICE</span>' : '<span style="color:var(--green)">AVAILABLE</span>')

--- a/code.gs
+++ b/code.gs
@@ -5209,7 +5209,7 @@ function pubPageShell_(title, bodyHtml) {
     + '<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"><\/script>'
     + '<style>'
     + ':root{--bg:#0b1f38;--card:#132d50;--surface:#0f2847;--border:#1e3f6e;--border-l:#2a5490;'
-    + '--text:#d6e4f0;--muted:#6b92b8;--faint:#2a4a6e;--brass:#d4af37;--brass-l:#e8c84a;'
+    + '--text:#d6e4f0;--muted:#6b92b8;--faint:#2a4a6e;--brass:#d4af37;--brass-fg:#d4af37;--brass-l:#e8c84a;'
     + '--green:#27ae60;--yellow:#f1c40f;--orange:#e67e22;--red:#e74c3c;--blue:#2980b9}'
     + '*{box-sizing:border-box;margin:0;padding:0}'
     + 'body{background:var(--bg);color:var(--text);font-family:"DM Mono","Courier New",monospace;'
@@ -5222,10 +5222,10 @@ function pubPageShell_(title, bodyHtml) {
     + '.card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:16px;margin-bottom:12px}'
     // Header bar
     + '.pub-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;padding-bottom:12px;border-bottom:1px solid var(--border)}'
-    + '.pub-logo{color:var(--brass);font-size:18px;font-weight:700;letter-spacing:1px}'
+    + '.pub-logo{color:var(--brass-fg);font-size:18px;font-weight:700;letter-spacing:1px}'
     + '.pub-lang-btn{background:none;border:1px solid var(--border);color:var(--muted);border-radius:5px;'
     + 'padding:4px 12px;font-size:12px;font-family:inherit;cursor:pointer;transition:color .15s,border-color .15s}'
-    + '.pub-lang-btn:hover{color:var(--brass);border-color:var(--brass)}'
+    + '.pub-lang-btn:hover{color:var(--brass-fg);border-color:var(--brass)}'
     // Table
     + 'table{width:100%;border-collapse:collapse;font-size:12px}'
     + 'th{text-align:left;font-size:10px;text-transform:uppercase;letter-spacing:.8px;'
@@ -5253,7 +5253,7 @@ function pubPageShell_(title, bodyHtml) {
     + '.badge-yellow{color:var(--yellow);border-color:#f1c40f50;background:#f1c40f12}'
     + '.badge-red{color:var(--red);border-color:#e74c3c50;background:#e74c3c12}'
     + '.badge-muted{color:var(--muted);border-color:var(--border);background:var(--faint)}'
-    + '.badge-brass{color:var(--brass);border-color:#d4af3750;background:#d4af3712}'
+    + '.badge-brass{color:var(--brass-fg);border-color:#d4af3750;background:#d4af3712}'
     // Cert cards
     + '.cert-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 14px;'
     + 'margin-bottom:6px;cursor:pointer;transition:border-color .15s}'
@@ -5290,7 +5290,7 @@ function pubPageShell_(title, bodyHtml) {
     + '.detail-extra.open{display:block}'
     + '.detail-more-btn{background:none;border:1px solid var(--border);color:var(--muted);border-radius:5px;padding:3px 10px;'
     + 'font-size:10px;font-family:inherit;cursor:pointer;margin-top:6px;transition:color .15s,border-color .15s}'
-    + '.detail-more-btn:hover{color:var(--brass);border-color:var(--brass)}'
+    + '.detail-more-btn:hover{color:var(--brass-fg);border-color:var(--brass)}'
     // Form
     + '.form-group{margin-bottom:14px}'
     + '.form-group label{display:block;font-size:11px;color:var(--muted);margin-bottom:4px;letter-spacing:.5px}'
@@ -5643,7 +5643,7 @@ function pubTripTableHtml_(trips, allTrips, boats, opts) {
           + '<div class="pub-track-map" id="tmap-' + idx + '" data-track="' + trackJson + '" data-title="' + mapTitle + '" onclick="openPubMapModal(' + idx + ')">'
           + '<div class="pub-map-hint"><span class="lang-en">Click to expand</span><span class="lang-is" style="display:none">Smelltu til að stækka</span></div></div>';
         if (t.trackFileUrl) {
-          html += '<a href="' + esc_(t.trackFileUrl) + '" target="_blank" style="color:var(--brass);font-size:10px;margin-top:4px;display:inline-block">⬇ '
+          html += '<a href="' + esc_(t.trackFileUrl) + '" target="_blank" style="color:var(--brass-fg);font-size:10px;margin-top:4px;display:inline-block">⬇ '
             + '<span class="lang-en">Download file</span><span class="lang-is" style="display:none">Sækja skrá</span></a>';
         }
         html += '</div>';

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -19,7 +19,7 @@
 /* ── Stats ── */
 .cx-stats { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }
 .cx-stat { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 12px; text-align:center; box-shadow:var(--shadow-sm); }
-.cx-stat .sn { font-size:24px; color:var(--brass); font-weight:500; }
+.cx-stat .sn { font-size:24px; color:var(--brass-fg); font-weight:500; }
 .cx-stat .sl { font-size:9px; color:var(--muted); margin-top:4px; letter-spacing:.5px; }
 
 /* ── Tab bar ── */
@@ -27,7 +27,7 @@
 .cx-tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
   font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
   white-space:nowrap; transition:color .2s,border-color .2s; text-transform:uppercase; margin-bottom:-1px; }
-.cx-tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
+.cx-tab-btn.active { color:var(--brass-fg); border-bottom-color:var(--brass); }
 .cx-tab-btn:hover:not(.active) { color:var(--text); }
 
 /* ── Section headers ── */
@@ -47,7 +47,7 @@
 .cx-boat-actions { margin-left:auto; display:flex; gap:6px; }
 .cx-boat-actions button { font-size:10px; font-family:inherit; padding:4px 10px; border-radius:var(--radius-sm);
   cursor:pointer; border:1px solid var(--border); background:var(--surface); color:var(--muted); transition:color .2s,border-color .2s,background .2s; }
-.cx-boat-actions button:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)08; }
+.cx-boat-actions button:hover { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)08; }
 
 /* ── Read-only banner ── */
 .cx-readonly { font-size:11px; color:var(--muted); background:var(--surface); border:1px solid var(--border);
@@ -62,7 +62,7 @@
 .cb-count { font-size:10px; color:var(--muted); }
 .cb-badge { font-size:8px; padding:2px 6px; border-radius:10px; font-weight:500; }
 .cb-badge--active { background:var(--green)22; color:var(--green); border:1px solid var(--green)44; }
-.cb-badge--forming { background:var(--brass)22; color:var(--brass); border:1px solid var(--brass)44; }
+.cb-badge--forming { background:var(--brass)22; color:var(--brass-fg); border:1px solid var(--brass)44; }
 .cb-desc { font-size:11px; color:var(--muted); margin-bottom:8px; font-style:italic; }
 .cb-boats { display:flex; gap:8px; flex-wrap:wrap; }
 .cb-boat { min-width:70px; flex:1; }
@@ -72,26 +72,26 @@
 .cb-seat:first-of-type { border-radius:6px 6px 0 0; border-bottom:none; }
 .cb-seat:last-of-type { border-radius:0 0 6px 6px; }
 .cb-seat--filled { background:var(--surface); color:var(--text); cursor:pointer; }
-.cb-seat--you { background:var(--brass)18; color:var(--brass); border-color:var(--brass)66; font-weight:500; cursor:pointer; }
+.cb-seat--you { background:var(--brass)18; color:var(--brass-fg); border-color:var(--brass)66; font-weight:500; cursor:pointer; }
 .cb-seat--open { background:transparent; color:var(--muted); border-style:dashed; cursor:pointer; transition:all .15s; }
-.cb-seat--open:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)08; }
+.cb-seat--open:hover { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)08; }
 .cb-seat--expanded { height:auto; min-height:28px; white-space:normal; padding-top:4px; padding-bottom:4px; }
 .cb-seat--expanded .cb-seat-name { overflow:visible; text-overflow:clip; white-space:normal; word-break:break-word; line-height:1.2; }
 .cb-seat-role { font-size:8px; color:var(--muted); min-width:28px; opacity:.7; }
 .cb-seat-name { overflow:hidden; text-overflow:ellipsis; }
 .cb-actions { display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
-.cb-needs { font-size:10px; color:var(--brass); margin-top:6px; }
+.cb-needs { font-size:10px; color:var(--brass-fg); margin-top:6px; }
 .cb-color-dot { width:10px; height:10px; border-radius:50%; flex-shrink:0; }
 
 /* ── Passport ── */
 .pp-cat { margin-bottom:14px; }
 .pp-cat-hdr { font-size:10px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; margin-bottom:6px; display:flex; align-items:center; gap:8px; }
-.pp-cat-count { font-size:9px; color:var(--brass); }
+.pp-cat-count { font-size:9px; color:var(--brass-fg); }
 .pp-item { display:flex; align-items:flex-start; gap:10px; background:var(--card); border:1px solid var(--border); border-radius:var(--radius-sm); padding:8px 12px; margin-bottom:4px; font-size:11px; }
 .pp-item-signable { cursor:pointer; transition:border-color .2s; }
 .pp-item-signable:hover { border-color:var(--brass); }
 .pp-item-complete { border-left:3px solid var(--green); }
-.pp-item-icon { font-size:14px; color:var(--brass); width:18px; text-align:center; flex-shrink:0; }
+.pp-item-icon { font-size:14px; color:var(--brass-fg); width:18px; text-align:center; flex-shrink:0; }
 .pp-item-complete .pp-item-icon { color:var(--green); }
 .pp-item-body { flex:1; min-width:0; }
 .pp-item-name { color:var(--text); font-weight:500; }
@@ -99,11 +99,11 @@
 .pp-item-sigs { color:var(--muted); font-size:9px; margin-top:3px; font-style:italic; }
 .pp-item-count { font-size:10px; color:var(--muted); flex-shrink:0; }
 .pp-asmt { display:inline-block; font-size:8px; padding:1px 6px; border-radius:8px; margin-left:6px; vertical-align:middle; letter-spacing:.5px; text-transform:uppercase; font-weight:500; }
-.pp-asmt-practical { background:var(--brass)22; color:var(--brass); border:1px solid var(--brass)44; }
+.pp-asmt-practical { background:var(--brass)22; color:var(--brass-fg); border:1px solid var(--brass)44; }
 .pp-asmt-theory    { background:var(--surface); color:var(--muted); border:1px solid var(--border); }
-.pp-mod { display:inline-block; font-size:8px; padding:1px 6px; border-radius:8px; margin-left:4px; vertical-align:middle; letter-spacing:.5px; text-transform:uppercase; font-weight:500; background:var(--surface); color:var(--brass); border:1px solid var(--brass)44; }
+.pp-mod { display:inline-block; font-size:8px; padding:1px 6px; border-radius:8px; margin-left:4px; vertical-align:middle; letter-spacing:.5px; text-transform:uppercase; font-weight:500; background:var(--surface); color:var(--brass-fg); border:1px solid var(--brass)44; }
 .pp-sortbtn-active { background:var(--brass) !important; color:var(--card) !important; border-color:var(--brass) !important; }
-.pp-mod-hdr { font-size:11px; color:var(--brass); font-weight:700; letter-spacing:1px; text-transform:uppercase; margin:10px 0 4px; display:flex; align-items:center; gap:8px; }
+.pp-mod-hdr { font-size:11px; color:var(--brass-fg); font-weight:700; letter-spacing:1px; text-transform:uppercase; margin:10px 0 4px; display:flex; align-items:center; gap:8px; }
 .pp-mod-hdr .pp-cat-count { color:var(--muted); font-weight:400; }
 .pp-subcat-hdr { font-size:9px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; margin:6px 0 4px 0; padding-left:8px; border-left:2px solid var(--border); }
 
@@ -201,13 +201,13 @@
           <button class="btn btn-secondary" style="font-size:10px;padding:4px 10px" onclick="ppViewSelf()" data-s="passport.viewSelf">My passport</button>
         </div>
         <div id="ppMemberSuggestions" class="suggest-drop hidden" style="position:absolute;left:0;right:0;top:100%;z-index:10;background:var(--card);border:1px solid var(--border);border-radius:6px;margin-top:2px;max-height:240px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.2)"></div>
-        <div id="ppCurrentTarget" style="font-size:10px;color:var(--brass);margin-top:4px"></div>
+        <div id="ppCurrentTarget" style="font-size:10px;color:var(--brass-fg);margin-top:4px"></div>
       </div>
       <div id="passportProgressBar" style="height:6px;background:var(--surface);border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-bottom:10px">
         <div id="passportProgressFill" style="height:100%;width:0%;background:var(--brass);transition:width .3s"></div>
       </div>
       <div id="passportProgressLabel" style="font-size:10px;color:var(--muted);letter-spacing:.5px;margin-bottom:10px"></div>
-      <div id="passportSignerBanner" class="hidden" style="font-size:10px;color:var(--brass);background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 10px;margin-bottom:10px" data-s="passport.signerMode">Sign-off mode — tap items to sign.</div>
+      <div id="passportSignerBanner" class="hidden" style="font-size:10px;color:var(--brass-fg);background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 10px;margin-bottom:10px" data-s="passport.signerMode">Sign-off mode — tap items to sign.</div>
       <div id="passportSortBar" style="display:flex;gap:6px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
         <span style="font-size:9px;color:var(--muted);letter-spacing:.5px;text-transform:uppercase" data-s="passport.sortBy">Sort by</span>
         <button class="btn btn-secondary" id="ppSortCatMod" style="font-size:10px;padding:3px 8px" onclick="ppSetSortMode('cat-mod')" data-s="passport.sortCatMod">Category → Module</button>

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -20,7 +20,7 @@
 .date-nav { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
 .date-nav button { background:none; border:1px solid var(--border); border-radius:var(--radius-sm);
   color:var(--text); font-family:inherit; font-size:12px; padding:5px 12px; cursor:pointer; transition:border-color .2s,color .2s; }
-.date-nav button:hover { border-color:var(--brass); color:var(--brass); }
+.date-nav button:hover { border-color:var(--brass); color:var(--brass-fg); }
 .date-big { font-size:13px; font-weight:400; color:var(--muted); letter-spacing:.5px; flex:1; text-align:center; }
 .date-hero { font-size:28px; font-weight:500; color:var(--text); text-align:center; margin:4px 0 12px; line-height:1.1; }
 .signoff-badge { display:inline-flex; align-items:center; gap:6px;
@@ -39,7 +39,7 @@
 
 /* ── Checklists ── */
 .cl-progress-line { font-size:11px; color:var(--muted); margin-bottom:8px; }
-.cl-progress-line span { color:var(--brass); font-weight:500; }
+.cl-progress-line span { color:var(--brass-fg); font-weight:500; }
 .cl-bar-wrap { height:4px; background:var(--border); border-radius:2px; margin-bottom:12px; overflow:hidden; }
 .cl-bar      { height:100%; background:var(--brass); border-radius:2px; transition:width .3s; }
 .checklist-item { display:flex; align-items:flex-start; gap:10px; padding:8px 0; border-bottom:1px solid var(--border); cursor:pointer; user-select:none; }
@@ -78,7 +78,7 @@
 /* ── Weather log ── */
 .wx-snap-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:10px 12px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
 .wx-snap-header { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
-.wx-snap-time { color:var(--brass); font-weight:500; font-size:14px; flex:1; }
+.wx-snap-time { color:var(--brass-fg); font-weight:500; font-size:14px; flex:1; }
 .wx-snap-flag { font-size:16px; }
 .wx-snap-grid { display:grid; grid-template-columns:1fr 1fr; gap:6px 16px; }
 .wx-snap-label { font-size:9px; color:var(--muted); letter-spacing:.8px; margin-bottom:2px; }
@@ -98,7 +98,7 @@
 .type-btn { padding:5px 12px; background:var(--surface); border:1px solid var(--border);
   border-radius:var(--radius-sm); font-size:12px; font-family:inherit; color:var(--text);
   cursor:pointer; transition:all .2s; }
-.type-btn.selected { background:var(--brass)22; border-color:var(--brass); color:var(--brass); }
+.type-btn.selected { background:var(--brass)22; border-color:var(--brass); color:var(--brass-fg); }
 
 /* ── Trip detail modal ── */
 .dl-drow { display:flex; gap:12px; padding:5px 0; border-bottom:1px solid var(--border); font-size:13px; }

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -64,7 +64,7 @@
 .manual-member-drop{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 var(--radius-sm) var(--radius-sm);z-index:200;max-height:180px;overflow-y:auto;display:none;box-shadow:var(--shadow-md)}
 .manual-member-drop .mm-item{padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border)}
 .manual-member-drop .mm-item:hover{background:var(--card)}
-.manual-member-drop .mm-guest{font-size:10px;color:var(--brass);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
+.manual-member-drop .mm-guest{font-size:10px;color:var(--brass-fg);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
 .manual-member-drop .mm-guest:hover{background:var(--card)}
 .manual-crew-row{position:relative;margin-bottom:8px}
 .manual-crew-row .crew-row-fields{display:flex;gap:8px;align-items:center}
@@ -109,7 +109,7 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .conf-card .conf-line{font-size:11px;color:var(--text);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
 .conf-card .conf-line .conf-name{font-weight:500}
 .conf-card .conf-line .conf-type{color:var(--muted)}
-.conf-card .conf-line .conf-boat-info{color:var(--brass)}
+.conf-card .conf-line .conf-boat-info{color:var(--brass-fg)}
 .conf-card .conf-line .conf-date-info{color:var(--muted);font-size:10px}
 .conf-card .conf-actions{display:flex;gap:6px;margin-top:6px}
 .conf-card .conf-actions button{font-size:10px;font-family:inherit;padding:4px 10px;border-radius:var(--radius-sm);cursor:pointer;border:1px solid}

--- a/login/index.html
+++ b/login/index.html
@@ -21,7 +21,7 @@
     .stay-row input { margin:0; }
     .lang-row { text-align:center; margin-top:16px; }
     #roleScreen, #accountScreen, #forceChangeScreen { display:none; }
-    .role-greeting { color:var(--brass); font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; }
+    .role-greeting { color:var(--brass-fg); font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; }
     .role-btn {
       width:100%; padding:18px 20px; margin-bottom:10px; border-radius:var(--radius-md);
       border:1px solid var(--border); background:var(--surface); cursor:pointer;
@@ -29,7 +29,7 @@
       text-align:left; box-shadow:var(--shadow-sm);
     }
     .role-btn:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
-    .role-btn .role-icon { width:22px; height:22px; flex-shrink:0; display:inline-flex; align-items:center; color:var(--brass); }
+    .role-btn .role-icon { width:22px; height:22px; flex-shrink:0; display:inline-flex; align-items:center; color:var(--brass-fg); }
     .role-btn .role-icon svg { width:100%; height:100%; }
     .role-btn .role-label { color:var(--text); font-size:13px; font-weight:500; letter-spacing:.5px; }
     .role-btn .role-desc { color:var(--muted); font-size:11px; margin-top:2px; }
@@ -41,7 +41,7 @@
     .role-btn.role-ward   { border-color:#9b59b644; }
     .role-btn.role-ward:hover { border-color:#9b59b6; }
     .back-link { display:block; text-align:center; margin-top:12px; color:var(--muted); font-size:12px; cursor:pointer; }
-    .back-link:hover { color:var(--brass); }
+    .back-link:hover { color:var(--brass-fg); }
   </style>
 </head>
 <body>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -25,14 +25,14 @@
       border-radius:20px; padding:5px 14px; font-size:11px; font-family:inherit; cursor:pointer;
       letter-spacing:.5px; transition:all .2s; }
     .filter-btn.active { background:var(--brass); color:#0b1f38; border-color:var(--brass); }
-    .filter-btn:hover:not(.active):not(.muted) { border-color:var(--brass); color:var(--brass); }
+    .filter-btn:hover:not(.active):not(.muted) { border-color:var(--brass); color:var(--brass-fg); }
     .filter-btn.muted { opacity:0.3; pointer-events:none; border-style:dashed; }
 
     /* ── Stat strip ── */
     .stat-strip { display:grid; grid-template-columns:repeat(5,1fr); gap:8px; margin-bottom:20px; }
     .stat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
       padding:12px; text-align:center; box-shadow:var(--shadow-sm); }
-    .stat-num { font-size:24px; color:var(--brass); font-weight:500; }
+    .stat-num { font-size:24px; color:var(--brass-fg); font-weight:500; }
     .stat-label { font-size:10px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
     @media(max-width:580px){ .stat-strip { grid-template-columns:repeat(2,1fr); } }
 
@@ -82,7 +82,7 @@
     .modal-overlay.hidden { display:none; }
     .modal { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-lg);
       padding:22px; width:100%; max-width:500px; max-height:90vh; overflow-y:auto; box-shadow:var(--shadow-lg); }
-    .modal h3 { color:var(--brass); margin-bottom:16px; font-size:15px; }
+    .modal h3 { color:var(--brass-fg); margin-bottom:16px; font-size:15px; }
     .field { margin-bottom:14px; }
     .field label { display:block; font-size:10px; color:var(--muted); letter-spacing:.8px; margin-bottom:6px; }
     .field input, .field select, .field textarea {
@@ -108,7 +108,7 @@
     .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border);
       background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit;
       cursor:pointer; text-align:center; transition:all .2s; }
-    .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
+    .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)11; }
 
     /* Photo preview */
     .photo-preview { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm);
@@ -153,7 +153,7 @@
   </div>
 
   <!-- Pending sauma review alert -->
-  <div id="pendingReviewAlert" class="hidden" style="margin:10px 0;padding:10px 14px;border-radius:8px;background:var(--brass)11;border:1px solid var(--brass)66;color:var(--brass);font-size:13px;display:flex;align-items:center;gap:10px;cursor:pointer" onclick="showPendingReviews()">
+  <div id="pendingReviewAlert" class="hidden" style="margin:10px 0;padding:10px 14px;border-radius:8px;background:var(--brass)11;border:1px solid var(--brass)66;color:var(--brass-fg);font-size:13px;display:flex;align-items:center;gap:10px;cursor:pointer" onclick="showPendingReviews()">
     <span style="font-size:18px">⏳</span>
     <span id="pendingReviewAlertText" style="flex:1"></span>
     <span style="font-size:11px;opacity:.8">→</span>

--- a/member/index.html
+++ b/member/index.html
@@ -84,12 +84,12 @@
   font-family:inherit; font-size:11px; letter-spacing:.6px; cursor:pointer;
   border-bottom:2px solid transparent; white-space:nowrap; transition:color .2s,border-color .2s; margin-bottom:-1px; }
 .hub-tab:hover:not(.active) { color:var(--text); }
-.hub-tab.active { color:var(--brass); border-bottom-color:var(--brass); }
+.hub-tab.active { color:var(--brass-fg); border-bottom-color:var(--brass); }
 
 /* ── Boat category section ── */
 .boat-cat-toggle { display:flex; align-items:center; justify-content:space-between;
   padding:9px 0; cursor:pointer; user-select:none; border-bottom:1px solid var(--border)44; }
-.boat-cat-toggle:hover .bct-label { color:var(--brass); }
+.boat-cat-toggle:hover .bct-label { color:var(--brass-fg); }
 .bct-label { font-size:11px; font-weight:500; }
 .bct-count { font-size:10px; color:var(--muted); }
 .bct-arrow { font-size:10px; color:var(--muted); transition:transform .2s; }
@@ -108,7 +108,7 @@
   padding:12px 14px; margin-bottom:8px; cursor:pointer; transition:border-color .2s,box-shadow .2s; box-shadow:var(--shadow-sm); }
 .pub-trip:hover { border-color:var(--brass); }
 .pub-trip-head { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; }
-.pub-trip-date  { font-size:10px; color:var(--brass); margin-bottom:2px; }
+.pub-trip-date  { font-size:10px; color:var(--brass-fg); margin-bottom:2px; }
 .pub-trip-title { font-size:12px; font-weight:500; }
 .pub-trip-meta  { font-size:11px; color:var(--muted); margin-top:4px; display:flex; gap:8px; flex-wrap:wrap; }
 
@@ -122,7 +122,7 @@
 /* ── Stats card ── */
 .stats-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:8px; margin-bottom:14px; }
 .stat-box { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 12px; text-align:center; box-shadow:var(--shadow-sm); }
-.stat-box .sn { font-size:24px; color:var(--brass); font-weight:500; }
+.stat-box .sn { font-size:24px; color:var(--brass-fg); font-weight:500; }
 .stat-box .sl { font-size:9px; color:var(--muted); margin-top:4px; letter-spacing:.5px; }
 
 /* ── Cert badges ── */
@@ -131,7 +131,7 @@
 /* ── Inline report form styles ── */
 .cat-btns { display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
 .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border); background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit; cursor:pointer; text-align:center; transition:all .2s; }
-.cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
+.cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)11; }
 .sev-btns { display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
 .sev-btn { flex:1; min-width:60px; padding:7px 4px; border-radius:var(--radius-sm); border:1px solid; font-size:11px; font-family:inherit; cursor:pointer; text-align:center; font-weight:600; letter-spacing:.4px; transition:all .2s; }
 .sev-btn[data-sev="low"]      { color:var(--green);  border-color:var(--green)55;  background:var(--green)11;  }
@@ -167,7 +167,7 @@
   padding:12px 14px; margin-bottom:8px; }
 .conf-card .conf-from { font-size:12px; font-weight:500; color:var(--text); }
 .conf-card .conf-detail { font-size:11px; color:var(--muted); margin-top:3px; }
-.conf-card .conf-boat { font-size:11px; color:var(--brass); margin-top:2px; }
+.conf-card .conf-boat { font-size:11px; color:var(--brass-fg); margin-top:2px; }
 .conf-card .conf-actions { display:flex; gap:6px; margin-top:8px; }
 .conf-card .conf-actions button { font-size:11px; font-family:inherit; padding:5px 12px; border-radius:var(--radius-sm); cursor:pointer; border:1px solid; }
 .conf-card .btn-confirm { background:var(--green)18; color:var(--green); border-color:var(--green)55; }
@@ -689,7 +689,7 @@ function renderLaunchForm(boat) {
   document.getElementById('launchModalBody').innerHTML=
     '<div class="field"><label>'+s('lbl.location')+'</label>'+
     '<select id="launchLocation"><option value="">'+s('lbl.selectDots')+'</option>'+locOpts+'</select></div>'+
-    (isKeel?'<div class="field"><label style="color:var(--brass)">⚓️ '+s('member.departurePort')+'</label>'+
+    (isKeel?'<div class="field"><label style="color:var(--brass-fg)">⚓️ '+s('member.departurePort')+'</label>'+
       '<input type="text" list="launchPortsList" id="launchDeparturePort" placeholder="'+s('member.homePort')+'" value="'+esc(defaultPort)+'" autocomplete="off">'+
       '<datalist id="launchPortsList">'+portOpts+'</datalist></div>':'')+
     '<div class="grid2 mb-12 gap-10">'+
@@ -853,7 +853,7 @@ function searchCrewMembers(inp,drop) {
     if (m.role==='guest') {
       const badge=document.createElement('span');
       badge.textContent=s('lbl.guest');
-      badge.style.cssText='font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);flex-shrink:0';
+      badge.style.cssText='font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);flex-shrink:0';
       item.appendChild(badge);
     }
     item.dataset.name=m.name; item.dataset.kennitala=m.kennitala||''; item.dataset.guest=m.role==='guest'?'1':'';
@@ -867,7 +867,7 @@ function searchCrewMembers(inp,drop) {
   // Add "add as guest" option when typed name has 3+ chars
   if(q.length>=3){
     const guest=document.createElement('div');
-    guest.style.cssText='padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border);color:var(--brass)';
+    guest.style.cssText='padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border);color:var(--brass-fg)';
     guest.textContent=s('logbook.addAsGuest',{name:inp.value.trim()});
     guest.addEventListener('mousedown',function(e){
       e.preventDefault(); drop.style.display='none';
@@ -1146,7 +1146,7 @@ function renderLandingChecklist() {
     portDistRow=
       '<div class="field" style="display:flex;gap:10px;align-items:flex-end;margin-bottom:10px">'+
         '<div style="flex:1;min-width:0">'+
-          '<label style="display:block;font-size:9px;color:var(--brass);letter-spacing:.8px;margin-bottom:6px">'+'⚓️ '+s('member.arrivalPortLabel')+'</label>'+
+          '<label style="display:block;font-size:9px;color:var(--brass-fg);letter-spacing:.8px;margin-bottom:6px">'+'⚓️ '+s('member.arrivalPortLabel')+'</label>'+
           '<input type="text" list="retPortsList" id="retArrivalPort" placeholder="'+s('member.sameAsDeparture')+'" value="'+esc(homePt)+'" autocomplete="off" style="width:100%">'+
           '<datalist id="retPortsList">'+portOpts+'</datalist>'+
         '</div>'+
@@ -1177,7 +1177,7 @@ function renderLandingChecklist() {
     '</div>':'')+
     portDistRow+uploadRow+distStandaloneRow+
     '<div class="field" style="margin-bottom:14px">'+
-      '<label style="display:block;font-size:9px;color:var(--brass);letter-spacing:.8px;margin-bottom:6px">'+s('member.skipperNotes')+'</label>'+
+      '<label style="display:block;font-size:9px;color:var(--brass-fg);letter-spacing:.8px;margin-bottom:6px">'+s('member.skipperNotes')+'</label>'+
       '<div style="font-size:10px;color:var(--muted);margin-bottom:6px">'+s('member.notesVisibleAll')+'</div>'+
       '<textarea id="retSkipperNote" rows="2" placeholder="'+s('member.notesPlaceholder')+'" style="width:100%;resize:none;font-size:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px;font-family:inherit;box-sizing:border-box"></textarea>'+
     '</div>'+
@@ -1206,7 +1206,7 @@ function _renderHelmSection(){
     return mem&&mem.role==='guest';
   }
   function _guestTag(t){
-    return _isGuest(t)?' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:4px">'+s('member.guestLabel')+'</span>':'';
+    return _isGuest(t)?' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);margin-left:4px">'+s('member.guestLabel')+'</span>':'';
   }
   if(el){
     if(!entries.length){el.textContent=s('member.noNamedCrew');}
@@ -1669,7 +1669,7 @@ function renderClubCalendars() {
     return '<div style="margin-bottom:14px">'
       + '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px">'
       +   '<span style="font-size:11px;font-weight:500;color:var(--text)">' + esc(c.name) + '</span>'
-      +   '<a href="' + openUrl + '" target="_blank" rel="noopener" style="font-size:11px;color:var(--brass);text-decoration:none">' + esc(s('member.calOpen')) + ' \u2197</a>'
+      +   '<a href="' + openUrl + '" target="_blank" rel="noopener" style="font-size:11px;color:var(--brass-fg);text-decoration:none">' + esc(s('member.calOpen')) + ' \u2197</a>'
       + '</div>'
       + '<div style="border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden">'
       +   '<iframe src="' + src + '" style="border:0;width:100%;height:380px;display:block" frameborder="0"></iframe>'

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
   --navy-l:  #5b83cf;
   --moss:    #4fa55e;
   --brass:   #d9b441;
+  --brass-fg:#d9b441;
   --green:   var(--moss);
   --red:     #e74c3c;
   --yellow:  #f1c40f;
@@ -58,15 +59,15 @@
 .chart-lbl-bg { fill: var(--card); opacity: 0.85; }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bg);color:var(--text);font-family:var(--font-sans);font-size:14px;line-height:1.6;min-height:100vh;-webkit-font-smoothing:antialiased}
-a{color:var(--brass);text-decoration:none}
+a{color:var(--brass-fg);text-decoration:none}
 a:hover{text-decoration:underline}
 
 /* ── Header ─────────────────────────────────────────────────────── */
 header{background:var(--surface);border-bottom:1px solid var(--border);box-shadow:var(--shadow-md);padding:12px 24px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100}
-.logo{font-size:18px;font-weight:500;color:var(--brass);letter-spacing:1px}
+.logo{font-size:18px;font-weight:500;color:var(--brass-fg);letter-spacing:1px}
 .subtitle{font-size:11px;color:var(--muted);letter-spacing:.5px;margin-left:12px}
 .lang-btn{background:none;border:1px solid var(--border);color:var(--muted);font-family:inherit;font-size:11px;padding:4px 10px;border-radius:var(--radius-sm);cursor:pointer;letter-spacing:.5px;transition:color .2s,border-color .2s,background .2s}
-.lang-btn:hover{color:var(--brass);border-color:var(--brass);background:rgba(212,175,55,.06)}
+.lang-btn:hover{color:var(--brass-fg);border-color:var(--brass);background:rgba(212,175,55,.06)}
 
 /* ── Main layout ────────────────────────────────────────────────── */
 main{max-width:1100px;margin:0 auto;padding:24px 20px 48px}
@@ -76,7 +77,7 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 /* ── Stat boxes ─────────────────────────────────────────────────── */
 .stats-row{display:flex;gap:16px;flex-wrap:wrap;margin-bottom:20px}
 .stat-box{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 24px;flex:1;min-width:140px;text-align:center;box-shadow:var(--shadow-sm)}
-.stat-val{font-size:32px;font-weight:500;color:var(--brass);line-height:1.2}
+.stat-val{font-size:32px;font-weight:500;color:var(--brass-fg);line-height:1.2}
 .stat-lbl{font-size:11px;color:var(--muted);letter-spacing:.5px;margin-top:4px}
 
 /* ── Category breakdown ─────────────────────────────────────────── */
@@ -90,7 +91,7 @@ h2{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:1.2px;text-t
 /* ── On the water strip ─────────────────────────────────────────── */
 .stat-strip{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-bottom:14px}
 .strip-cell{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 10px;text-align:center;box-shadow:var(--shadow-sm)}
-.strip-n{font-size:22px;color:var(--brass);font-weight:500}
+.strip-n{font-size:22px;color:var(--brass-fg);font-weight:500}
 .strip-l{font-size:10px;color:var(--muted);letter-spacing:1px;margin-top:2px}
 .live-badge{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--green);margin-right:6px;animation:pulse 2s infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -15,7 +15,7 @@
   <style>
     .page-wrap { max-width: 820px; margin: 0 auto; padding: 20px 16px 60px; transition: max-width .2s; }
     .page-wrap.wide-board { max-width: 1200px; }
-    .page-title { font-size: 16px; font-weight: 600; color: var(--brass); margin-bottom: 4px; }
+    .page-title { font-size: 16px; font-weight: 600; color:var(--brass-fg); margin-bottom: 4px; }
     .page-subtitle { font-size: 12px; color: var(--muted); margin-bottom: 18px; }
 
     /* ── Filter bar ── */
@@ -24,7 +24,7 @@
       border-radius:20px; padding:5px 14px; font-size:11px; font-family:inherit; cursor:pointer;
       letter-spacing:.5px; transition:all .2s; }
     .filter-btn.active { background:var(--brass); color:#0b1f38; border-color:var(--brass); }
-    .filter-btn:hover:not(.active) { border-color:var(--brass); color:var(--brass); }
+    .filter-btn:hover:not(.active) { border-color:var(--brass); color:var(--brass-fg); }
 
     /* ── Project card ── */
     .req-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
@@ -43,7 +43,7 @@
     .req-photo:hover { opacity:.8; }
     .comment-thread { margin-top:8px; border-top:1px solid var(--border)44; padding-top:8px; }
     .comment-item { margin-bottom:8px; }
-    .verk-tag { font-size:11px; color:var(--brass); font-weight:500; }
+    .verk-tag { font-size:11px; color:var(--brass-fg); font-weight:500; }
 
     /* ── Badges ── */
     .badge { display:inline-block; font-size:10px; padding:2px 7px; border-radius:4px; font-weight:500; letter-spacing:.3px; }
@@ -52,7 +52,7 @@
     .badge-orange { background:var(--orange)22; color:var(--orange); border:1px solid var(--orange)44; }
     .badge-red    { background:var(--red)22;    color:var(--red);    border:1px solid var(--red)44; }
     .badge-muted  { background:var(--surface);  color:var(--muted);  border:1px solid var(--border); }
-    .badge-brass  { background:var(--brass)22;  color:var(--brass);  border:1px solid var(--brass)44; }
+    .badge-brass  { background:var(--brass)22;  color:var(--brass-fg);  border:1px solid var(--brass)44; }
     .oos-badge { font-size:10px; background:var(--red)22; color:var(--red);
       border:1px solid var(--red)44; border-radius:3px; padding:2px 6px; font-weight:500; }
 
@@ -65,7 +65,7 @@
     .modal-overlay.hidden { display:none; }
     .modal { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-lg);
       padding:22px; width:100%; max-width:500px; max-height:90vh; overflow-y:auto; box-shadow:var(--shadow-lg); }
-    .modal h3 { color:var(--brass); margin-bottom:16px; font-size:15px; }
+    .modal h3 { color:var(--brass-fg); margin-bottom:16px; font-size:15px; }
     .field { margin-bottom:14px; }
     .field label { display:block; font-size:10px; color:var(--muted); letter-spacing:.8px; margin-bottom:6px; }
     .field input, .field select, .field textarea {
@@ -90,7 +90,7 @@
     .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border);
       background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit;
       cursor:pointer; text-align:center; transition:all .2s; }
-    .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass); background:var(--brass)11; }
+    .cat-btn.selected, .cat-btn:hover { border-color:var(--brass); color:var(--brass-fg); background:var(--brass)11; }
 
     .photo-preview { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm);
       border:1px solid var(--border); margin-top:6px; display:none; }
@@ -427,7 +427,7 @@ function renderProjectCard(r) {
     ${r.description ? `<div class="req-desc">${esc(r.description)}</div>` : ''}
     ${r.photoUrl ? `<img class="req-photo" src="${esc(r.photoUrl)}" onclick="event.stopPropagation();viewPhoto('${esc(r.photoUrl)}')">` : ''}
     <div class="flex-center gap-8 mt-8 text-sm text-muted">
-      ${following ? '<span style="color:var(--brass)" title="' + s('sauma.unfollow') + '">★</span>' : ''}
+      ${following ? '<span style="color:var(--brass-fg)" title="' + s('sauma.unfollow') + '">★</span>' : ''}
       <span>💬 ${commentCount}</span>
       ${lastComment ? `<span>· ${esc(lastComment.by||'')} · ${sstr(lastComment.at).slice(0,16).replace('T',' ')}</span>` : ''}
     </div>
@@ -515,7 +515,7 @@ function renderKanbanCard(r) {
       ${r.verkstjori ? `<span class="verk-tag" style="font-size:10px">${esc(r.verkstjori)}</span>` : ''}
       ${materials.length ? `<span>📦 ${matDone}/${materials.length}</span>` : ''}
       ${comments.length ? `<span>💬 ${comments.length}</span>` : ''}
-      ${_isFollowing(r) ? '<span style="color:var(--brass)">★</span>' : ''}
+      ${_isFollowing(r) ? '<span style="color:var(--brass-fg)">★</span>' : ''}
     </div>
   </div>`;
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -39,7 +39,7 @@
 .session-row .ua{font-size:12px;color:var(--text);word-break:break-word}
 .session-row .when{font-size:10px;color:var(--muted);margin-top:2px}
 .session-row.current{border-color:var(--brass)}
-.session-row.current .badge{display:inline-block;margin-left:6px;font-size:9px;color:var(--brass);border:1px solid var(--brass);border-radius:99px;padding:1px 6px;letter-spacing:.5px;text-transform:uppercase}
+.session-row.current .badge{display:inline-block;margin-left:6px;font-size:9px;color:var(--brass-fg);border:1px solid var(--brass);border-radius:99px;padding:1px 6px;letter-spacing:.5px;text-transform:uppercase}
 .session-row .row-del{background:none;border:1px solid var(--border);color:var(--muted);padding:5px 10px;border-radius:var(--radius-sm);cursor:pointer;font-size:11px}
 .session-row .row-del:hover{border-color:var(--red);color:var(--red)}
 .save-bar{position:sticky;bottom:-20px;background:var(--card);border-top:1px solid var(--border);padding:12px 0;margin-top:16px;display:flex;gap:8px;justify-content:flex-end}

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -329,7 +329,7 @@ function renderBoatCard(boat, opts) {
   // Badge
   const badgeMap = {
     avail:   { text:s("fleet.badgeAvail"),   style:"color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)" },
-    out:     { text:s("fleet.badgeOut"),      style:"color:var(--brass);border-color:var(--brass)55;background:var(--brass)11" },
+    out:     { text:s("fleet.badgeOut"),      style:"color:var(--brass-fg);border-color:var(--brass)55;background:var(--brass)11" },
     overdue: { text:s("fleet.badgeOverdue"),  style:"color:var(--red);border-color:var(--red)55;background:var(--red)11" },
     oos:     { text:s("fleet.badgeOos"),      style:"color:var(--muted);border-color:var(--border);background:var(--surface)" },
   };
@@ -363,11 +363,11 @@ function renderBoatCard(boat, opts) {
   const userCanAccess = curUser ? canAccessBoat(boat, curUser) : true;
   let ownerLine = "";
   if (priv && boat.ownerName) {
-    ownerLine = `<div style="font-size:10px;color:var(--brass);margin-top:4px">${_besc(s("fleet.ownedBy",{name:boat.ownerName}))}</div>`;
+    ownerLine = `<div style="font-size:10px;color:var(--brass-fg);margin-top:4px">${_besc(s("fleet.ownedBy",{name:boat.ownerName}))}</div>`;
   }
   let charterLine = "";
   if (activeRes) {
-    charterLine = `<div style="font-size:10px;color:var(--brass);margin-top:4px">`
+    charterLine = `<div style="font-size:10px;color:var(--brass-fg);margin-top:4px">`
                 + `${_besc(s("boat.reservedFor",{name:activeRes.memberName}))} ${_besc(s("boat.reservedUntil",{date:activeRes.endDate}))}`
                 + `</div>`;
   }
@@ -385,7 +385,7 @@ function renderBoatCard(boat, opts) {
   if (controlled && !userCanAccess && !opts.staffView) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--red);border-color:var(--red)55;background:var(--red)11;margin-left:4px">${_besc(s("fleet.badgeRestricted"))}</span>`;
   } else if (activeRes) {
-    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeChartered"))}</span>`;
+    ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass-fg);border-color:var(--brass)55;background:var(--brass)11;margin-left:4px">${_besc(s("fleet.badgeChartered"))}</span>`;
   } else if (controlled && userCanAccess && !opts.staffView) {
     ownerBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent);margin-left:4px">${_besc(s("fleet.badgeAuthorized"))}</span>`;
   } else if (priv) {
@@ -450,7 +450,7 @@ function renderCheckoutCard(co, opts) {
   if (!staffView) {
     if      (overdue) topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--red);border-color:var(--red)55;background:var(--red)11">${_besc(s("fleet.badgeOverdue"))}</span>`;
     else if (isMe)    topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)">${_besc(s("fleet.badgeYours"))}</span>`;
-    else              topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass);border-color:var(--brass)55;background:var(--brass)11">${_besc(s("fleet.badgeOut"))}</span>`;
+    else              topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--brass-fg);border-color:var(--brass)55;background:var(--brass)11">${_besc(s("fleet.badgeOut"))}</span>`;
   } else if (overdue) {
     topBadge = `<span style="font-size:9px;letter-spacing:.8px;padding:2px 7px;border-radius:10px;border:1px solid;color:var(--red);border-color:var(--red)55;background:var(--red)11">⚠️ ${_besc(s("fleet.badgeOverdue"))}</span>`;
   }
@@ -479,11 +479,11 @@ function renderCheckoutCard(co, opts) {
     if (isMinor && co.guardianName) {
       contactHtml = `<div style="font-size:11px;color:var(--muted);background:var(--card);border:1px solid var(--brass)44;border-radius:6px;padding:7px 10px;margin-top:8px;display:flex;align-items:center;gap:8px">`
                   + `<span>· Minor — guardian: <strong style="color:var(--text)">${_besc(co.guardianName)}</strong></span>`
-                  + `${co.guardianPhone?`<a href="tel:${_besc(co.guardianPhone)}" style="color:var(--brass);text-decoration:none">${_besc(co.guardianPhone)}</a>`:""}`
+                  + `${co.guardianPhone?`<a href="tel:${_besc(co.guardianPhone)}" style="color:var(--brass-fg);text-decoration:none">${_besc(co.guardianPhone)}</a>`:""}`
                   + `</div>`;
     } else if (co.memberPhone) {
       contactHtml = `<div style="font-size:11px;color:var(--muted);background:var(--card);border:1px solid var(--border);border-radius:6px;padding:7px 10px;margin-top:8px;display:flex;align-items:center;gap:8px">`
-                  + `<span>=</span><a href="tel:${_besc(co.memberPhone)}" style="color:var(--brass);text-decoration:none">${_besc(co.memberPhone)}</a>`
+                  + `<span>=</span><a href="tel:${_besc(co.memberPhone)}" style="color:var(--brass-fg);text-decoration:none">${_besc(co.memberPhone)}</a>`
                   + `</div>`;
     }
   }

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -107,11 +107,11 @@ function tripCard(t){
   const helmLabel = s('tc.helm');
   const helmBadge = ' <span class="text-brass" style="font-size:9px;border:1px solid var(--brass)55;border-radius:4px;padding:0 3px;margin-left:2px">'+helmLabel+'</span>';
   const guestLabel = s('tc.guest');
-  const guestBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:2px">'+guestLabel+'</span>';
+  const guestBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);margin-left:2px">'+guestLabel+'</span>';
   const studentLabel = s('tc.student');
   const studentBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid color-mix(in srgb, var(--navy-l) 33%, transparent);background:color-mix(in srgb, var(--navy-l) 8%, transparent);color:var(--navy-l);margin-left:2px">'+studentLabel+'</span>';
   const skipperLabel = s('tc.skipper');
-  const skipperBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:2px">'+skipperLabel+'</span>';
+  const skipperBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);margin-left:2px">'+skipperLabel+'</span>';
   const pendingTag = `<span class="conf-status pending" style="font-size:9px;padding:1px 6px">${s('tc.pending')}</span>`;
 
   // Check for pending/confirmed student confirmations
@@ -884,7 +884,7 @@ function searchManualMember(inp, dropOrId){
     if (m.role==='guest') {
       const badge=document.createElement('span');
       badge.textContent=s('lbl.guest');
-      badge.style.cssText='font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);flex-shrink:0';
+      badge.style.cssText='font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);flex-shrink:0';
       item.appendChild(badge);
     }
     item.addEventListener('mousedown',function(e){
@@ -1046,7 +1046,7 @@ function renderClubTripsList(){
     document.getElementById('loadMoreTripsBtn').style.display='none';
     return;
   }
-  var _gBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);margin-left:2px">'+s('tc.guest')+'</span>';
+  var _gBadge = ' <span style="font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);margin-left:2px">'+s('tc.guest')+'</span>';
   var frag = document.createDocumentFragment();
   page.forEach(function(t) {
     var _sm = t.kennitala ? allMembers.find(function(m){return String(m.kennitala)===String(t.kennitala);}) : null;

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -65,7 +65,7 @@ function maintRenderCardCompact(r) {
   const oosTag    = boolVal(r.markOos) && r.category==='boat' && !boolVal(r.resolved)
     ? '<span style="background:var(--red);color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;white-space:nowrap;flex-shrink:0">'+s('maint.oosTag')+'</span>' : '';
   const saumaTag = boolVal(r.saumaklubbur)
-    ? '<span style="font-size:10px;background:var(--brass)22;color:var(--brass);border:1px solid var(--brass)44;padding:1px 6px;border-radius:10px;white-space:nowrap;flex-shrink:0">🧵</span>' : '';
+    ? '<span style="font-size:10px;background:var(--brass)22;color:var(--brass-fg);border:1px solid var(--brass)44;padding:1px 6px;border-radius:10px;white-space:nowrap;flex-shrink:0">🧵</span>' : '';
   const subject = r.category==='boat' ? esc(r.boatName||r.boatId||'') : '';
   const part = esc(r.part||'');
   const fallback = (!subject && !part) ? esc(maintTitleFallback_(r)) : '';
@@ -169,7 +169,7 @@ function maintOpenDetail(r, currentUser) {
     // Materials list for saumaklúbbur projects
     const materialsHtml = isSauma ? `
       <div style="margin-bottom:14px">
-        <div style="font-size:10px;color:var(--brass);letter-spacing:1px;margin-bottom:6px">${s('maint.materials')}</div>
+        <div style="font-size:10px;color:var(--brass-fg);letter-spacing:1px;margin-bottom:6px">${s('maint.materials')}</div>
         ${materials.map((m,i)=>`
           <div class="mat-row" data-midx="${i}" style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:12px;border-bottom:1px solid var(--border)33">
             <input type="checkbox" ${m.purchased?'checked':''} style="width:15px;height:15px;accent-color:var(--green);cursor:pointer" data-matidx="${i}">
@@ -195,7 +195,7 @@ function maintOpenDetail(r, currentUser) {
         ${oosBtn}
       </div>
       ${isSauma ? `<div style="margin-bottom:10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-        <span class="badge" style="background:var(--brass)22;color:var(--brass);border:1px solid var(--brass)44">🧵 ${s('maint.saumaBadge')}</span>
+        <span class="badge" style="background:var(--brass)22;color:var(--brass-fg);border:1px solid var(--brass)44">🧵 ${s('maint.saumaBadge')}</span>
         ${isOnHold ? `<span class="badge" style="background:var(--yellow)22;color:var(--yellow);border:1px solid var(--yellow)44">⏸ ${s('maint.onHoldBadge')}</span>` : ''}
         ${r.verkstjori ? `<span style="font-size:12px;color:var(--muted)">Verkstjóri: <strong style="color:var(--text)">${esc(r.verkstjori)}</strong></span>` : `<span style="font-size:12px;color:var(--muted);font-style:italic">${s('maint.noVerkstjori')}</span>`}
         ${!r.verkstjori && !resolved ? `<button id="mdAdoptBtn" class="btn btn-secondary" style="font-size:11px;padding:4px 12px">${s('maint.adoptProject')}</button>` : ''}
@@ -220,7 +220,7 @@ function maintOpenDetail(r, currentUser) {
         </div>
         <div id="mdCommentPhotoPreview" style="margin-top:6px"></div>
       </div>
-      ${isSauma && !boolVal(r.approved) ? `<div style="margin-bottom:10px;padding:8px 12px;border-radius:6px;background:var(--brass)11;border:1px solid var(--brass)44;font-size:12px;color:var(--brass)">⏳ ${s('maint.pendingReview')}<button id="mdApproveBtn" class="btn btn-primary" style="font-size:11px;padding:4px 14px;margin-left:12px">${s('maint.approveBtn')}</button></div>` : ''}
+      ${isSauma && !boolVal(r.approved) ? `<div style="margin-bottom:10px;padding:8px 12px;border-radius:6px;background:var(--brass)11;border:1px solid var(--brass)44;font-size:12px;color:var(--brass-fg)">⏳ ${s('maint.pendingReview')}<button id="mdApproveBtn" class="btn btn-primary" style="font-size:11px;padding:4px 14px;margin-left:12px">${s('maint.approveBtn')}</button></div>` : ''}
       <div class="req-actions" style="margin-top:10px;display:flex;gap:8px;align-items:center">
         <button id="mdDeleteBtn" class="btn btn-secondary" style="font-size:12px;color:var(--red)">${s('maint.deleteBtn')}</button>
         ${typeof window.maintOpenEdit === 'function' ? `<button id="mdEditBtn" class="btn btn-secondary" style="font-size:12px;padding:7px 14px">${s('btn.edit')}</button>` : ''}
@@ -516,7 +516,7 @@ function maintRenderCard(r) {
     ? esc(r.boatName||r.boatId||'')
     : '';
   const oosTag = isOos ? '<span class="oos-badge">'+s('maint.oosTag')+'</span>' : '';
-  const saumaBadge = isSauma ? '<span style="font-size:10px;background:var(--brass)22;color:var(--brass);border:1px solid var(--brass)44;padding:1px 6px;border-radius:3px">🧵</span>' : '';
+  const saumaBadge = isSauma ? '<span style="font-size:10px;background:var(--brass)22;color:var(--brass-fg);border:1px solid var(--brass)44;padding:1px 6px;border-radius:3px">🧵</span>' : '';
 
   const comments = parseJson(r.comments, []);
   const materials = isSauma ? parseJson(r.materials, []) : [];
@@ -537,7 +537,7 @@ function maintRenderCard(r) {
         </div>
         <div class="req-meta">
           <span class="badge ${SEV_BADGE[r.severity]||'badge-green'}">${r.severity||'low'}</span>
-          ${isSauma && r.verkstjori ? `<span style="color:var(--brass)">Verkstjóri: ${esc(r.verkstjori)}</span>` : ''}
+          ${isSauma && r.verkstjori ? `<span style="color:var(--brass-fg)">Verkstjóri: ${esc(r.verkstjori)}</span>` : ''}
           ${r.reportedBy ? `<span>${esc(r.reportedBy)}</span>` : ''}
           ${r.createdAt  ? `<span>${sstr(r.createdAt).slice(0,10)}</span>` : ''}
           ${materials.length ? `<span>📦 ${matDone}/${materials.length}</span>` : ''}

--- a/shared/mcm.js
+++ b/shared/mcm.js
@@ -40,7 +40,7 @@
       '      <input type="text" id="mcmMemberSearch" oninput="mcmFilterMembers()" autocomplete="off" placeholder="">',
       '      <div id="mcmMemberResults" style="max-height:120px;overflow-y:auto;margin-top:4px"></div>',
       '    </div>',
-      '    <div id="mcmMemberName" style="margin-top:6px;margin-bottom:10px;font-size:12px;font-weight:500;color:var(--brass);display:none"></div>',
+      '    <div id="mcmMemberName" style="margin-top:6px;margin-bottom:10px;font-size:12px;font-weight:500;color:var(--brass-fg);display:none"></div>',
       '',
       '    <!-- Current certs -->',
       '    <div id="mcmCurrentWrap" style="margin-bottom:14px;display:none">',
@@ -349,7 +349,7 @@
       var expiry = c.expiresAt
         ? (c.expired ? ' \u00b7 <span style="color:var(--red)">EXPIRED ' + c.expiresAt + '</span>' : ' \u00b7 exp. ' + c.expiresAt)
         : ' \u00b7 Does not expire';
-      var catLine  = c.displayCategory ? '<span style="color:var(--brass)">[' + esc(c.displayCategory) + ']</span> ' : '';
+      var catLine  = c.displayCategory ? '<span style="color:var(--brass-fg)">[' + esc(c.displayCategory) + ']</span> ' : '';
       var authLine = c.issuingAuthority ? ' \u00b7 ' + esc(c.issuingAuthority) : '';
       var verifiedLine = c.verifiedBy ? ' \u00b7 verified by ' + esc(c.verifiedBy) : (c.assignedBy ? ' \u00b7 by ' + esc(c.assignedBy) : '');
       var dateLine = c.verifiedAt || c.assignedAt ? ' on ' + (c.verifiedAt || c.assignedAt) : '';

--- a/shared/payroll.js
+++ b/shared/payroll.js
@@ -268,7 +268,7 @@ function punchClockWidget(el, employeeId, opts) {
       '.pc-btn:disabled{opacity:.45;cursor:default}' +
       '.pc-btn-in{background:var(--green);color:#fff}' +
       '.pc-btn-out{background:var(--red);color:#fff}' +
-      '.pc-btn-brk{background:var(--surface);border:1px solid var(--brass);color:var(--brass)}' +
+      '.pc-btn-brk{background:var(--surface);border:1px solid var(--brass);color:var(--brass-fg)}' +
       '.pc-btn-brk-end{background:var(--brass);color:#0b1f38}' +
       '.pc-status{font-size:11px;color:var(--muted);display:flex;align-items:center;gap:6px}' +
       '.pc-recent{border-top:1px solid var(--border);padding:10px 16px 12px;display:flex;flex-direction:column;gap:0}' +
@@ -283,7 +283,7 @@ function punchClockWidget(el, employeeId, opts) {
       // End-of-shift modal
       '.pc-modal-bg{position:fixed;inset:0;background:#00000088;z-index:600;display:flex;align-items:flex-end;justify-content:center}' +
       '.pc-modal{background:var(--bg);border-radius:16px 16px 0 0;padding:20px 20px 36px;width:100%;max-width:520px;max-height:80vh;overflow-y:auto}' +
-      '.pc-modal-title{font-size:14px;font-weight:600;color:var(--brass);margin-bottom:4px;letter-spacing:.3px}' +
+      '.pc-modal-title{font-size:14px;font-weight:600;color:var(--brass-fg);margin-bottom:4px;letter-spacing:.3px}' +
       '.pc-modal-sub{font-size:11px;color:var(--muted);margin-bottom:16px}' +
       '.pc-summary-row{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid var(--border);font-size:13px}' +
       '.pc-summary-row:last-child{border-bottom:none}' +

--- a/shared/style.css
+++ b/shared/style.css
@@ -63,6 +63,7 @@
   --brass:    #d9b441;
   --brass-d:  #b8941f;
   --brass-l:  #e8c84a;
+  --brass-fg: #d9b441;
   --green:    var(--moss);
   --yellow:   #f1c40f;
   --orange:   #e67e22;
@@ -97,6 +98,7 @@
   --brass:    #2070a8;
   --brass-d:  #18537e;
   --brass-l:  #4a9bd4;
+  --brass-fg: #1e8e4e;
   --green:    #1e8e4e;
   --yellow:   #d4a80c;
   --orange:   #c46a1a;
@@ -121,6 +123,7 @@
     --brass:    #2070a8;
     --brass-d:  #18537e;
     --brass-l:  #4a9bd4;
+    --brass-fg: #1e8e4e;
     --green:    #1e8e4e;
     --yellow:   #d4a80c;
     --orange:   #c46a1a;
@@ -178,7 +181,7 @@ header {
   aspect-ratio: 1170 / 1450;
   flex-shrink: 0;
   display: inline-block;
-  background: var(--brass);
+  background: #fff;
   -webkit-mask: url(logo.svg) center/contain no-repeat;
   mask: url(logo.svg) center/contain no-repeat;
 }
@@ -386,7 +389,7 @@ textarea { min-height: 70px; }
 .badge-orange { color: var(--orange); border-color: #e67e2250; background: #e67e2212; }
 .badge-red    { color: var(--red);    border-color: #e74c3c50; background: #e74c3c12; }
 .badge-blue   { color: var(--blue);   border-color: #2980b950; background: #2980b912; }
-.badge-brass  { color: var(--brass);  border-color: var(--brass)50; background: var(--brass)12; }
+.badge-brass  { color:var(--brass-fg);  border-color: var(--brass)50; background: var(--brass)12; }
 .badge-muted  { color: var(--muted);  border-color: var(--border); background: var(--faint); }
 
 /* ── TABLE ────────────────────────────────────────────────────────────────────── */
@@ -446,7 +449,7 @@ textarea { min-height: 70px; }
   overflow-y: auto;
   box-shadow: var(--shadow-lg);
 }
-.modal h3 { color: var(--brass); margin-bottom: 18px; font-size: 16px; }
+.modal h3 { color:var(--brass-fg); margin-bottom: 18px; font-size: 16px; }
 
 .modal-header {
   display: flex;
@@ -607,7 +610,7 @@ textarea { min-height: 70px; }
 .text-muted      { color: var(--muted); }
 .text-red        { color: var(--red); }
 .text-green      { color: var(--green); }
-.text-brass      { color: var(--brass); }
+.text-brass      { color:var(--brass-fg); }
 .text-xs         { font-size: 10px; }
 .text-sm         { font-size: 11px; }
 .text-md         { font-size: 12px; }
@@ -699,7 +702,7 @@ textarea { min-height: 70px; }
   cursor: pointer;
   transition: color .2s, border-color .2s, background .2s;
 }
-.btn-ghost-sm:hover { color: var(--brass); border-color: var(--brass); background: var(--brass)08; }
+.btn-ghost-sm:hover { color:var(--brass-fg); border-color: var(--brass); background: var(--brass)08; }
 
 /* Dashed add button */
 .btn-dashed {
@@ -754,7 +757,7 @@ textarea { min-height: 70px; }
 .cal-cell.other-month{opacity:.3}
 .cal-cell.today{border-color:var(--brass);background:var(--brass)11}
 .cal-day-num{font-size:11px;font-weight:600;color:var(--muted);margin-bottom:3px;display:block}
-.cal-cell.today .cal-day-num{color:var(--brass)}
+.cal-cell.today .cal-day-num{color:var(--brass-fg)}
 .cal-pill{font-size:10px;padding:2px 6px;border-radius:4px;margin-bottom:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer;display:block;line-height:1.5;border:1px solid transparent}
 .cal-pill:hover{filter:brightness(1.1)}
 .cal-more{font-size:9px;color:var(--muted);margin-top:1px;padding-left:2px}
@@ -765,7 +768,7 @@ textarea { min-height: 70px; }
 .ts-table th{text-align:left;padding:5px 8px;font-size:10px;color:var(--muted);border-bottom:2px solid var(--border);font-weight:600;letter-spacing:.4px}
 .ts-table td{padding:5px 8px;border-bottom:1px solid var(--border)44;vertical-align:middle}
 .ts-table tr:last-child td{border-bottom:none}
-.src-admin{color:var(--brass)}
+.src-admin{color:var(--brass-fg)}
 .modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:200;display:flex;align-items:center;justify-content:center}
 .modal-box{background:var(--card);border-radius:var(--radius-lg);padding:22px 26px;min-width:320px;max-width:460px;width:90vw;box-shadow:var(--shadow-lg)}
 .modal-title{margin:0 0 16px;font-size:15px;font-weight:700}
@@ -810,16 +813,16 @@ textarea { min-height: 70px; }
 .psc-col-hdr{font-size:10px;font-weight:700;color:var(--muted);text-align:right;text-transform:uppercase;letter-spacing:.4px}
 .psc-num{text-align:right;font-weight:500;white-space:nowrap}
 .psc-net-val{font-weight:700;color:var(--green)}
-.psc-ytd-val{color:var(--brass)}
+.psc-ytd-val{color:var(--brass-fg)}
 .psc-table{width:100%;border-collapse:collapse;font-size:11px;padding:0 14px 12px}
 .psc-table th,.psc-table td{padding:3px 8px;border-bottom:1px solid var(--border)22;vertical-align:middle}
 .psc-table th{font-size:9px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;border-bottom:2px solid var(--border)66;background:var(--surface)88}
 .psc-table .num{text-align:right}
 .psc-table td:first-child,.psc-table td:nth-child(2){color:var(--muted)}
 .psc-total-row td,.psc-total-row th{font-weight:700;border-top:2px solid var(--border)66;border-bottom:2px solid var(--border)66;background:var(--surface);color:var(--text)!important}
-.psc-total-row .psc-ytd-val{color:var(--brass)!important}
+.psc-total-row .psc-ytd-val{color:var(--brass-fg)!important}
 .psc-section-hdr td,.psc-section-hdr th{font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px;background:var(--surface)55;padding-top:8px;border-top:2px solid var(--border)}
-.btn-link{background:none;border:none;cursor:pointer;color:var(--brass);font-size:10px;padding:0 14px 10px;font-family:inherit;display:block}
+.btn-link{background:none;border:none;cursor:pointer;color:var(--brass-fg);font-size:10px;padding:0 14px 10px;font-family:inherit;display:block}
 /* Period filter */
 .period-filter-card{display:flex;align-items:center;gap:6px;flex-wrap:wrap;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:8px 12px;margin-bottom:14px}
 .filter-lbl{font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;white-space:nowrap}
@@ -878,7 +881,7 @@ textarea { min-height: 70px; }
 }
 .sc-day-hdr:last-of-type { border-right: none; }
 .sc-day-hdr.sc-today { background: var(--brass)11; }
-.sc-day-hdr.sc-today .sc-day-num { color: var(--brass); font-weight: 500; }
+.sc-day-hdr.sc-today .sc-day-num { color:var(--brass-fg); font-weight: 500; }
 .sc-day-name { display: block; font-size: 9px; letter-spacing: .5px; text-transform: uppercase; line-height: 1; }
 .sc-day-num  { display: block; font-size: 13px; font-weight: 500; color: var(--text); line-height: 1.2; }
 
@@ -964,7 +967,7 @@ textarea { min-height: 70px; }
   white-space: nowrap;
 }
 .sc-slot-who--mine {
-  color: var(--brass);
+  color:var(--brass-fg);
   font-weight: 600;
   font-size: 9px;
   text-transform: uppercase;
@@ -1005,8 +1008,8 @@ textarea { min-height: 70px; }
   cursor: pointer;
   transition: all .2s;
 }
-.sc-mpick-btn.active { border-color: var(--brass); color: var(--brass); background: var(--brass)11; }
-.sc-mpick-btn.today .sc-mpick-num { color: var(--brass); }
+.sc-mpick-btn.active { border-color: var(--brass); color:var(--brass-fg); background: var(--brass)11; }
+.sc-mpick-btn.today .sc-mpick-num { color:var(--brass-fg); }
 .sc-mpick-day { display: block; font-size: 8px; text-transform: uppercase; letter-spacing: .3px; }
 .sc-mpick-num { display: block; font-size: 13px; font-weight: 500; color: var(--text); margin-top: 1px; }
 
@@ -1126,7 +1129,7 @@ textarea { min-height: 70px; }
 .vp-card.admin:hover { border-color:var(--brass)55; }
 
 .vp-card-head { display:flex; align-items:baseline; gap:8px; flex-wrap:wrap; }
-.vp-card-date { font-size:10px; color:var(--brass); letter-spacing:.5px; text-transform:uppercase; white-space:nowrap; }
+.vp-card-date { font-size:10px; color:var(--brass-fg); letter-spacing:.5px; text-transform:uppercase; white-space:nowrap; }
 .vp-card-title { font-size:13px; font-weight:500; color:var(--text); }
 .vp-card-subtitle { font-size:10px; color:var(--muted); }
 .vp-card-actions { margin-left:auto; display:flex; gap:4px; align-items:center; }
@@ -1144,14 +1147,14 @@ textarea { min-height: 70px; }
 .vp-bar-fill { height:100%; background:var(--brass); border-radius:2px; transition:width .2s; }
 .vp-bar-fill.full { background:var(--green); }
 .vp-role-status { font-size:10px; color:var(--muted); white-space:nowrap; }
-.vp-role-endorse { font-size:9px; color:var(--brass); }
+.vp-role-endorse { font-size:9px; color:var(--brass-fg); }
 .vp-role-desc { font-size:10px; color:var(--muted); margin-top:4px; white-space:pre-wrap; padding-left:2px; }
 
 /* Chips — used for signup names and leader badge */
 .vp-chip { display:inline-flex; align-items:center; gap:4px; font-size:9px; padding:2px 8px;
   border-radius:10px; background:var(--surface); border:1px solid var(--border); color:var(--text); white-space:nowrap; }
-.vp-chip.me { background:var(--brass)18; border-color:var(--brass); color:var(--brass); font-weight:500; }
-.vp-chip a { color:var(--brass); text-decoration:none; }
+.vp-chip.me { background:var(--brass)18; border-color:var(--brass); color:var(--brass-fg); font-weight:500; }
+.vp-chip a { color:var(--brass-fg); text-decoration:none; }
 .vp-chip a:hover { text-decoration:underline; }
 
 /* Action button (member mode — sign up / withdraw) */

--- a/shared/tides.js
+++ b/shared/tides.js
@@ -273,7 +273,7 @@ function tideWidget(targetEl, { onData } = {}) {
         + `<span style="color:${col};font-size:10px;font-weight:500">${lbl}</span>`
         + `<span style="font-size:11px;font-weight:500;color:var(--text);font-family:var(--font-mono)">${curH.toFixed(1)}m</span>`;
     } else {
-      statusHtml = `<button class="tide-today-btn" style="background:none;border:1px solid var(--border);color:var(--brass);border-radius:4px;padding:0 6px;font-size:9px;cursor:pointer;font-family:inherit;line-height:1.6;letter-spacing:.3px">${IS?'Fara á í dag':'Go to today'}</button>`;
+      statusHtml = `<button class="tide-today-btn" style="background:none;border:1px solid var(--border);color:var(--brass-fg);border-radius:4px;padding:0 6px;font-size:9px;cursor:pointer;font-family:inherit;line-height:1.6;letter-spacing:.3px">${IS?'Fara á í dag':'Go to today'}</button>`;
     }
 
     // Day label

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -10,10 +10,10 @@
 .trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:4px}
 .trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center}
 .trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
-.badge-skipper{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
+.badge-skipper{color:var(--brass-fg);border-color:var(--brass)55;background:var(--brass)11}
 .badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}
 .badge-verified{color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)}
-.badge-helm{color:var(--brass);border-color:var(--brass)55;background:var(--brass)11}
+.badge-helm{color:var(--brass-fg);border-color:var(--brass)55;background:var(--brass)11}
 .trip-arrow{padding:10px 14px 10px 4px;display:flex;align-items:center;color:var(--muted);font-size:11px;transition:transform .2s;flex-shrink:0}
 .trip-card.open .trip-arrow{transform:rotate(180deg)}
 
@@ -21,7 +21,7 @@
 .trip-expand{display:none;padding:0 12px 0;position:relative}
 .trip-card.open .trip-expand{display:block}
 .trip-card-close{position:absolute;top:6px;right:6px;background:none;border:1px solid var(--border);color:var(--muted);width:24px;height:24px;border-radius:50%;font-size:12px;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:2;padding:0;line-height:1;transition:color .15s,border-color .15s}
-.trip-card-close:hover{color:var(--brass);border-color:var(--brass)}
+.trip-card-close:hover{color:var(--brass-fg);border-color:var(--brass)}
 .trip-expand-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:4px 12px;font-size:11px;border-top:1px solid var(--border);padding-top:10px;margin-top:2px}
 .trip-exp-row{display:flex;flex-direction:column;gap:1px;padding:4px 0}
 .trip-exp-lbl{font-size:9px;color:var(--muted);letter-spacing:.6px;text-transform:uppercase}
@@ -38,7 +38,7 @@
 .exp-notes{background:var(--faint)}
 .exp-section-hdr{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px;font-weight:500}
 .exp-section-hdr.expandable{cursor:pointer;display:flex;align-items:center;gap:4px}
-.exp-section-hdr.expandable:hover{color:var(--brass)}
+.exp-section-hdr.expandable:hover{color:var(--brass-fg)}
 .exp-section-hdr .exp-chevron{font-size:10px;transition:transform .2s;transform:rotate(0deg)}
 .exp-section-hdr.expanded .exp-chevron{transform:rotate(180deg)}
 .exp-section-detail{display:none;margin-top:4px}
@@ -47,10 +47,10 @@
 /* ── Trip action buttons ── */
 .trip-actions{display:flex;gap:6px;flex-wrap:wrap;margin-top:8px;padding-top:8px;border-top:1px solid var(--border)}
 .trip-action-btn{background:var(--surface);border:1px solid var(--border);color:var(--muted);border-radius:var(--radius-sm);padding:4px 10px;font-size:10px;font-family:inherit;cursor:pointer;display:inline-flex;align-items:center;gap:4px;transition:color .2s,border-color .2s,background .2s}
-.trip-action-btn:hover{color:var(--brass);border-color:var(--brass)}
-.trip-action-btn.primary{color:var(--brass);border-color:var(--brass)55}
+.trip-action-btn:hover{color:var(--brass-fg);border-color:var(--brass)}
+.trip-action-btn.primary{color:var(--brass-fg);border-color:var(--brass)55}
 .trip-more-btn{background:none;border:1px solid var(--border);color:var(--muted);border-radius:var(--radius-sm);padding:3px 10px;font-size:10px;font-family:inherit;cursor:pointer;margin-top:4px;transition:color .2s,border-color .2s}
-.trip-more-btn:hover{color:var(--brass);border-color:var(--brass)}
+.trip-more-btn:hover{color:var(--brass-fg);border-color:var(--brass)}
 
 /* ── Photos ── */
 .photo-thumb{width:60px;height:60px;object-fit:cover;border-radius:var(--radius-sm);border:1px solid var(--border);cursor:pointer}
@@ -63,7 +63,7 @@
 .photo-sharing-badge{font-size:8px;letter-spacing:.4px;padding:1px 5px;border-radius:4px;text-transform:uppercase;margin-left:4px}
 .photo-sharing-badge.shared{color:var(--green);border:1px solid var(--green)55;background:var(--green)11}
 .photo-sharing-badge.private{color:var(--muted);border:1px solid var(--border);background:var(--surface)}
-.photo-sharing-badge.club{color:var(--brass);border:1px solid var(--brass)55;background:var(--brass)11}
+.photo-sharing-badge.club{color:var(--brass-fg);border:1px solid var(--brass)55;background:var(--brass)11}
 
 /* ── Track map ── */
 .track-map-thumb{width:100%;height:140px;border-radius:var(--radius-sm);border:1px solid var(--border);overflow:hidden;cursor:pointer;margin-top:4px;position:relative}

--- a/shared/weather.js
+++ b/shared/weather.js
@@ -522,7 +522,7 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
           <div style="font-size:9px;color:var(--muted);letter-spacing:1.2px">${s('wx.birkConditions')}${c._obs_time ? ' · ' + c._obs_time.slice(11,16) + ' UTC' : ''}</div>
           <div style="display:flex;align-items:center;gap:6px;flex-shrink:0">
             ${showRefreshBtn ? `<button onclick="this.closest('.wx-widget')._wxRefresh({fresh:true})" title="Refresh" style="background:none;border:1px solid var(--border);color:var(--muted);padding:2px 6px;border-radius:4px;font-size:10px;cursor:pointer;font-family:inherit">↻ ${updTime}</button>` : `<span style="font-size:10px;color:var(--muted)">↻ ${updTime}</span>`}
-            <a href="../weather/" style="font-size:11px;font-weight:600;color:var(--brass);text-decoration:none;white-space:nowrap;border:1px solid var(--brass);border-radius:6px;padding:4px 10px;background:var(--brass)12">${s('wx.openForecast')}</a>
+            <a href="../weather/" style="font-size:11px;font-weight:600;color:var(--brass-fg);text-decoration:none;white-space:nowrap;border:1px solid var(--brass);border-radius:6px;padding:4px 10px;background:var(--brass)12">${s('wx.openForecast')}</a>
           </div>
         </div>
         <!-- 2-row grid, columns locked -->
@@ -530,8 +530,8 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
           <div class="wx-cell">
             <div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">${s('wx.wind')}</div>
             <div style="display:flex;align-items:center;gap:3px;line-height:1">
-              <span style="font-size:32px;color:var(--brass);font-weight:500;line-height:1">${wxDirArrow(wd)}</span>
-              <span style="font-size:32px;color:var(--brass);font-weight:500;line-height:1">${Math.round(ws)}</span>
+              <span style="font-size:32px;color:var(--brass-fg);font-weight:500;line-height:1">${wxDirArrow(wd)}</span>
+              <span style="font-size:32px;color:var(--brass-fg);font-weight:500;line-height:1">${Math.round(ws)}</span>
               <span style="font-size:12px;color:var(--muted);margin-left:2px">m/s</span>
             </div>
             <div style="font-size:11px;color:var(--muted);margin-top:5px">
@@ -627,7 +627,7 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
       // Expose badge-only re-render so pages can call after toggling duty status
       targetEl._wxRefreshBadges = () => _renderSsBadges(targetEl.querySelector('.wx-status-badges'));
     } catch(e) {
-      targetEl.innerHTML = `<div style="color:var(--muted);font-size:12px;padding:6px 0">⚠️ Weather unavailable  —  <a href="../weather/" style="color:var(--brass)">try full page →</a>${showRefreshBtn ? ` <button onclick="this.closest('.wx-widget')._wxRefresh()" style="margin-left:8px;background:none;border:1px solid var(--border);color:var(--muted);padding:2px 8px;border-radius:4px;font-size:10px;cursor:pointer;font-family:inherit">↻</button>` : ''}</div>`;
+      targetEl.innerHTML = `<div style="color:var(--muted);font-size:12px;padding:6px 0">⚠️ Weather unavailable  —  <a href="../weather/" style="color:var(--brass-fg)">try full page →</a>${showRefreshBtn ? ` <button onclick="this.closest('.wx-widget')._wxRefresh()" style="margin-left:8px;background:none;border:1px solid var(--border);color:var(--muted);padding:2px 8px;border-radius:4px;font-size:10px;cursor:pointer;font-family:inherit">↻</button>` : ''}</div>`;
       targetEl._wxRefresh = refresh;
     }
   }

--- a/staff/index.html
+++ b/staff/index.html
@@ -64,7 +64,7 @@
 .stat-row  { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:16px; }
 .stat-cell { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
   padding:12px 10px; text-align:center; box-shadow:var(--shadow-sm); }
-.stat-n { font-size:22px; color:var(--brass); font-weight:500; }
+.stat-n { font-size:22px; color:var(--brass-fg); font-weight:500; }
 .stat-l { font-size:9px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
 
 /* ── Section card ── */
@@ -76,7 +76,7 @@
 /* ── Checkout form ── */
 .checkout-form { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
   padding:18px; margin-top:12px; box-shadow:var(--shadow-sm); }
-.checkout-form h4 { color:var(--brass); font-size:10px; letter-spacing:1px; margin-bottom:14px; }
+.checkout-form h4 { color:var(--brass-fg); font-size:10px; letter-spacing:1px; margin-bottom:14px; }
 .inline-fields { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
 .crew-field { display:flex; align-items:center; gap:10px; }
 .crew-btn { width:30px; height:30px; border-radius:50%; border:1px solid var(--border);
@@ -86,7 +86,7 @@
 .crew-num { width:36px; text-align:center; font-size:16px; }
 .ret-btn  { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
   color:var(--text); font-family:inherit; font-size:11px; padding:4px 8px; cursor:pointer; transition:color .2s,border-color .2s; }
-.ret-btn:hover { border-color:var(--brass); color:var(--brass); }
+.ret-btn:hover { border-color:var(--brass); color:var(--brass-fg); }
 
 /* ── Available by category ── */
 .cat-row { display:flex; align-items:center; gap:10px; padding:6px 0;
@@ -104,7 +104,7 @@
 .fleet-cat-toggle { display:flex; align-items:center; justify-content:space-between;
   padding:8px 0; cursor:pointer; user-select:none; border-bottom:1px solid var(--border)44; }
 .fleet-cat-toggle:last-of-type { border-bottom:none; }
-.fleet-cat-toggle:hover .fct-label { color:var(--brass); }
+.fleet-cat-toggle:hover .fct-label { color:var(--brass-fg); }
 .fct-label   { font-size:11px; font-weight:500; }
 .fct-count   { font-size:10px; color:var(--muted); }
 .fct-arrow   { font-size:10px; color:var(--muted); transition:transform .2s; }
@@ -234,7 +234,7 @@
 .bc-group-card.overdue{border-color:var(--red);border-left-color:var(--red)}
 .gc-header{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:6px}
 .gc-boats{font-size:13px;font-weight:500;color:var(--text)}
-.gc-badge{font-size:9px;letter-spacing:.5px;padding:2px 7px;border-radius:10px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass)}
+.gc-badge{font-size:9px;letter-spacing:.5px;padding:2px 7px;border-radius:10px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg)}
 .gc-ret{font-size:13px;font-weight:500;text-align:right}
 .gc-meta{font-size:11px;color:var(--muted);margin-bottom:6px}
 .gc-staff{font-size:11px;color:var(--muted)}
@@ -243,12 +243,12 @@
 .guest-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:600;display:flex;align-items:center;justify-content:center}
 .guest-modal-overlay.hidden{display:none}
 .guest-modal{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-lg);padding:20px;width:90%;max-width:360px;box-shadow:var(--shadow-lg)}
-.guest-modal h4{font-size:12px;color:var(--brass);letter-spacing:.5px;margin:0 0 14px}
+.guest-modal h4{font-size:12px;color:var(--brass-fg);letter-spacing:.5px;margin:0 0 14px}
 .guest-modal .gm-field{margin-bottom:10px}
 .guest-modal .gm-field label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:4px}
 .guest-modal .gm-field input{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
 .guest-modal .btn-row{display:flex;gap:8px;margin-top:14px;justify-content:flex-end}
-.guest-add-hint{font-size:10px;color:var(--brass);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
+.guest-add-hint{font-size:10px;color:var(--brass-fg);cursor:pointer;padding:6px 10px;border-bottom:1px solid var(--border)}
 .guest-add-hint:hover{background:var(--card)}
 
 #groupCheckOutBtn{background:var(--navy);border-color:var(--navy);color:#fff}
@@ -389,7 +389,7 @@
       </div>
       <!-- Departure port — shown for keelboats only -->
       <div id="coPortRow" class="field" style="display:none">
-        <label style="color:var(--brass)">⚓️ <span data-s="staff.departurePort"></span></label>
+        <label style="color:var(--brass-fg)">⚓️ <span data-s="staff.departurePort"></span></label>
         <input type="text" list="coPortsList" id="coDeparturePort" autocomplete="off">
         <datalist id="coPortsList"></datalist>
       </div>
@@ -864,7 +864,7 @@ function searchCoCrewMembers(inp, drop) {
     if (m.role === 'guest') {
       const badge = document.createElement('span');
       badge.textContent = s('lbl.guest');
-      badge.style.cssText = 'font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass);flex-shrink:0';
+      badge.style.cssText = 'font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--brass)55;background:var(--brass)11;color:var(--brass-fg);flex-shrink:0';
       item.appendChild(badge);
     }
     item.addEventListener('mouseover', function(){ this.style.background = 'var(--card)'; });

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -19,21 +19,21 @@
     .trip-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 16px; margin-bottom:8px; box-shadow:var(--shadow-sm); }
     .trip-card.verified { border-left:3px solid var(--green); }
     .trip-head { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; margin-bottom:8px; }
-    .trip-date { font-size:10px; color:var(--brass); margin-bottom:3px; }
+    .trip-date { font-size:10px; color:var(--brass-fg); margin-bottom:3px; }
     .trip-title { font-size:13px; font-weight:500; }
     .trip-meta { font-size:11px; color:var(--muted); margin-top:4px; display:flex; gap:8px; flex-wrap:wrap; }
     .trip-notes { font-size:11px; color:var(--muted); margin-top:8px; padding-top:8px; border-top:1px solid var(--border)44; line-height:1.5; }
     .badge { font-size:10px; padding:2px 7px; border-radius:10px; border:1px solid; flex-shrink:0; }
     .badge-verified { color:var(--moss); border-color:color-mix(in srgb, var(--moss) 33%, transparent); background:color-mix(in srgb, var(--moss) 8%, transparent); }
     .badge-pending  { color:var(--muted); border-color:var(--border); background:var(--surface); }
-    .badge-linked   { color:var(--brass); border-color:var(--brass)55; background:var(--brass)11; }
+    .badge-linked   { color:var(--brass-fg); border-color:var(--brass)55; background:var(--brass)11; }
     .verify-row { display:flex; align-items:center; gap:8px; margin-top:10px; padding-top:10px; border-top:1px solid var(--border)44; flex-wrap:wrap; }
     .verify-row input[type="text"] { flex:1; min-width:160px; }
     .staff-comment { margin-top:8px; padding:8px 10px; background:var(--surface); border-radius:var(--radius-sm); font-size:11px; }
     .staff-comment-label { font-size:9px; color:var(--muted); letter-spacing:1px; margin-bottom:3px; }
     .stat-strip { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:20px; }
     .stat-cell { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 10px; text-align:center; box-shadow:var(--shadow-sm); }
-    .stat-n { font-size:22px; color:var(--brass); font-weight:500; }
+    .stat-n { font-size:22px; color:var(--brass-fg); font-weight:500; }
     .stat-l { font-size:9px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
     .cert-row { display:flex; align-items:flex-start; justify-content:space-between; padding:10px 0; border-bottom:1px solid var(--border); gap:10px; }
     .cert-row:last-child { border-bottom:none; }

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -20,7 +20,7 @@
 .vp-tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted);
   font-family:inherit; font-size:11px; letter-spacing:.6px; padding:10px 16px; cursor:pointer;
   white-space:nowrap; transition:color .2s,border-color .2s; text-transform:uppercase; margin-bottom:-1px; }
-.vp-tab-btn.active { color:var(--brass); border-bottom-color:var(--brass); }
+.vp-tab-btn.active { color:var(--brass-fg); border-bottom-color:var(--brass); }
 .vp-tab-btn:hover:not(.active) { color:var(--text); }
 
 /* ── Section headers ── */
@@ -40,7 +40,7 @@
 .vp-cal-nav button { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
   color:var(--text); font-family:inherit; font-size:11px; padding:4px 10px; cursor:pointer;
   transition:border-color .15s, color .15s; min-width:32px; }
-.vp-cal-nav button:hover { border-color:var(--brass); color:var(--brass); }
+.vp-cal-nav button:hover { border-color:var(--brass); color:var(--brass-fg); }
 .vp-cal-grid { display:grid; grid-template-columns:repeat(7,1fr); }
 .vp-cal-dow { font-size:8px; color:var(--muted); text-align:center; padding:6px 4px; letter-spacing:.6px;
   background:var(--surface); border-bottom:1px solid var(--border); text-transform:uppercase; font-weight:500; }
@@ -48,7 +48,7 @@
   padding:4px; position:relative; box-sizing:border-box; }
 .vp-cal-day:nth-child(7n) { border-right:none; }
 .vp-cal-day.other-month { background:var(--surface); opacity:.55; }
-.vp-cal-day.today .vp-cal-day-num { color:var(--brass); font-weight:600; }
+.vp-cal-day.today .vp-cal-day-num { color:var(--brass-fg); font-weight:600; }
 .vp-cal-day-num { font-size:10px; color:var(--muted); margin-bottom:3px; }
 .vp-cal-ev { display:block; margin-top:2px; padding:2px 5px; border-radius:3px;
   background:var(--brass)1f; border-left:2px solid var(--brass); font-size:9px; color:var(--text);
@@ -63,7 +63,7 @@
 .vp-cal-ev-span-start { border-left-style:solid; }
 .vp-cal-ev-span-end { opacity:.85; }
 .vp-cal-ev-more { display:block; margin-top:2px; font-size:9px; color:var(--muted); padding:1px 4px; cursor:pointer; }
-.vp-cal-ev-more:hover { color:var(--brass); }
+.vp-cal-ev-more:hover { color:var(--brass-fg); }
 /* Day cell dot for days where the user has at least one signup */
 .vp-cal-day.has-mine .vp-cal-day-num::after { content:''; display:inline-block; width:5px; height:5px;
   border-radius:50%; background:var(--brass); margin-left:5px; vertical-align:middle; }

--- a/weather/index.html
+++ b/weather/index.html
@@ -39,8 +39,8 @@
 .wind-cols { display:flex; align-items:flex-start; gap:16px; margin-bottom:16px; }
 .wind-data { flex:1; }
 .wind-speed-row { display:flex; align-items:center; gap:6px; line-height:1; }
-.dir-arrow { font-size:56px; color:var(--brass); line-height:1; font-weight:700; }
-.wind-ms   { font-size:56px; font-weight:500; color:var(--brass); line-height:1; }
+.dir-arrow { font-size:56px; color:var(--brass-fg); line-height:1; font-weight:700; }
+.wind-ms   { font-size:56px; font-weight:500; color:var(--brass-fg); line-height:1; }
 .wind-unit { font-size:18px; color:var(--muted); }
 .wind-sub  { font-size:16px; color:var(--muted); display:flex; align-items:center; gap:8px; margin-top:6px; }
 .wind-sub b    { color:var(--text); }
@@ -86,8 +86,8 @@ svg.chart { width:100%; overflow:visible; display:block; }
 .h-slot.past { opacity:.5; }
 .h-time  { font-size:10px; color:var(--muted); margin-bottom:6px; }
 .h-main  { display:flex; align-items:center; justify-content:center; gap:3px; line-height:1; margin-bottom:2px; }
-.h-dir   { font-size:18px; color:var(--brass); font-weight:500; line-height:1; }
-.h-wind  { font-size:18px; color:var(--brass); font-weight:500; line-height:1; }
+.h-dir   { font-size:18px; color:var(--brass-fg); font-weight:500; line-height:1; }
+.h-wind  { font-size:18px; color:var(--brass-fg); font-weight:500; line-height:1; }
 .h-unit  { font-size:9px; color:var(--muted); }
 .h-kt    { font-size:10px; color:var(--muted); line-height:1; }
 .h-gust  { font-size:10px; color:var(--muted); margin-top:1px; }


### PR DESCRIPTION
Add --brass-fg variable (brass in dark, green in light) and globally replace all text/icon color:var(--brass) with color:var(--brass-fg) across 25 files so icons render green while border-color and background stay blue via the existing --brass mapping.

Header logo changed to always-white — visible against the dark --header-bg in both themes.

Also adds --brass-fg to code.gs and public/index.html which define their own CSS variable sets.

https://claude.ai/code/session_01PMXRKRRXCxPmVgyxHby35Q