### PR TITLE
Guard wxCondDesc call in trip card render

### DIFF
--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -60,7 +60,7 @@ function tripCard(t){
   const eWs = _expWind ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${s('tc.windSpeed')}</span><span class="trip-exp-val">${esc(_expWind)}${_expExtra}</span></div>` : '';
   const eDir  = (wx?.dir||_windDir) ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${s('tc.direction')}</span><span class="trip-exp-val">${dirArrow(wx?.dir||_windDir)} ${esc(wx?.dir||_windDir)}</span></div>` : '';
   const eGust = wx?.wg!=null  ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${s('tc.gusts')}</span><span class="trip-exp-val">${_windUnit==='bft'?s('wx.force')+' '+bftFromMs(wx.wg):convertWind(wx.wg,_windUnit)+' '+windUnitLabel(_windUnit)}</span></div>` : '';
-  const _condDesc = wx?.cond?.code != null ? wxCondDesc(wx.cond.code) : (wx?.cond?.desc || '');
+  const _condDesc = (wx?.cond?.code != null && typeof wxCondDesc === 'function') ? wxCondDesc(wx.cond.code) : (wx?.cond?.desc || '');
   const eCond = _condDesc ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${s('tc.conditions')}</span><span class="trip-exp-val">${wx?.cond?.icon||''} ${esc(_condDesc)}</span></div>` : '';
   const eAir  = wx?.tc!=null   ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${s('tc.airTemp')}</span><span class="trip-exp-val">${Math.round(wx.tc)}°C</span></div>` : '';
   const eFeel = wx?.feels!=null ? `<div class="trip-exp-row"><span class="trip-exp-lbl">${s('tc.feelsLike')}</span><span class="trip-exp-val">${Math.round(wx.feels)}°C</span></div>` : '';


### PR DESCRIPTION
The previous localization commit started calling wxCondDesc() (defined in shared/weather.js) when re-resolving a stored weather code, but the captain and logbook pages don't load weather.js. That left tripCard throwing "wxCondDesc is not defined" whenever a snapshot included a condition code, breaking the card render entirely.

Fall back to the snapshot's stored cond.desc when wxCondDesc isn't available so cards still render localized when weather.js is loaded and gracefully when it isn't.

https://claude.ai/code/session_018MHQMbfHBAX9cVFT9DPyyw