### PR TITLE
Label rowing slots by crew name and wrap cards in crew color

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4093,6 +4093,15 @@ function renderSlotCalendar() {
   var newCals = {};
   catBoats.forEach(function(boat) {
     var boatSlots = _slotData.filter(function(sl) { return sl.boatId === boat.id; });
+    // Enrich with crew name so the calendar identifies bookings by crew.
+    if (Array.isArray(window._allCrews)) {
+      boatSlots.forEach(function(sl) {
+        if (sl.bookedByCrewId && !sl.bookedByCrewName) {
+          var crew = window._allCrews.find(function(c) { return c.id === sl.bookedByCrewId; });
+          if (crew) sl.bookedByCrewName = crew.name;
+        }
+      });
+    }
     var wrap = document.createElement('div');
     wrap.style.marginBottom = '16px';
     var hdr = document.createElement('div');

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -55,8 +55,8 @@
 
 /* ── Crew board ── */
 .cb-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
-.cb-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:14px;
-  border-left:6px solid var(--border); box-shadow:var(--shadow-sm); }
+.cb-card { background:var(--card); border:3px solid var(--border); border-radius:var(--radius-md); padding:14px;
+  box-shadow:var(--shadow-sm); }
 .cb-header { display:flex; align-items:center; gap:8px; margin-bottom:6px; flex-wrap:wrap; }
 .cb-name { font-size:13px; font-weight:500; color:var(--text); }
 .cb-count { font-size:10px; color:var(--muted); }
@@ -616,7 +616,7 @@ function renderCrewCard(c) {
 
   var descHtml = c.description ? '<div class="cb-desc">' + esc(c.description) + '</div>' : '';
 
-  return '<div class="cb-card" style="border-left-color:' + esc(crewColor) + '">'
+  return '<div class="cb-card" style="border-color:' + esc(crewColor) + '">'
     + '<div class="cb-header">'
       + '<span class="cb-name">' + esc(c.name) + '</span> ' + badge
       + ' <span class="cb-count">' + filledSeats + '/' + totalSeats + '</span>'
@@ -942,6 +942,14 @@ function renderCxSlots() {
     });
   }
   _cxCalendar.opts.isMine = function(sl) { return sl.bookedByCrewId && myCrewIds.indexOf(sl.bookedByCrewId) !== -1; };
+  // Enrich slots with crew name so the calendar can label each booked slot
+  // by crew (unambiguous when the user belongs to multiple crews).
+  _cxSlots.forEach(function(sl) {
+    if (sl.bookedByCrewId && !sl.bookedByCrewName) {
+      var crew = _allBoardCrews.find(function(c) { return c.id === sl.bookedByCrewId; });
+      if (crew) sl.bookedByCrewName = crew.name;
+    }
+  });
   _cxCalendar.setWeekStart(_cxWeekStart);
   _cxCalendar.setSlots(_cxSlots);
 }

--- a/shared/calendar.js
+++ b/shared/calendar.js
@@ -230,12 +230,16 @@
       var span = endRow - startRow;
       var timeLabel = sl.startTime + '\u2013' + sl.endTime;
       var sub = '';
-      if (isMine) {
-        var mineStyle = fgColor ? ' style="color:' + fgColor + '"' : '';
-        sub = '<span class="sc-slot-who sc-slot-who--mine"' + mineStyle + '>' + esc(s('slot.yours')) + '</span>';
-      } else if (isBooked) {
-        var bookedStyle = fgColor ? ' style="color:' + fgColor + '"' : '';
-        sub = '<span class="sc-slot-who"' + bookedStyle + '>' + esc(sl.bookedByName || sl.bookedByCrewName || '') + '</span>';
+      if (isBooked) {
+        var whoStyle = fgColor ? ' style="color:' + fgColor + '"' : '';
+        var whoCls = 'sc-slot-who' + (isMine ? ' sc-slot-who--mine' : '');
+        // Crew bookings always show the crew name — "YOURS" alone is ambiguous
+        // for rowers who belong to more than one crew.
+        var whoLabel = sl.bookedByCrewName
+          || (isMine ? s('slot.yours') : (sl.bookedByName || ''));
+        if (whoLabel) {
+          sub = '<span class="' + whoCls + '"' + whoStyle + '>' + esc(whoLabel) + '</span>';
+        }
       }
 
       var timeStyle = fgColor ? ' style="color:' + fgColor + '"' : '';


### PR DESCRIPTION
The coxswain crew board card previously showed the crew color only as a thick left border, and the slot calendar labelled a rower's own slots "YOURS". That's ambiguous for anyone who belongs to more than one crew: you couldn't tell which crew had actually booked the boat.

- Use the crew color as a full-sided 3px border on the crew card so the identity of the crew reads the same on every edge.
- Always label booked slots by the booking crew's name. Non-crew (captain) bookings still fall back to "YOURS" / booker's name.
- Enrich slot data with the crew name on the coxswain and admin calendars since the backend only returns bookedByCrewId.