### PR TITLE
Prefix trip photo filenames with sharing state

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -4752,7 +4752,13 @@ function saveTripPhoto_(b) {
   try {
     const ext      = (b.fileName || 'photo.jpg').split('.').pop().toLowerCase();
     const ts       = now_().replace(/[: ]/g, '-');
-    const safeName = ts + '_' + (b.fileName || 'photo.' + ext);
+    // Prefix marks the member's sharing choice so admins browsing the Drive
+    // folder can tell shared/club-use photos apart from private uploads.
+    let prefix = 'PRIVATE_';
+    if (b.shared && b.clubUse)      prefix = 'SHARED_CLUB_';
+    else if (b.shared)              prefix = 'SHARED_';
+    else if (b.clubUse)             prefix = 'CLUB_';
+    const safeName = prefix + ts + '_' + (b.fileName || 'photo.' + ext);
     const base64   = b.fileData.replace(/^data:[^;]+;base64,/, '');
     const bytes    = Utilities.base64Decode(base64);
     const mimeMap  = { jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif', webp:'image/webp', heic:'image/heic' };

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -1261,7 +1261,7 @@ async function submitManual(){
   const mPhotoClubUse = document.getElementById('mPhotoClubUse').checked;
   await Promise.all(_pendingPhotos.map(async ph=>{
     try{
-      const pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType});
+      const pr=await apiPost('uploadTripFile',{fileType:'photo',fileName:ph.fileName,fileData:ph.fileData,mimeType:ph.mimeType,shared:mPhotoShared,clubUse:mPhotoClubUse});
       if(pr.ok && pr.photoUrl) photoUrls.push(pr.photoUrl);
       else if(!pr.ok) showToast(s('logbook.photoNoConfig'),'warn');
     }catch(e){ showToast(s('logbook.photoUploadFailed',{msg:e.message}),'warn'); }
@@ -2219,7 +2219,7 @@ async function submitInlinePhotos() {
     const newUrls = [];
     await Promise.all(_inlinePhotos.map(async ph => {
       try {
-        const res = await apiPost('uploadTripFile', { fileType: 'photo', fileName: ph.fileName, fileData: ph.fileData, mimeType: ph.mimeType });
+        const res = await apiPost('uploadTripFile', { fileType: 'photo', fileName: ph.fileName, fileData: ph.fileData, mimeType: ph.mimeType, shared, clubUse });
         if (res.ok && res.photoUrl) {
           newUrls.push(res.photoUrl);
           meta[res.photoUrl] = { shared, clubUse, uploadedBy: user.kennitala };


### PR DESCRIPTION
Route all trip photos into the single DRIVE_FOLDER_ID_PHOTOS folder as before, but prefix the Drive filename with SHARED_, CLUB_, SHARED_CLUB_, or PRIVATE_ based on the member's sharing choice. This lets admins browsing the folder tell opted-in photos apart from private uploads at a glance without changing ACLs or splitting folders.

https://claude.ai/code/session_01S3YW7HjrwjkGQ3Zws7ec44