### PR TITLE
Retrofit list+filter pages onto shared/list-filter.js helper

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -12,6 +12,7 @@
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
 <script src="../shared/strings.js"></script>
+<script src="../shared/list-filter.js"></script>
 <script src="../shared/calendar.js" defer></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/certs.js" defer></script>
@@ -923,6 +924,7 @@ window.mcmGetCertCategories = function() { return _cqCertCategories; };
 
 // ══ CAPTAIN LOGBOOK FILTERS (override shared/logbook.js) ════════════════════
 var _captains = [];
+var _cqTripFilter = null;  // shared/list-filter.js controller built in buildFilters()
 
 // Resolve the skipper's kennitala for a trip. For a crew trip, this walks the
 // linkage (linkedTripId / linkedCheckoutId) back to the skipper row.
@@ -1024,45 +1026,52 @@ function buildFilters() {
   mSel.innerHTML = '<option value="">' + s('cq.allMembers') + '</option>';
   keelboatMembers.forEach(function(m) { var o = document.createElement('option'); o.value = m.kennitala; o.textContent = memberDisplayName(m, keelboatMembers); mSel.appendChild(o); });
 
-  // Rebuild boat options when category changes (registered first so it runs before applyFilter)
+  // Category change rebuilds boat-name options before the filter re-runs.
   cSel.addEventListener('change', function() { _rebuildBoatNameOptions(this.value); });
-  ['fYear', 'fCat', 'fBoatName', 'fCaptain', 'fMember', 'fWind'].forEach(function(id) { document.getElementById(id).addEventListener('change', applyFilter); });
-  document.getElementById('fText').addEventListener('input', applyFilter);
-}
 
-function applyFilter() {
-  Object.keys(_thumbMaps).forEach(function(k) { try { _thumbMaps[k].remove(); } catch(e){} delete _thumbMaps[k]; });
-  var yr       = document.getElementById('fYear').value;
-  var cat      = document.getElementById('fCat').value;
-  var boatName = document.getElementById('fBoatName').value;
-  var captain  = document.getElementById('fCaptain').value;
-  var member   = document.getElementById('fMember').value;
-  var wind     = document.getElementById('fWind').value;
-  var txt      = document.getElementById('fText').value.toLowerCase().trim();
-
-  var filtered = myTrips.filter(function(t) {
-    if (yr && !(t.date || '').startsWith(yr)) return false;
-    if (cat) { var tCat = ((allBoats.find(function(b) { return b.id === t.boatId; }) || {}).category || t.boatCategory || '').toLowerCase(); if (tCat !== cat.toLowerCase()) return false; }
-    if (boatName && (t.boatName || '') !== boatName) return false;
-    if (captain && _tripSkipperKt(t) !== String(captain)) return false;
-    if (member && !_tripPartyKts(t).has(String(member))) return false;
-    if (wind) {
-      var b = parseInt(t.beaufort) || 0;
-      if (wind === 'gt4' && b <= 4) return false;
-      if (wind === 'lte4' && b > 4) return false;
-      if (['calm', 'light', 'moderate', 'strong'].includes(wind) && bftGroup(b) !== wind) return false;
-    }
-    if (txt) {
-      var hay = [t.boatName, t.memberName, t.locationName, t.date, t.beaufort, t.windDir, t.notes, t.skipperNote, t.boatCategory].join(' ').toLowerCase();
-      if (!hay.includes(txt)) return false;
-    }
-    return true;
+  var yrInitial  = yrSel.value;
+  var catInitial = cSel.value;
+  _cqTripFilter = createListFilter({
+    source:  function() { return myTrips; },
+    filters: { yr: yrInitial, cat: catInitial, boatName: '', captain: '', member: '', wind: '' },
+    predicate: function(t, f) {
+      if (f.yr && !(t.date || '').startsWith(f.yr)) return false;
+      if (f.cat) {
+        var tCat = ((allBoats.find(function(b) { return b.id === t.boatId; }) || {}).category || t.boatCategory || '').toLowerCase();
+        if (tCat !== f.cat.toLowerCase()) return false;
+      }
+      if (f.boatName && (t.boatName || '') !== f.boatName) return false;
+      if (f.captain  && _tripSkipperKt(t) !== String(f.captain)) return false;
+      if (f.member   && !_tripPartyKts(t).has(String(f.member))) return false;
+      if (f.wind) {
+        var b = parseInt(t.beaufort) || 0;
+        if (f.wind === 'gt4'  && b <= 4) return false;
+        if (f.wind === 'lte4' && b >  4) return false;
+        if (['calm','light','moderate','strong'].includes(f.wind) && bftGroup(b) !== f.wind) return false;
+      }
+      if (f.search) {
+        var hay = [t.boatName, t.memberName, t.locationName, t.date, t.beaufort, t.windDir, t.notes, t.skipperNote, t.boatCategory].join(' ').toLowerCase();
+        if (!hay.includes(f.search.toLowerCase().trim())) return false;
+      }
+      return true;
+    },
+    render: function(filtered) {
+      // Tear down previous mini-maps before re-rendering cards — leaflet leaks
+      // handlers otherwise.
+      Object.keys(_thumbMaps).forEach(function(k) { try { _thumbMaps[k].remove(); } catch(e){} delete _thumbMaps[k]; });
+      document.getElementById('tripList').innerHTML = filtered.length
+        ? filtered.map(tripCard).join('')
+        : '<div class="empty-note">' + s('cq.noTripsMatch') + '</div>';
+      document.getElementById('filterCount').textContent = filtered.length + ' / ' + myTrips.length;
+    },
+  }).autoWire({
+    fields: { fYear: 'yr', fCat: 'cat', fBoatName: 'boatName', fCaptain: 'captain', fMember: 'member', fWind: 'wind' },
+    search: 'fText',
   });
-  document.getElementById('tripList').innerHTML = filtered.length
-    ? filtered.map(tripCard).join('')
-    : '<div class="empty-note">' + s('cq.noTripsMatch') + '</div>';
-  document.getElementById('filterCount').textContent = filtered.length + ' / ' + myTrips.length;
 }
+
+// Kept as a thin shim so existing callers (init, post-save refreshes) keep working.
+function applyFilter() { if (_cqTripFilter) _cqTripFilter.refresh(); }
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // CAPTAIN RESERVATION SLOTS

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -14,6 +14,7 @@
 <script>prefetch({Trips:['getTrips',{limit:500}],Config:['getConfig'],Members:['getMembers']});</script>
 <script src="../shared/ui.js"></script>
 <script src="../shared/strings.js"></script>
+<script src="../shared/list-filter.js"></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/certs.js" defer></script>
 <script src="../shared/boats.js" defer></script>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -11,6 +11,7 @@
   <script src="../shared/api.js"></script>
   <script src="../shared/ui.js"></script>
   <script src="../shared/strings.js"></script>
+  <script src="../shared/list-filter.js"></script>
   <script src="../shared/maintenance.js" defer></script>
   <style>
     .page-wrap { max-width: 820px; margin: 0 auto; padding: 20px 16px 60px; 
@@ -286,18 +287,17 @@ let pendingMaterials = [];
 let isSaumaMode = false;
 let editingId = "";
 
-let activeFilters = {
-  status:   new Set(['open']),
-  type:     new Set(),
-  category: new Set(),
-  severity: new Set(),
-  sauma:    new Set(),
-};
+// Filter state lives inside _maintFilter (shared/list-filter.js). activeFilters
+// is kept as an alias onto that state so the existing pill-update code keeps
+// working without threading the controller through everything.
+let _maintFilter = null;
+let activeFilters = null;
 
 // ── Init ──────────────────────────────────────────────────────────────────
 document.addEventListener("DOMContentLoaded", async () => {
   buildHeader('maintenance');
   applyStrings();
+  initMaintFilter();
 
   try {
     const [rRes, cfgRes] = await Promise.all([
@@ -311,7 +311,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     populateBoatSelect();
     renderStats();
     updateFilterUI();
-    renderList();
+    _maintFilter.refresh();  // predicate + render in one shot
   } catch(e) {
     document.getElementById("reqList").innerHTML =
       `<div class="empty-wrap"><div class="empty-icon">⚠️</div><p>${esc(s('maint.loadFailed',{msg:e.message}))}</p></div>`;
@@ -388,14 +388,58 @@ function showPendingReviews() {
   document.getElementById('reqList')?.scrollIntoView({behavior:'smooth',block:'start'});
 }
 
-// ── Filter & render ────────────────────────────────────────────────────────────
-function toggleFilter(group, value) {
-  const set = activeFilters[group];
-  if (set.has(value)) set.delete(value);
-  else set.add(value);
-  updateFilterUI();
-  renderList();
+// ── Filter setup & render ─────────────────────────────────────────────────────
+function initMaintFilter() {
+  _maintFilter = createListFilter({
+    source: () => allRequests || [],
+    filters: {
+      status:   new Set(['open']),
+      type:     new Set(),
+      category: new Set(),
+      severity: new Set(),
+      sauma:    new Set(),
+    },
+    predicate: (r, f) => {
+      const resolved = boolVal(r.resolved);
+      const isSauma  = boolVal(r.saumaklubbur);
+      const anyActive = ['status','type','category','severity','sauma'].some(k => f[k] && f[k].size > 0);
+      const userName = window._maintUser?.name || '';
+
+      // Default: no selections = show open items.
+      if (!anyActive) return !resolved;
+
+      if (f.status.size > 0) {
+        const ok = (f.status.has('open') && !resolved) || (f.status.has('resolved') && resolved);
+        if (!ok) return false;
+      }
+      if (f.type.size > 0) {
+        const ok = (f.type.has('sauma') && isSauma) || (f.type.has('maintenance') && !isSauma);
+        if (!ok) return false;
+      }
+      if (f.category.size > 0 && !f.category.has(r.category)) return false;
+      if (f.severity.size > 0 && !f.severity.has(r.severity)) return false;
+      if (f.sauma.size > 0) {
+        if (!isSauma) return false;
+        const matchUn      = f.sauma.has('unassigned') && !r.verkstjori;
+        const matchMy      = f.sauma.has('myprojects') && (r.verkstjori === userName || parseJson(r.comments,[]).some(c => c.by === userName));
+        const matchPending = f.sauma.has('pending')    && !boolVal(r.approved);
+        if (!matchUn && !matchMy && !matchPending) return false;
+      }
+      return true;
+    },
+    render: renderMaintList,
+  });
+  activeFilters = _maintFilter.state();  // live alias used by updateFilterUI()
 }
+
+function toggleFilter(group, value) {
+  _maintFilter.toggleSetMember(group, value);  // triggers re-render
+  updateFilterUI();
+}
+
+// Back-compat: anything that used to call renderList() now just re-runs the
+// filter pipeline. New code should prefer _maintFilter.refresh().
+function renderList() { if (_maintFilter) _maintFilter.refresh(); }
 
 function updateFilterUI() {
   const tf = activeFilters.type;
@@ -416,55 +460,7 @@ function updateFilterUI() {
   });
 }
 
-function getFiltered() {
-  const f = activeFilters;
-  const anyActive = Object.values(f).some(s => s.size > 0);
-  const userName = window._maintUser?.name || '';
-
-  return allRequests.filter(r => {
-    const resolved = boolVal(r.resolved);
-    const isSauma = boolVal(r.saumaklubbur);
-
-    // Default: no selections = show open items
-    if (!anyActive) return !resolved;
-
-    // STATUS (OR)
-    if (f.status.size > 0) {
-      const ok = (f.status.has('open') && !resolved) || (f.status.has('resolved') && resolved);
-      if (!ok) return false;
-    }
-
-    // TYPE (OR)
-    if (f.type.size > 0) {
-      const ok = (f.type.has('sauma') && isSauma) || (f.type.has('maintenance') && !isSauma);
-      if (!ok) return false;
-    }
-
-    // CATEGORY (OR)
-    if (f.category.size > 0) {
-      if (!f.category.has(r.category)) return false;
-    }
-
-    // SEVERITY (OR)
-    if (f.severity.size > 0) {
-      if (!f.severity.has(r.severity)) return false;
-    }
-
-    // SAUMA-specific (OR within, AND with sauma type)
-    if (f.sauma.size > 0) {
-      if (!isSauma) return false;
-      const matchUn = f.sauma.has('unassigned') && !r.verkstjori;
-      const matchMy = f.sauma.has('myprojects') && (r.verkstjori === userName || parseJson(r.comments,[]).some(c => c.by === userName));
-      const matchPending = f.sauma.has('pending') && !boolVal(r.approved);
-      if (!matchUn && !matchMy && !matchPending) return false;
-    }
-
-    return true;
-  });
-}
-
-function renderList() {
-  const items = getFiltered();
+function renderMaintList(items) {
   const el = document.getElementById("reqList");
   if (!items.length) {
     el.innerHTML = `<div class="empty-wrap"><div class="empty-icon">🔧</div><p>${s('maint.noFilterMatch')}</p></div>`;

--- a/shared/list-filter.js
+++ b/shared/list-filter.js
@@ -1,16 +1,15 @@
 // ═══════════════════════════════════════════════════════════════════════════════
 // ÝMIR — shared/list-filter.js
 //
-// Lightweight state container for the "list + filter + edit modal" pattern
-// used on logbook, captain, incidents, maintenance, and dailylog. Pages keep
-// ownership of their row/detail HTML (it is intentionally domain-specific);
-// this helper removes the boilerplate of tracking filter values, running the
-// predicate, debouncing search, and triggering a re-render.
+// State container for the "list + filter + edit modal" pattern. Pages keep
+// ownership of their row/detail HTML (it's intentionally domain-specific);
+// this helper owns filter state, predicate runs, search debounce, and the
+// render trigger — the pieces every list page was reimplementing.
 //
-// Usage:
+// ── Basic usage ──────────────────────────────────────────────────────────────
 //   const lf = createListFilter({
-//     source:   () => allTrips,            // array accessor
-//     filters:  { boat: '', status: 'open' },  // initial filter state
+//     source:   () => allTrips,
+//     filters:  { boat: '', status: 'open' },      // initial state
 //     predicate: (item, f) => {
 //       if (f.boat   && item.boatId !== f.boat)   return false;
 //       if (f.status && item.status !== f.status) return false;
@@ -18,12 +17,25 @@
 //       return true;
 //     },
 //     render:   items => renderRows(items),
-//     onSearch: 250,                       // debounce ms (default 200)
+//     onSearch: 250,                               // search-input debounce ms
 //   });
-//   lf.setFilter('boat', boatId);          // triggers render
-//   lf.setSearch(input.value);             // debounced
-//   lf.refresh();                          // force re-run (e.g. after POST)
-//   lf.get();                              // current filtered array
+//
+// ── Wiring shortcut (autoWire) ───────────────────────────────────────────────
+//   lf.autoWire({
+//     fields: { fYear: 'yr', fCat: 'cat', fWind: 'wind' },  // elId → state key
+//     search: 'fText',                                      // input → setSearch()
+//   });
+// Equivalent to adding change/input listeners by hand; skips any missing elements.
+//
+// ── Set-valued filters (multi-select pills) ──────────────────────────────────
+// Initial state value can be a Set; toggleSetMember flips membership without
+// the caller managing Set semantics:
+//   lf.toggleSetMember('status', 'open');
+//
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+//   lf.refresh();   // re-run (e.g. after a POST updates the source)
+//   lf.get();       // current filtered array
+//   lf.getState();  // snapshot of filter state
 // ═══════════════════════════════════════════════════════════════════════════════
 
 ;(function () {
@@ -43,7 +55,7 @@
       return lastOut;
     }
 
-    return {
+    const api = {
       setFilter(key, val) { state[key] = val; apply(); },
       setFilters(patch)   { Object.assign(state, patch); apply(); },
       setSearch(val) {
@@ -51,9 +63,36 @@
         if (searchTid) clearTimeout(searchTid);
         searchTid = setTimeout(apply, debounce);
       },
-      refresh()      { apply(); return lastOut; },
-      get()          { return lastOut; },
-      getState()     { return Object.assign({}, state); },
+      toggleSetMember(key, val) {
+        if (!(state[key] instanceof Set)) state[key] = new Set();
+        if (state[key].has(val)) state[key].delete(val);
+        else                     state[key].add(val);
+        apply();
+      },
+      refresh()  { apply(); return lastOut; },
+      get()      { return lastOut; },
+      getState() { return Object.assign({}, state); },
+      // Live reference to the internal state (including Sets). Callers that
+      // only read are fine; mutations bypass re-render — use setFilter /
+      // toggleSetMember for writes.
+      state()    { return state; },
+      // Bind select/input elements to state keys in one call. Missing elements
+      // are skipped (handy when a page hides certain filters conditionally).
+      autoWire(cfg) {
+        const fields = (cfg && cfg.fields) || {};
+        Object.keys(fields).forEach(function (elId) {
+          const el  = document.getElementById(elId);
+          if (!el) return;
+          const key = fields[elId];
+          el.addEventListener('change', function () { api.setFilter(key, el.value); });
+        });
+        if (cfg && cfg.search) {
+          const searchEl = document.getElementById(cfg.search);
+          if (searchEl) searchEl.addEventListener('input', function () { api.setSearch(searchEl.value); });
+        }
+        return api;
+      },
     };
+    return api;
   };
 })();

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -445,45 +445,10 @@ var _filteredTrips = [];
 var _renderedCount = 0;
 var _tripListObserver = null;
 var _TRIP_BATCH = 40;
+var _tripFilter = null;  // shared/list-filter.js controller — built in buildFilters()
 
-function applyFilter(){
-  // Destroy stale thumb maps before re-rendering
-  Object.keys(_thumbMaps).forEach(k => { try { _thumbMaps[k].remove(); } catch(e){} delete _thumbMaps[k]; });
-  const yr  = (document.getElementById('fYear')||{}).value||'';
-  const cat = (document.getElementById('fCat')||{}).value||'';
-  const role= (document.getElementById('fRole')||{}).value||'';
-  const wind= (document.getElementById('fWind')||{}).value||'';
-  const txt = ((document.getElementById('fText')||{}).value||'').toLowerCase().trim();
-
-  _filteredTrips=myTrips.filter(t=>{
-    if(yr  && !(t.date||'').startsWith(yr)) return false;
-    if(cat){const tCat=((allBoats.find(b=>b.id===t.boatId)?.category)||t.boatCategory||'').toLowerCase();if(tCat!==cat.toLowerCase())return false;}
-    if(role==='skipper' && t.role==='crew') return false;
-    if(role==='crew'    && t.role!=='crew') return false;
-    if(wind){
-      const b=parseInt(t.beaufort)||0;
-      if(wind==='gt4'  && b<=4)  return false;
-      if(wind==='lte4' && b>4)   return false;
-      if(['calm','light','moderate','strong'].includes(wind) && bftGroup(b)!==wind) return false;
-    }
-    if(txt){
-      const hay=[t.boatName,t.locationName,t.date,t.beaufort,t.windDir,t.notes,t.skipperNote,t.boatCategory].join(' ').toLowerCase();
-      if(!hay.includes(txt)) return false;
-    }
-    return true;
-  });
-
-  _renderedCount = 0;
-  var el = document.getElementById('tripList');
-  if (!_filteredTrips.length) {
-    el.innerHTML = '<div class="empty-note">'+s('logbook.noFilter')+'</div>';
-  } else {
-    el.innerHTML = '';
-    _renderTripBatch(el);
-    _setupTripScrollObserver(el);
-  }
-  document.getElementById('filterCount').textContent=_filteredTrips.length+' / '+myTrips.length;
-}
+// Captain overrides this via its own applyFilter() shim, so we keep a stable name.
+function applyFilter(){ if (_tripFilter) _tripFilter.refresh(); }
 
 function _renderTripBatch(el) {
   var end = Math.min(_renderedCount + _TRIP_BATCH, _filteredTrips.length);
@@ -530,8 +495,48 @@ function buildFilters(){
   const cSel=document.getElementById('fCat');
   cats.forEach(c=>{const o=document.createElement('option');o.value=c;o.textContent=boatEmoji(c.toLowerCase())+' '+c;cSel.appendChild(o);});
 
-  ['fYear','fCat','fRole','fWind'].forEach(id=>{const el=document.getElementById(id);if(el)el.addEventListener('change',applyFilter);});
-  const fText=document.getElementById('fText');if(fText)fText.addEventListener('input',applyFilter);
+  _tripFilter = createListFilter({
+    source:  function() { return myTrips; },
+    filters: { yr: yrSel.value, cat: '', role: '', wind: '' },
+    predicate: function(t, f) {
+      if (f.yr && !(t.date || '').startsWith(f.yr)) return false;
+      if (f.cat) {
+        const tCat = ((allBoats.find(b => b.id === t.boatId)?.category) || t.boatCategory || '').toLowerCase();
+        if (tCat !== f.cat.toLowerCase()) return false;
+      }
+      if (f.role === 'skipper' && t.role === 'crew') return false;
+      if (f.role === 'crew'    && t.role !== 'crew') return false;
+      if (f.wind) {
+        const b = parseInt(t.beaufort) || 0;
+        if (f.wind === 'gt4'  && b <= 4) return false;
+        if (f.wind === 'lte4' && b >  4) return false;
+        if (['calm','light','moderate','strong'].includes(f.wind) && bftGroup(b) !== f.wind) return false;
+      }
+      if (f.search) {
+        const hay = [t.boatName, t.locationName, t.date, t.beaufort, t.windDir, t.notes, t.skipperNote, t.boatCategory].join(' ').toLowerCase();
+        if (!hay.includes(f.search.toLowerCase().trim())) return false;
+      }
+      return true;
+    },
+    render: function(filtered) {
+      // Tear down stale thumb maps before re-rendering; batched render below.
+      Object.keys(_thumbMaps).forEach(k => { try { _thumbMaps[k].remove(); } catch(e){} delete _thumbMaps[k]; });
+      _filteredTrips = filtered;
+      _renderedCount = 0;
+      const el = document.getElementById('tripList');
+      if (!filtered.length) {
+        el.innerHTML = '<div class="empty-note">' + s('logbook.noFilter') + '</div>';
+      } else {
+        el.innerHTML = '';
+        _renderTripBatch(el);
+        _setupTripScrollObserver(el);
+      }
+      document.getElementById('filterCount').textContent = filtered.length + ' / ' + myTrips.length;
+    },
+  }).autoWire({
+    fields: { fYear: 'yr', fCat: 'cat', fRole: 'role', fWind: 'wind' },
+    search: 'fText',
+  });
 }
 
 // ── Log manually modal ────────────────────────────────────────────────────────


### PR DESCRIPTION
Enhance the helper (now has autoWire, toggleSetMember, state()) and migrate the three pages that actually had a filter bar onto it. Incidents and dailylog don't filter a list, so they're left alone.

shared/list-filter.js:
- autoWire({fields, search}) binds DOM elements to state keys in one call.
- toggleSetMember(key, value) for Set-valued filters (multi-select pills).
- state() returns the live state object (read-only contract; writes still go through setFilter / toggleSetMember for re-render).

captain/index.html:
- Replace applyFilter() (40 lines of DOM-read + predicate + render) with a createListFilter config + autoWire. applyFilter() remains as a thin refresh() shim so existing call sites keep working.

shared/logbook.js:
- Same retrofit; render callback preserves batched IntersectionObserver rendering by assigning _filteredTrips and delegating to _renderTripBatch.

maintenance/index.html:
- Set-based pill filters routed through toggleSetMember. activeFilters is kept as a live alias onto the helper's state so updateFilterUI() and the showPendingReviews() shortcut continue to work without threading the controller through every caller.
- renderList() / renderMaintList() split: renderMaintList() is the pure render function passed to the helper; renderList() remains as a refresh() shim for external callers.

https://claude.ai/code/session_01FVm6YsxYWu1FUEttJ5RMds