### PR TITLE
Swap login role/account card to navy/brass wash

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -22,20 +22,20 @@
     .stay-row input { margin:0; }
     .lang-row { text-align:center; margin-top:16px; }
     #roleScreen, #accountScreen, #forceChangeScreen { display:none; }
-    /* Role/account picker card: moss-green brand wash with white welcome text */
+    /* Role/account picker card: deep-navy wash with brass welcome text */
     #roleScreen .card, #accountScreen .card {
-      background: var(--moss);
-      border-color: var(--moss-d);
-      color: #fff;
+      background: var(--navy-d);
+      border-color: var(--navy-l);
+      color: var(--text);
     }
-    .role-greeting { color:#fff; font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; font-weight:500; }
+    .role-greeting { color:var(--brass-fg); font-size:13px; margin-bottom:20px; text-align:center; letter-spacing:.5px; font-weight:500; }
     .role-btn {
       width:100%; padding:18px 20px; margin-bottom:10px; border-radius:var(--radius-md);
-      border:1px solid var(--moss-l); background:var(--surface); cursor:pointer;
+      border:1px solid var(--navy-l); background:var(--surface); cursor:pointer;
       display:flex; align-items:center; gap:14px; transition:all .2s;
       text-align:left; box-shadow:var(--shadow-sm);
     }
-    .role-btn:hover { border-color:var(--moss-d); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
+    .role-btn:hover { border-color:var(--brass); background:var(--card); transform:translateY(-1px); box-shadow:var(--shadow-md); }
     .role-btn .role-icon { width:22px; height:22px; flex-shrink:0; display:inline-flex; align-items:center; color:var(--brass-fg); }
     .role-btn .role-icon svg { width:100%; height:100%; }
     .role-btn .role-label { color:var(--text); font-size:13px; font-weight:500; letter-spacing:.5px; }


### PR DESCRIPTION
The green moss panel stood out from the rest of the dark login flow. Use the deep-navy surface with brass greeting and brass hover border instead — keeps the "this card is a moment" feel while staying on-brand with the navy/brass login styling.

https://claude.ai/code/session_01AJ9Wft9bJkh9wdKkJtqStF