### PR TITLE
Temp: leak full doPost error into the response for debug

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1079,7 +1079,10 @@ function doPost(e) {
     return route_(action, b, caller);
   } catch (err) {
     console.error('doPost error:', err && err.stack || err);
-    return failJ('Server error', 500);
+    // TEMPORARY: leak the actual exception message so the login-flow bug
+    // can be diagnosed when the Executions UI isn't expanding versioned
+    // deployment log rows. Roll back to 'Server error' once we're done.
+    return failJ('Server error: ' + (err && (err.stack || err.message) || err), 500);
   }
 }
 


### PR DESCRIPTION
Versioned Apps Script deployments don't expose Logger.log output in the Executions UI, so we can't see which line is throwing during login. Surface the stack trace through the response itself until the root cause is found, then revert.