### PR TITLE
Fill slot blocks with booking color; restore icons; crew color stripe

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -612,8 +612,8 @@
         </div>
       </div>
       <div id="slotCalGrid" style="overflow-x:auto"></div>
-      <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted)">
-        <span><span style="display:inline-block;width:10px;height:10px;border:2px solid var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
+      <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted);flex-wrap:wrap">
+        <span><span style="display:inline-block;width:10px;height:10px;background:var(--surface);border:1px solid var(--border);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
         <span><span style="display:inline-block;width:10px;height:10px;background:var(--green);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendBooked">Booked</span></span>
       </div>
     </div>

--- a/captain/index.html
+++ b/captain/index.html
@@ -187,9 +187,9 @@
       </div>
     </div>
     <div id="cqSlotGrid" style="overflow-x:auto"></div>
-    <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted)">
-      <span><span style="display:inline-block;width:10px;height:10px;border:2px solid var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
-      <span><span style="display:inline-block;width:10px;height:10px;background:var(--brass)44;border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendYours">Yours</span></span>
+    <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted);flex-wrap:wrap">
+      <span><span style="display:inline-block;width:10px;height:10px;background:var(--surface);border:1px solid var(--border);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
+      <span><span style="display:inline-block;width:10px;height:10px;background:var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle;box-shadow:inset 0 0 0 2px var(--bg)"></span> <span data-s="slot.legendYours">Yours</span></span>
       <span><span style="display:inline-block;width:10px;height:10px;background:var(--green);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendBooked">Booked</span></span>
     </div>
   </div>

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -56,7 +56,7 @@
 /* ── Crew board ── */
 .cb-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
 .cb-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px;
-  border-left:3px solid var(--border); box-shadow:var(--shadow-sm); }
+  border-left:6px solid var(--border); box-shadow:var(--shadow-sm); }
 .cb-header { display:flex; align-items:center; gap:8px; margin-bottom:6px; flex-wrap:wrap; }
 .cb-name { font-size:13px; font-weight:500; color:var(--text); }
 .cb-count { font-size:10px; color:var(--muted); }
@@ -180,11 +180,11 @@
         </div>
       </div>
       <div id="cxSlotGrid" style="overflow-x:auto"></div>
-      <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted)">
-        <span><span style="display:inline-block;width:10px;height:10px;border:2px solid var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
-        <span><span style="display:inline-block;width:10px;height:10px;background:var(--brass)44;border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendYours">Yours</span></span>
+      <div style="margin-top:8px;display:flex;gap:12px;font-size:10px;color:var(--muted);flex-wrap:wrap">
+        <span><span style="display:inline-block;width:10px;height:10px;background:var(--surface);border:1px solid var(--border);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendOpen">Open</span></span>
+        <span><span style="display:inline-block;width:10px;height:10px;background:var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle;box-shadow:inset 0 0 0 2px var(--bg)"></span> <span data-s="slot.legendYours">Yours</span></span>
         <span><span style="display:inline-block;width:10px;height:10px;background:var(--green);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="slot.legendBooked">Booked</span></span>
-        <span><span style="display:inline-block;width:10px;height:10px;border:2px dashed var(--brass);border-radius:2px;margin-right:4px;vertical-align:middle;opacity:.7"></span> <span data-s="cox.tentative">Tentative</span></span>
+        <span><span style="display:inline-block;width:10px;height:10px;background:var(--green);border:1px dashed var(--bg);border-radius:2px;margin-right:4px;vertical-align:middle"></span> <span data-s="cox.tentative">Tentative</span></span>
       </div>
     </div>
 

--- a/shared/calendar.js
+++ b/shared/calendar.js
@@ -26,6 +26,21 @@
 
   function isMobile() { return window.innerWidth <= MOBILE_BP; }
 
+  // Pick readable foreground (black/white) for a given hex background color
+  function contrastText(hex) {
+    if (!hex) return null;
+    var m = /^#?([0-9a-f]+)$/i.exec(hex);
+    if (!m) return null;
+    var h = m[1];
+    if (h.length === 3) h = h[0]+h[0]+h[1]+h[1]+h[2]+h[2];
+    if (h.length < 6) return null;
+    var r = parseInt(h.substr(0,2), 16);
+    var g = parseInt(h.substr(2,2), 16);
+    var b = parseInt(h.substr(4,2), 16);
+    var y = (r*299 + g*587 + b*114) / 1000;
+    return y > 150 ? '#111' : '#fff';
+  }
+
   // Compute display range from actual slots (avoid wasted empty rows)
   function autoBounds(slots) {
     if (!slots.length) return { startHour: 8, endHour: 18 };
@@ -199,30 +214,35 @@
       block.style.gridRow = startRow + ' / ' + endRow;
       block.style.gridColumn = String(colIdx + 2);
 
-      // Custom slot color (e.g. crew color)
+      // Custom slot color (e.g. crew or captain booking color) fills the
+      // whole block when booked, so the color reads as the primary identifier.
       var slotColor = self.opts.getSlotColor ? self.opts.getSlotColor(sl) : null;
+      var fgColor = null;
       if (slotColor && isBooked) {
-        block.style.borderLeftColor = slotColor;
-        block.style.borderLeftWidth = '3px';
-        block.style.borderLeftStyle = isTentative ? 'dashed' : 'solid';
-        if (isMine) {
-          block.style.background = slotColor + '20';
-          block.style.borderColor = slotColor;
-        }
+        block.style.background = slotColor;
+        block.style.borderColor = slotColor;
+        fgColor = contrastText(slotColor);
+        if (fgColor) block.style.color = fgColor;
+        // "Mine" gets a contrast ring so the owner's block stands out.
+        if (isMine) block.style.boxShadow = 'inset 0 0 0 2px var(--bg)';
       }
 
       var span = endRow - startRow;
       var timeLabel = sl.startTime + '\u2013' + sl.endTime;
       var sub = '';
       if (isMine) {
-        var mineStyle = slotColor ? ' style="color:' + slotColor + '"' : '';
+        var mineStyle = fgColor ? ' style="color:' + fgColor + '"' : '';
         sub = '<span class="sc-slot-who sc-slot-who--mine"' + mineStyle + '>' + esc(s('slot.yours')) + '</span>';
-      } else if (isBooked) sub = '<span class="sc-slot-who">' + esc(sl.bookedByName || sl.bookedByCrewName || '') + '</span>';
+      } else if (isBooked) {
+        var bookedStyle = fgColor ? ' style="color:' + fgColor + '"' : '';
+        sub = '<span class="sc-slot-who"' + bookedStyle + '>' + esc(sl.bookedByName || sl.bookedByCrewName || '') + '</span>';
+      }
 
+      var timeStyle = fgColor ? ' style="color:' + fgColor + '"' : '';
       if (span <= 1) {
-        block.innerHTML = '<span class="sc-slot-time">' + timeLabel + '</span>';
+        block.innerHTML = '<span class="sc-slot-time"' + timeStyle + '>' + timeLabel + '</span>';
       } else {
-        block.innerHTML = '<span class="sc-slot-time">' + timeLabel + '</span>' + sub;
+        block.innerHTML = '<span class="sc-slot-time"' + timeStyle + '>' + timeLabel + '</span>' + sub;
       }
 
       if (isMine && self.opts.onUnbook) {

--- a/shared/style.css
+++ b/shared/style.css
@@ -907,7 +907,7 @@ textarea { min-height: 70px; }
 
 /* ── Slot blocks ── */
 .sc-slot {
-  margin: 1px 2px;
+  margin: 0 2px;
   border-radius: 4px;
   padding: 3px 5px;
   font-size: 9px;
@@ -917,30 +917,31 @@ textarea { min-height: 70px; }
   justify-content: flex-start;
   transition: box-shadow .12s, transform .12s;
   position: relative;
-  z-index: 1;
+  z-index: 2;
   min-height: 0;
 }
-.sc-slot:hover { transform: scale(1.02); z-index: 2; }
+.sc-slot:hover { transform: scale(1.02); z-index: 3; }
 
 .sc-slot--open {
   background: var(--surface);
-  border: 1px solid var(--brass)66;
+  border: 1px solid var(--border);
   cursor: pointer;
 }
-.sc-slot--open:hover { border-color: var(--brass); box-shadow: 0 0 0 1px var(--brass)44; }
+.sc-slot--open:hover { border-color: var(--brass); background: var(--brass)08; box-shadow: 0 0 0 1px var(--brass)44; }
 
 .sc-slot--mine {
-  background: var(--brass)18;
+  background: var(--brass);
   border: 1px solid var(--brass);
-  border-left: 3px solid var(--brass);
+  color: var(--bg);
   cursor: pointer;
 }
-.sc-slot--mine:hover { box-shadow: 0 0 0 1px var(--brass)44; }
+.sc-slot--mine .sc-slot-time,
+.sc-slot--mine .sc-slot-who { color: var(--bg); }
+.sc-slot--mine:hover { box-shadow: 0 0 0 2px var(--brass)66; }
 
 .sc-slot--booked {
   background: var(--green);
   border: 1px solid var(--green);
-  border-left: 3px solid var(--green);
   color: var(--bg);
   cursor: default;
 }
@@ -949,7 +950,6 @@ textarea { min-height: 70px; }
 
 .sc-slot--tentative {
   border-style: dashed;
-  opacity: 0.75;
 }
 
 .sc-slot-time {
@@ -1016,7 +1016,7 @@ textarea { min-height: 70px; }
 .slot-week-nav { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .slot-week-nav .btn { font-size: 11px; padding: 4px 10px; min-height: 0; }
 .slot-week-nav .week-label { font-size: 11px; min-width: 140px; text-align: center; }
-.slot-week-nav .btn .btn-icon { display: none; width: 14px; height: 14px; vertical-align: middle; }
+.slot-week-nav .btn .btn-icon { display: inline-block; width: 14px; height: 14px; vertical-align: middle; margin-right: 5px; }
 
 /* ══════════════════════════════════════════════════════════════════════════════
    RESPONSIVE — Mobile (≤ 600px)
@@ -1101,7 +1101,7 @@ textarea { min-height: 70px; }
   .slot-week-nav { gap: 3px; }
   .slot-week-nav .btn { min-height: 32px; padding: 4px 8px; font-size: 11px; }
   .slot-week-nav .week-label { min-width: 0; font-size: 10px; white-space: nowrap; }
-  .slot-week-nav .btn .btn-icon { display: inline-block; }
+  .slot-week-nav .btn .btn-icon { margin-right: 0; }
   .slot-week-nav .btn .btn-icon ~ .btn-label { display: none; }
 }
 


### PR DESCRIPTION
- Coxswain crew cards now use a wider 6px left stripe so each crew's booking color is prominent on the crew board.
- Slot calendar blocks are opaque (no vertical gap showing the hour gridline underneath) and the booking color fills the whole block rather than only a left-border accent. Text color flips to black or white based on luminance so light booking colors stay readable, and "mine" slots get an inset ring against the booking color to differentiate without losing the color.
- Tentative slots keep the dashed border cue but are no longer semi-transparent so the hour lines do not bleed through.
- Open/unclaimed slots switch from a brass-accent border to a neutral --surface + --border look that reads as available in both themes (brass only appears on hover).
- The calendar-with-dots / multi-dot icons on the single/bulk/+new booking buttons now show on desktop (previously hidden by the week-nav CSS), matching the mobile behavior and restoring the visual language shared with admin.
- Legend swatches on coxswain/captain/admin updated to match.