### PR TITLE
Standardize logbook stat cards to match member/staff styling

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -19,10 +19,10 @@
 <style>
 .page{max-width:640px;margin:0 auto;padding:20px 16px 60px}
 .stat-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:12px}
-.stat-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;text-align:center;box-shadow:var(--shadow-sm)}
-.stat-val{font-size:22px;font-weight:500;color:var(--text);line-height:1}
+.stat-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 10px;text-align:center;box-shadow:var(--shadow-sm)}
+.stat-val{font-size:22px;font-weight:500;color:var(--brass-fg);line-height:1}
 .stat-val.stat-val-text{font-size:13px;font-weight:500;line-height:1.15;padding:4px 0 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.stat-lbl{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;margin-top:4px}
+.stat-lbl{font-size:9px;color:var(--muted);letter-spacing:.5px;text-transform:uppercase;margin-top:3px}
 .cat-hours{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 14px;margin-bottom:12px;box-shadow:var(--shadow-sm)}
 .cat-hours-title{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:10px}
 .cat-hour-row{display:flex;align-items:center;gap:10px;margin-bottom:6px;font-size:12px}


### PR DESCRIPTION
- Stat value now uses --brass-fg (green) instead of --text (black)
- Card background uses --card (matches member/staff) instead of --surface
- Padding/letter-spacing/margins aligned with staff stat cells

https://claude.ai/code/session_01XbojxvyAxPhw8gZZiwqxnR