### PR TITLE
Branding pass: logo, cards, login, weather, section accents

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -21,23 +21,25 @@
     .stay-row input { margin:0; }
     .lang-row { text-align:center; margin-top:16px; }
     #roleScreen, #accountScreen, #forceChangeScreen { display:none; }
-    .role-greeting { color:var(--brass-fg); font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; }
+    /* Role/account picker card: moss-green brand wash with white welcome text */
+    #roleScreen .card, #accountScreen .card {
+      background: var(--moss);
+      border-color: var(--moss-d);
+      color: #fff;
+    }
+    .role-greeting { color:#fff; font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; font-weight:500; }
     .role-btn {
       width:100%; padding:18px 20px; margin-bottom:10px; border-radius:var(--radius-md);
-      border:1px solid var(--border); background:var(--surface); cursor:pointer;
+      border:1px solid var(--moss-l); background:var(--surface); cursor:pointer;
       display:flex; align-items:center; gap:14px; transition:all .2s;
       text-align:left; box-shadow:var(--shadow-sm);
     }
-    .role-btn:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
+    .role-btn:hover { border-color:var(--moss-d); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
     .role-btn .role-icon { width:22px; height:22px; flex-shrink:0; display:inline-flex; align-items:center; color:var(--brass-fg); }
     .role-btn .role-icon svg { width:100%; height:100%; }
     .role-btn .role-label { color:var(--text); font-size:13px; font-weight:500; letter-spacing:.5px; }
     .role-btn .role-desc { color:var(--muted); font-size:11px; margin-top:2px; }
-    .role-btn.role-admin  { border-color:color-mix(in srgb, var(--red)  27%, transparent); }
-    .role-btn.role-admin:hover { border-color:var(--red); }
-    .role-btn.role-staff  { border-color:color-mix(in srgb, var(--brass) 27%, transparent); }
-    .role-btn.role-member { border-color:color-mix(in srgb, var(--moss) 33%, transparent); }
-    .role-btn.role-member:hover { border-color:var(--moss); }
+    /* Ward picker keeps a distinct purple accent so guardians recognise it as a separate flow */
     .role-btn.role-ward   { border-color:#9b59b644; }
     .role-btn.role-ward:hover { border-color:#9b59b6; }
     .back-link { display:block; text-align:center; margin-top:12px; color:var(--muted); font-size:12px; cursor:pointer; }

--- a/member/index.html
+++ b/member/index.html
@@ -127,7 +127,7 @@
 
 /* ── Cert badges ── */
 .cert-section { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px 16px; margin-bottom:12px; box-shadow:var(--shadow-sm); }
-.cert-section-title { font-size:9px; color:var(--muted); letter-spacing:1.2px; margin-bottom:10px; }
+.cert-section-title { font-size:9px; color:var(--brass-fg); letter-spacing:1.2px; margin-bottom:10px; }
 /* ── Inline report form styles ── */
 .cat-btns { display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
 .cat-btn { flex:1; min-width:80px; padding:8px 6px; border-radius:var(--radius-sm); border:1px solid var(--border); background:var(--surface); color:var(--muted); font-size:11px; font-family:inherit; cursor:pointer; text-align:center; transition:all .2s; }

--- a/shared/style.css
+++ b/shared/style.css
@@ -64,6 +64,7 @@
   --brass-d:  #b8941f;
   --brass-l:  #e8c84a;
   --brass-fg: #d9b441;
+  --logo-color: var(--brass);
   --green:    var(--moss);
   --yellow:   #f1c40f;
   --orange:   #e67e22;
@@ -99,6 +100,7 @@
   --brass-d:  #18537e;
   --brass-l:  #4a9bd4;
   --brass-fg: #1e8e4e;
+  --logo-color: #fff;
   --green:    #1e8e4e;
   --yellow:   #d4a80c;
   --orange:   #c46a1a;
@@ -124,6 +126,7 @@
     --brass-d:  #18537e;
     --brass-l:  #4a9bd4;
     --brass-fg: #1e8e4e;
+    --logo-color: #fff;
     --green:    #1e8e4e;
     --yellow:   #d4a80c;
     --orange:   #c46a1a;
@@ -181,7 +184,7 @@ header {
   aspect-ratio: 1170 / 1450;
   flex-shrink: 0;
   display: inline-block;
-  background: #fff;
+  background: var(--logo-color);
   -webkit-mask: url(logo.svg) center/contain no-repeat;
   mask: url(logo.svg) center/contain no-repeat;
 }
@@ -238,7 +241,6 @@ main.wide { max-width: 1100px; }
 .card {
   background: var(--card);
   border: 1px solid var(--border);
-  border-left: 8px solid var(--moss);
   border-radius: var(--radius-md);
   padding: 18px 20px;
   margin-bottom: 16px;
@@ -774,7 +776,7 @@ textarea { min-height: 70px; }
 .modal-title{margin:0 0 16px;font-size:15px;font-weight:700}
 .modal-err{font-size:11px;color:var(--red);min-height:14px;margin-bottom:2px}
 .modal-actions{display:flex;gap:8px;margin-top:16px;align-items:center}
-.period-card{border:1px solid var(--border);border-left:3px solid var(--moss);border-radius:var(--radius-md);margin-bottom:12px;overflow:hidden;box-shadow:var(--shadow-sm)}
+.period-card{border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:12px;overflow:hidden;box-shadow:var(--shadow-sm)}
 .period-head{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;background:var(--surface);cursor:pointer}
 .period-title{font-weight:600;font-size:13px}
 .period-meta{font-size:11px;color:var(--muted)}
@@ -801,7 +803,7 @@ textarea { min-height: 70px; }
 .btn-del{font-size:10px;padding:2px 8px;background:var(--red)22;color:var(--red);border:1px solid var(--red)44;border-radius:var(--radius-sm);cursor:pointer}
 .edited-badge{font-size:9px;color:var(--muted);margin-left:3px}
 /* Payslip cards */
-.payslip-card{background:var(--card);border:1px solid var(--border);border-left:3px solid var(--moss);border-radius:var(--radius-md);margin-bottom:16px;overflow:hidden;box-shadow:var(--shadow-sm)}
+.payslip-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:16px;overflow:hidden;box-shadow:var(--shadow-sm)}
 .psc-header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;padding:12px 14px;border-bottom:2px solid var(--border);background:var(--surface)}
 .psc-identity .psc-name{font-weight:700;font-size:14px}
 .psc-identity .psc-sub{font-size:11px;color:var(--muted);margin-top:1px}

--- a/shared/weather.js
+++ b/shared/weather.js
@@ -535,15 +535,15 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
               <span style="font-size:12px;color:var(--muted);margin-left:2px">m/s</span>
             </div>
             <div style="font-size:11px;color:var(--muted);margin-top:5px">
-              <b style="color:var(--text)">${wDir}</b> · <b style="color:var(--text)">${wxMsToKt(ws)}</b> kt · ${s('wx.force')} <b style="color:var(--text)">${bft}</b>
+              <b style="color:var(--navy-l)">${wDir}</b> · <b style="color:var(--navy-l)">${wxMsToKt(ws)}</b> kt · ${s('wx.force')} <b style="color:var(--navy-l)">${bft}</b>
             </div>
             <div style="font-size:10px;color:var(--muted);margin-top:3px">
-              ${s('wx.gusts')} <b style="color:var(--text)">${Math.round(wg)} m/s</b> · <b style="color:var(--text)">${wxMsToKt(wg)}</b> kt · ${wxBftDesc(bft)}
+              ${s('wx.gusts')} <b style="color:var(--navy-l)">${Math.round(wg)} m/s</b> · <b style="color:var(--navy-l)">${wxMsToKt(wg)}</b> kt · ${wxBftDesc(bft)}
             </div>
           </div>
           <div class="wx-cell">
             <div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:6px">${s('wx.airTemp')}</div>
-            <div style="font-size:28px;font-weight:500;color:var(--text);line-height:1">${c.temperature_2m != null ? Math.round(c.temperature_2m)+'°' : ''}</div>
+            <div style="font-size:28px;font-weight:500;color:var(--brass-fg);line-height:1">${c.temperature_2m != null ? Math.round(c.temperature_2m)+'°' : ''}</div>
             <div style="font-size:10px;color:var(--muted);margin-top:5px">${c.apparent_temperature != null && c.apparent_temperature !== c.temperature_2m ? s('wx.feelsLike', { t: Math.round(c.apparent_temperature) }) : ''}</div>
           </div>
           <div class="wx-cell">
@@ -563,7 +563,7 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
           </div>
           <div class="wx-cell" style="border-top:1px solid var(--border);padding-top:8px;margin-top:2px">
             <div style="font-size:9px;color:var(--muted);letter-spacing:.8px;margin-bottom:4px">${s('wx.pressure')}</div>
-            <div style="font-size:17px;color:var(--text)">${pres != null ? Math.round(pres) : ''}</div>
+            <div style="font-size:17px;color:var(--navy-l)">${pres != null ? Math.round(pres) : ''}</div>
             <div style="font-size:10px;color:${wxPressureTrendColor(trend)}">${wxPressureTrendIcon(trend)} ${s('wx.pressure' + trend[0].toUpperCase() + trend.slice(1))}</div>
           </div>
         </div>

--- a/staff/index.html
+++ b/staff/index.html
@@ -71,7 +71,7 @@
 .section { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);
   padding:14px 16px; margin-bottom:12px; box-shadow:var(--shadow-sm); }
 .section-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
-.section-head h3 { font-size:9px; letter-spacing:1px; color:var(--muted); margin:0; }
+.section-head h3 { font-size:9px; letter-spacing:1px; color:var(--brass-fg); margin:0; }
 
 /* ── Checkout form ── */
 .checkout-form { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md);

--- a/weather/index.html
+++ b/weather/index.html
@@ -43,13 +43,13 @@
 .wind-ms   { font-size:56px; font-weight:500; color:var(--brass-fg); line-height:1; }
 .wind-unit { font-size:18px; color:var(--muted); }
 .wind-sub  { font-size:16px; color:var(--muted); display:flex; align-items:center; gap:8px; margin-top:6px; }
-.wind-sub b    { color:var(--text); }
+.wind-sub b    { color:var(--navy-l); }
 .wind-sub .sep { color:var(--border); }
 .wind-icon-col { display:flex; flex-direction:column; align-items:center; flex-shrink:0; gap:4px; min-width:72px; }
 .wind-cond-icon { font-size:52px; line-height:1; }
 .gust-row  { padding-top:14px; border-top:1px solid var(--border); display:flex; align-items:center; gap:20px; flex-wrap:wrap; }
 .gust-lbl  { font-size:10px; color:var(--muted); letter-spacing:.8px; margin-bottom:3px; }
-.gust-val  { font-size:18px; color:var(--text); }
+.gust-val  { font-size:18px; color:var(--navy-l); }
 
 /* ── Info grids ── */
 .info-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:12px; }


### PR DESCRIPTION
Logo tracks --logo-color: brass in dark, white in light, so the brass brand mark returns to dark mode while the white-on-navy header stays legible in light mode.

Drop the decorative green trim: .card loses its 8px moss left border and .period-card/.payslip-card lose the matching 3px stripes so the moss accent becomes meaningful (fleet availability states, confirmations) rather than ambient.

Login role picker: unify admin/staff/member borders on moss and wrap the role/account picker card in a moss background with white welcome text. Ward keeps its distinct purple accent.

Weather widget text: replace --text (dark navy, reads as near-black in light mode) with --navy-l on secondary wind/gust/pressure lines and --brass-fg (green in light) on the air-temperature headline, matching the "blue or green" direction.

Staff .section-head h3 and member .cert-section-title shift from muted grey to --brass-fg so small-caps section labels carry the club green in light mode and brass in dark.

https://claude.ai/code/session_01PMXRKRRXCxPmVgyxHby35Q