### PR TITLE
Raise fetch client-timeout from 20s to 60s

### DIFF
--- a/shared/api.js
+++ b/shared/api.js
@@ -110,7 +110,13 @@ async function _call(action, payload) {
   }
   var body = JSON.stringify(Object.assign(envelope, payload));
   var ctrl = (typeof AbortController !== 'undefined') ? new AbortController() : null;
-  var timer = ctrl ? setTimeout(function() { ctrl.abort(); }, 20000) : null;
+  // 60s client abort: most calls return in <2s, but PBKDF2-gated actions
+  // (loginMember runs one, setPassword runs two) can each take ~5-8s on
+  // Apps Script, and any further sheet I/O after the HMAC loop adds on
+  // top. A shorter bound aborts the fetch while the server is still
+  // persisting, which has the confusing effect of failing the UI even
+  // though the write already landed.
+  var timer = ctrl ? setTimeout(function() { ctrl.abort(); }, 60000) : null;
   try {
     var res = await fetch(SCRIPT_URL, {
       method:   "POST",


### PR DESCRIPTION
setPassword runs two PBKDF2 ops back-to-back (verify current + hash new) — each takes ~5-8s in Apps Script, so the call routinely brushed up against the 20s AbortController limit. When the abort fired first, the browser threw AbortError → the UI reported "could not change password" even though the server had already persisted the new hash, leaving the user logged in with the temp they'd just replaced.

60s gives comfortable headroom for two PBKDF2 ops plus sheet I/O without changing the typical-request UX (the timer fires only on genuinely stuck requests).