### PR TITLE
Remove decorative green trims; green icons in light mode

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -32,7 +32,7 @@
 }
 .member-actions .act-btn::before {
   content:''; display:inline-block; width:16px; height:16px; flex-shrink:0;
-  background-color:var(--brass);
+  background-color:var(--brass-fg);
   -webkit-mask-repeat:no-repeat; mask-repeat:no-repeat;
   -webkit-mask-size:contain; mask-size:contain;
   -webkit-mask-position:center; mask-position:center;

--- a/shared/style.css
+++ b/shared/style.css
@@ -254,7 +254,6 @@ main.wide { max-width: 1100px; }
   letter-spacing: 1.2px;
   color: #ffffff;
   background: var(--navy);
-  border-bottom: 4px solid var(--moss);
   font-weight: bold;
   padding: 10px 16px;
   margin: -18px -20px 16px -20px;
@@ -273,9 +272,8 @@ main.wide { max-width: 1100px; }
 .section-heading::after {
   content: "";
   flex: 1;
-  height: 4px;
-  background: var(--moss);
-  border-radius: 2px;
+  height: 1px;
+  background: var(--border);
 }
 
 /* ── FORMS ────────────────────────────────────────────────────────────────────── */
@@ -404,7 +402,6 @@ textarea { min-height: 70px; }
   letter-spacing: 1px;
   color: #ffffff;
   padding: 10px 12px;
-  border-bottom: 3px solid var(--moss);
   background: var(--navy);
 }
 .tbl td {

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -1,5 +1,5 @@
 /* ── Trip card (shared between logbook & captain) ── */
-.trip-card{background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--moss);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
+.trip-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
 .trip-card:hover{border-color:var(--moss-l)}
 .trip-card-main{display:grid;grid-template-columns:52px 1fr auto;align-items:stretch;cursor:pointer}
 .trip-date-col{background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}

--- a/staff/index.html
+++ b/staff/index.html
@@ -31,7 +31,7 @@
 .nc-icon {
   grid-column:1; grid-row:1/3;
   display:inline-block; width:24px; height:24px;
-  background-color:var(--brass);
+  background-color:var(--brass-fg);
   -webkit-mask-repeat:no-repeat; mask-repeat:no-repeat;
   -webkit-mask-size:contain;     mask-size:contain;
   -webkit-mask-position:center;  mask-position:center;


### PR DESCRIPTION
Strip moss accent borders from .card-title, .tbl th, .section-heading::after, and .trip-card — the green trim was ambient decoration that competed with meaningful status borders (fleet availability, severity, confirmations). Section heading divider downgrades to a 1px --border line.

Member action-button icons and staff nav-card icons now use --brass-fg (green in light, brass in dark) instead of --brass so they read as the club green in light mode.

https://claude.ai/code/session_01PMXRKRRXCxPmVgyxHby35Q