### PR TITLE
Switch staff duty badges from red/green to blue/orange

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1577,9 +1577,9 @@ function _renderMemberStaffStatus() {
   if (!_staffStatus) { el.innerHTML = ''; return; }
   const onDuty = _staffStatus.onDuty;
   const boat   = _staffStatus.supportBoat;
-  const dutyCol  = onDuty ? 'var(--moss)' : 'var(--muted)';
+  const dutyCol  = onDuty ? 'var(--blue)' : 'var(--orange)';
   const boatCol  = boat   ? 'var(--navy)' : 'var(--muted)';
-  const dutyBg   = onDuty ? 'color-mix(in srgb, var(--moss) 10%, transparent);border-color:color-mix(in srgb, var(--moss) 27%, transparent)' : 'var(--surface);border-color:var(--border)';
+  const dutyBg   = onDuty ? 'color-mix(in srgb, var(--blue) 10%, transparent);border-color:color-mix(in srgb, var(--blue) 27%, transparent)' : 'color-mix(in srgb, var(--orange) 10%, transparent);border-color:color-mix(in srgb, var(--orange) 27%, transparent)';
   const boatBg   = boat   ? 'color-mix(in srgb, var(--navy) 10%, transparent);border-color:color-mix(in srgb, var(--navy) 27%, transparent)' : 'var(--surface);border-color:var(--border)';
   el.innerHTML = '<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:2px">'
     + '<span style="display:inline-flex;align-items:center;gap:5px;padding:4px 12px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;background:' + dutyBg + ';color:' + dutyCol + '">'

--- a/public/index.html
+++ b/public/index.html
@@ -489,9 +489,9 @@ function renderDutyPills() {
   if (!el || !_staffStatus) { if (el) el.innerHTML = ''; return; }
   var IS = lang() === 'IS';
   var bst = 'display:inline-flex;align-items:center;gap:4px;padding:4px 12px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;white-space:nowrap;';
-  var dc  = _staffStatus.onDuty      ? 'var(--moss)' : 'var(--red)';
+  var dc  = _staffStatus.onDuty      ? 'var(--blue)' : 'var(--orange)';
   var bc  = _staffStatus.supportBoat ? 'var(--moss)' : 'var(--red)';
-  var dbg = _staffStatus.onDuty      ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
+  var dbg = _staffStatus.onDuty      ? 'color-mix(in srgb, var(--blue) 8%, transparent);border-color:color-mix(in srgb, var(--blue) 25%, transparent)' : 'color-mix(in srgb, var(--orange) 8%, transparent);border-color:color-mix(in srgb, var(--orange) 25%, transparent)';
   var bbg = _staffStatus.supportBoat ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
   var dtx = IS ? (_staffStatus.onDuty      ? 'Starfsmaður á vakt' : 'Enginn starfsmaður')
                : (_staffStatus.onDuty      ? 'Staff on duty'      : 'No staff on duty');

--- a/shared/weather.js
+++ b/shared/weather.js
@@ -258,7 +258,7 @@ function wxScoreFlag(ws, wDir, waveH, airT, sst, wg, visKey) {
 function wxStaffStatusHtml(status) {
   if (!status) return '';
   const badges = [];
-  if (status.onDuty)      badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:color-mix(in srgb, var(--moss) 10%, transparent);border:1px solid color-mix(in srgb, var(--moss) 27%, transparent);color:var(--moss);border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.lifebuoy+s('wx.staffOnDuty')+'</span>');
+  if (status.onDuty)      badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:color-mix(in srgb, var(--blue) 10%, transparent);border:1px solid color-mix(in srgb, var(--blue) 27%, transparent);color:var(--blue);border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.lifebuoy+s('wx.staffOnDuty')+'</span>');
   if (status.supportBoat) badges.push('<span style="display:inline-flex;align-items:center;gap:5px;background:color-mix(in srgb, var(--navy) 10%, transparent);border:1px solid color-mix(in srgb, var(--navy) 27%, transparent);color:var(--navy);border-radius:20px;padding:3px 10px;font-size:11px">'+DUTY_ICONS.ship+s('wx.supportBoatOut')+'</span>');
   if (!badges.length) return '';
   let ago = '';
@@ -314,9 +314,9 @@ function wxFlagDetailHtml(result, staffStatus, lang) {
   const _ssBadgesHtml = (() => {
     if (!staffStatus) return '';
     const bst   = 'display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;white-space:nowrap;margin-bottom:10px;';
-    const dCol  = staffStatus.onDuty      ? 'var(--moss)' : 'var(--red)';
+    const dCol  = staffStatus.onDuty      ? 'var(--blue)' : 'var(--orange)';
     const bCol  = staffStatus.supportBoat ? 'var(--moss)' : 'var(--red)';
-    const dBg   = staffStatus.onDuty      ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
+    const dBg   = staffStatus.onDuty      ? 'color-mix(in srgb, var(--blue) 8%, transparent);border-color:color-mix(in srgb, var(--blue) 25%, transparent)' : 'color-mix(in srgb, var(--orange) 8%, transparent);border-color:color-mix(in srgb, var(--orange) 25%, transparent)';
     const bBg   = staffStatus.supportBoat ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
     const dTx   = s(staffStatus.onDuty      ? 'wx.staffOnDuty'    : 'wx.noStaffOnDuty');
     const bTx   = s(staffStatus.supportBoat ? 'wx.supportBoatOut' : 'wx.noSupportBoat');
@@ -618,9 +618,9 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
         const _ss = typeof getStaffStatus === 'function' ? getStaffStatus() : null;
         if (!_ss) { container.innerHTML = ''; return; }
         const _bst = 'display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:20px;border:1px solid;font-size:11px;font-weight:500;white-space:nowrap;';
-        const _dc  = _ss.onDuty      ? 'var(--moss)' : 'var(--red)';
+        const _dc  = _ss.onDuty      ? 'var(--blue)' : 'var(--orange)';
         const _bc  = _ss.supportBoat ? 'var(--moss)' : 'var(--red)';
-        const _dbg = _ss.onDuty      ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
+        const _dbg = _ss.onDuty      ? 'color-mix(in srgb, var(--blue) 8%, transparent);border-color:color-mix(in srgb, var(--blue) 25%, transparent)' : 'color-mix(in srgb, var(--orange) 8%, transparent);border-color:color-mix(in srgb, var(--orange) 25%, transparent)';
         const _bbg = _ss.supportBoat ? 'color-mix(in srgb, var(--moss) 8%, transparent);border-color:color-mix(in srgb, var(--moss) 25%, transparent)' : 'color-mix(in srgb, var(--red) 8%, transparent);border-color:color-mix(in srgb, var(--red) 25%, transparent)';
         const _dtx = s(_ss.onDuty      ? 'wx.staffOnDuty'    : 'wx.noStaffOnDuty');
         const _btx = s(_ss.supportBoat ? 'wx.supportBoatOut' : 'wx.noSupportBoat');

--- a/staff/index.html
+++ b/staff/index.html
@@ -316,7 +316,7 @@
   <div id="staffStatusStrip" class="mb-12">
     <div class="section-label mb-8">DUTY STATUS</div>
     <div class="flex-center flex-wrap gap-8">
-      <button id="btnStaffOnDuty" onclick="toggleStaffStatus('onDuty')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:var(--red);color:#fff;">No staff on duty</button>
+      <button id="btnStaffOnDuty" onclick="toggleStaffStatus('onDuty')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:var(--orange);color:#fff;">No staff on duty</button>
       <button id="btnSupportBoat" onclick="toggleStaffStatus('supportBoat')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;background:var(--red);color:#fff;">No support boat</button>
       <span id="staffStatusUpdated" class="text-xs text-muted"></span>
     </div>
@@ -1527,10 +1527,12 @@ function renderStaffStatusStrip() {
   const upd     = document.getElementById('staffStatusUpdated');
   if (!btnDuty || !btnBoat) return;
   const base = 'display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;border:none;font-size:12px;font-weight:600;white-space:nowrap;cursor:pointer;font-family:inherit;transition:opacity .15s;';
-  const on   = 'background:var(--moss);color:#fff;';
-  const off  = 'background:var(--red);color:#fff;';
-  btnDuty.setAttribute('style', base + (_staffStatus.onDuty      ? on : off));
-  btnBoat.setAttribute('style', base + (_staffStatus.supportBoat ? on : off));
+  const dutyOn  = 'background:var(--blue);color:#fff;';
+  const dutyOff = 'background:var(--orange);color:#fff;';
+  const boatOn  = 'background:var(--moss);color:#fff;';
+  const boatOff = 'background:var(--red);color:#fff;';
+  btnDuty.setAttribute('style', base + (_staffStatus.onDuty      ? dutyOn : dutyOff));
+  btnBoat.setAttribute('style', base + (_staffStatus.supportBoat ? boatOn : boatOff));
   btnDuty.innerHTML = DUTY_ICONS[_staffStatus.onDuty ? 'lifebuoy' : 'lifebuoyOff'] + (_staffStatus.onDuty ? s('staff.staffOnDuty') : s('staff.noStaffOnDuty'));
   btnBoat.innerHTML = DUTY_ICONS[_staffStatus.supportBoat ? 'ship' : 'shipOff'] + (_staffStatus.supportBoat ? s('staff.supportBoat') : s('staff.noSupportBoat'));
   if (upd && _staffStatus.updatedAt) upd.textContent = s('staff.updatedShort') + ' ' + _staffStatus.updatedAt.slice(11,16) + ' UTC';


### PR DESCRIPTION
Staff on duty / no staff on duty badges now use blue when active and orange when inactive across the member hub, staff portal, public page, weather widget, and weather flag detail modal. The support boat badge is unchanged.