### PR TITLE
Stop slicing UTC ISO for checkout/trip date+time defaults

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -274,6 +274,14 @@ function gs_(key, vars, lang) {
 
 function ss_() { return SpreadsheetApp.openById(SHEET_ID_); }
 function now_() { return new Date().toISOString(); }
+// Script-timezone formatters — use these for defaults that go into sheet
+// columns whose values round-trip as local (trip `date`, `timeOut`, `timeIn`,
+// `checkedOutAt`, `checkedInAt`, `expectedReturn`). Slicing `now_()` instead
+// silently stores UTC, which drifts from what the user sees whenever the
+// script timezone isn't UTC.
+function nowLocalDate_() { return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd'); }
+function nowLocalTime_() { return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'HH:mm'); }
+function nowLocalDateTime_() { return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm"); }
 function uid_() { return Utilities.getUuid().replace(/-/g, '').slice(0, 16); }
 function bool_(v) { return v === true || v === 'TRUE' || v === 'true' || v === 1 || v === '1'; }
 // Prefix a literal apostrophe onto any string whose first character Sheets
@@ -3053,9 +3061,11 @@ function addIncidentNote_(b) {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 function getActiveCheckouts_() {
-  const today = now_().slice(0, 10);
+  // Compare against createdAt's UTC date since createdAt is stored as UTC ISO
+  // via now_(); both operands must share the same reference frame.
+  const todayUtc = now_().slice(0, 10);
   const all = readAll_('checkouts');
-  const result = all.filter(c => c.status === 'out' || (c.status === 'in' && (c.createdAt || '').slice(0, 10) === today));
+  const result = all.filter(c => c.status === 'out' || (c.status === 'in' && (c.createdAt || '').slice(0, 10) === todayUtc));
   let memberMap = {};
   try { memberMap = getMemberMap_(); } catch (e) { }
   const enriched = result.map(c => {
@@ -3100,14 +3110,13 @@ function saveCheckout_(b) {
           if (!hasAccess && checkBoat.accessAllowlist && Array.isArray(checkBoat.accessAllowlist) && checkBoat.accessAllowlist.indexOf(checkKt) !== -1) hasAccess = true;
           // Reservation check (date-range)
           if (!hasAccess && checkBoat.reservations && checkBoat.reservations.length) {
-            var today = new Date().toISOString().slice(0, 10);
+            var today = nowLocalDate_();
             hasAccess = checkBoat.reservations.some(function(r) { return String(r.memberKennitala) === checkKt && today >= r.startDate && today <= r.endDate; });
           }
           // Slot-based scheduling check
           if (!hasAccess && checkBoat.slotSchedulingEnabled) {
-            var nowDate = new Date();
-            var todayStr = nowDate.toISOString().slice(0, 10);
-            var nowTime = String(nowDate.getHours()).padStart(2, '0') + ':' + String(nowDate.getMinutes()).padStart(2, '0');
+            var todayStr = nowLocalDate_();
+            var nowTime = nowLocalTime_();
             try {
               var slots = readAll_('reservationSlots').filter(function(s) {
                 return s.boatId === checkBoat.id && s.date === todayStr && s.startTime <= nowTime && s.endTime > nowTime && s.bookedByKennitala;
@@ -3159,7 +3168,7 @@ function saveCheckout_(b) {
         wv: w.wv != null ? parseFloat(w.wv.toFixed ? w.wv.toFixed(1) : w.wv) : (w.waveH != null ? parseFloat(parseFloat(w.waveH).toFixed(1)) : null),
         flag: w.flag || w.flagKey || '',
         tc: w.tc != null ? Math.round(w.tc) : (w.airT != null ? Math.round(w.airT) : null),
-        ts: w.ts || ts.slice(0, 16),
+        ts: w.ts || nowLocalDateTime_(),
       });
     } catch (e) { wxSnap = ''; }
   }
@@ -3168,7 +3177,7 @@ function saveCheckout_(b) {
     memberKennitala: kt,
     memberName: b.memberName || '', crew: b.crew || 1,
     locationId: b.locationId || '', locationName: b.locationName || '',
-    checkedOutAt: b.checkedOutAt || b.timeOut || ts.slice(11, 16),
+    checkedOutAt: b.checkedOutAt || b.timeOut || nowLocalTime_(),
     expectedReturn: b.expectedReturn || b.returnBy || '',
     checkedInAt: '', wxSnapshot: wxSnap,
     preLaunchChecklist: b.preLaunchChecklist || '', notes: b.notes || '',
@@ -3192,7 +3201,7 @@ function saveGroupCheckout_(b) {
         bft: Math.round(w.bft||0), ws: wsVal2, wg: Math.round(w.wg||0),
         dir: w.dir||w.wDir||'',
         wv: w.wv != null ? parseFloat(parseFloat(w.wv).toFixed(1)) : null,
-        flag: w.flag||'', tc: w.tc != null ? Math.round(w.tc) : null, ts: w.ts||ts.slice(0,16),
+        flag: w.flag||'', tc: w.tc != null ? Math.round(w.tc) : null, ts: w.ts||nowLocalDateTime_(),
       });
     } catch(e) { wxSnap = ''; }
   }
@@ -3210,7 +3219,7 @@ function saveGroupCheckout_(b) {
     crew:            parseInt(b.crew) || (parseInt(b.participants)||0) + staffNames.length,
     locationId:      b.locationId || '',
     locationName:    b.locationName || '',
-    checkedOutAt:    b.checkedOutAt || ts.slice(11,16),
+    checkedOutAt:    b.checkedOutAt || nowLocalTime_(),
     expectedReturn:  b.expectedReturn || '',
     checkedInAt:     '',
     wxSnapshot:      wxSnap,
@@ -3231,7 +3240,7 @@ function saveGroupCheckout_(b) {
 
 function groupCheckIn_(b) {
   if (!b.id) return failJ('id required');
-  const checkedInAt = b.timeIn || now_().slice(11, 16);
+  const checkedInAt = b.timeIn || nowLocalTime_();
   updateRow_('checkouts', 'id', b.id, { status: 'in', checkedInAt });
   cDel_('checkouts');
   return okJ({ updated: true, checkedInAt });
@@ -3254,7 +3263,7 @@ function tryParseArr_(v) {
 
 function checkIn_(b) {
   if (!b.id) return failJ('id required');
-  const checkedInAt = b.timeIn || now_().slice(11, 16);
+  const checkedInAt = b.timeIn || nowLocalTime_();
   const updates = { status: 'in', checkedInAt };
   if (b.afterSailChecklist) updates.afterSailChecklist = b.afterSailChecklist;
   updateRow_('checkouts', 'id', b.id, updates);
@@ -4129,7 +4138,7 @@ function saveTrip_(b) {
   }
   insertRow_('trips', {
     id, kennitala: b.kennitala || '', memberName: b.memberName || '',
-    date: b.date || ts.slice(0, 10), timeOut: b.timeOut || '', timeIn: b.timeIn || '',
+    date: b.date || nowLocalDate_(), timeOut: b.timeOut || '', timeIn: b.timeIn || '',
     hoursDecimal: b.hoursDecimal || 0,
     boatId: b.boatId || '', boatName: b.boatName || '', boatCategory: boatCategory,
     locationId: b.locationId || '', locationName: b.locationName || '',
@@ -5333,10 +5342,9 @@ function resolveFromEmail_(b) {
       sheet.getRange(rowIdx+1, col('alertSilenced')+1).setValue(true);
       if (action === 'checkInAndClose') {
         const L = CLUB_LANG_;
-        const now = now_();
         const note = L === 'IS' ? 'Skráð inn sjálfvirkt í gegnum tölvupóstviðvörun.' : 'Checked in automatically via email alert.';
         sheet.getRange(rowIdx+1, col('status')+1).setValue('in');
-        sheet.getRange(rowIdx+1, col('checkedInAt')+1).setValue(now);
+        sheet.getRange(rowIdx+1, col('checkedInAt')+1).setValue(nowLocalTime_());
         sheet.getRange(rowIdx+1, col('notes')+1).setValue(note);
         cDel_('checkouts');
         const L2 = CLUB_LANG_;
@@ -5520,7 +5528,7 @@ function resolveAlert_(b) {
     sheet.getRange(rowIdx+1, col('alertSilenced')+1).setValue(true);
     if (op === 'checkInAndClose') {
       const L            = CLUB_LANG_;
-      const checkedInAt  = now_().slice(11, 16);
+      const checkedInAt  = nowLocalTime_();
       const note         = L === 'IS' ? 'Skráð inn í gegnum viðvörun á vef.' : 'Checked in via web alert.';
       sheet.getRange(rowIdx+1, col('status')+1).setValue('in');
       sheet.getRange(rowIdx+1, col('checkedInAt')+1).setValue(checkedInAt);

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -325,7 +325,7 @@
 // ════════════════════════════════════════════════════════════════════════════
 const user  = requireAuth(isStaff);
 const L     = getLang();
-const TODAY = new Date().toISOString().slice(0, 10);
+const TODAY = todayISO();
 
 function esc(s) {
   return (s == null ? '' : String(s)).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');

--- a/member/index.html
+++ b/member/index.html
@@ -934,7 +934,7 @@ async function submitLaunch() {
             linkedCheckoutId:_coId,
             boatId:_boatId, boatName:_boatName, boatCategory:_boatCat,
             locationId:_locId, locationName:_locName,
-            date:new Date().toISOString().slice(0,10), timeOut:tout,
+            date:todayISO(), timeOut:tout,
             role:'crew', wxSnapshot:snap,
           }).catch(function(e2){console.warn('crew confirmation:',cn,e2.message);});
         })).catch(function(e3){console.warn('crew confirmations failed:',e3.message);});
@@ -1384,7 +1384,7 @@ async function confirmCheckIn(coId) {
   var tout=sstr(co.checkedOutAt||co.timeOut).slice(0,5);
   var h=(tout&&timeIn)?((new Date('2000-01-01T'+timeIn)-new Date('2000-01-01T'+tout))/3600000):0;
   if(h<0) h+=24;
-  var today=new Date().toISOString().slice(0,10);
+  var today=todayISO();
   var errEl=document.getElementById('landCheckErr');
   var IS=getLang()==='IS';
   var isKeel=(co.boatCategory||'').toLowerCase()==='keelboat';
@@ -1513,7 +1513,7 @@ async function confirmCheckIn(coId) {
 
 // ══ MANUAL TRIP MODAL ════════════════════════════════════════════════════════
 function openManualTripModal() {
-  document.getElementById('rDate').value=new Date().toISOString().slice(0,10);
+  document.getElementById('rDate').value=todayISO();
   document.getElementById('rTimeOut').value=''; document.getElementById('rTimeIn').value='';
   document.getElementById('rNotes').value=''; document.getElementById('manualTripErr').style.display='none';
   openModal('manualTripModal');
@@ -1586,7 +1586,7 @@ function renderVolunteerNotifBadge() {
   // Strip any previous badge before recounting
   btn.querySelectorAll('.notif-badge').forEach(function(b) { b.remove(); });
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayISO();
   const virtualEvents = (typeof expandVolunteerActivityTypes === 'function')
     ? expandVolunteerActivityTypes(_volunteerActTypes || [], today, null)
     : [];

--- a/shared/api.js
+++ b/shared/api.js
@@ -683,8 +683,21 @@ function fmtTime(iso) {
   catch(e) { return ""; }
 }
 
-function fmtTimeNow() { return new Date().toTimeString().slice(0, 5); }
-function fmtDateNow() { return new Date().toISOString().slice(0, 10); }
+// Local-date YYYY-MM-DD (vs. toISOString which is UTC and drifts across
+// midnight for non-UTC timezones). Use this for anything the user perceives
+// as "today" in their own timezone — trip dates, checkout dates, filenames.
+window.toLocalISODate = function(d) {
+  d = d || new Date();
+  return d.getFullYear() + '-'
+       + String(d.getMonth() + 1).padStart(2, '0') + '-'
+       + String(d.getDate()).padStart(2, '0');
+};
+
+function fmtTimeNow() {
+  var d = new Date();
+  return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+}
+function fmtDateNow() { return window.toLocalISODate(); }
 
 // Shared primitives - single source of truth
 window.boolVal = function(v) {
@@ -697,7 +710,7 @@ window.parseJson = function(v, fallback) {
 };
 
 window.todayISO = function() {
-  return new Date().toISOString().slice(0, 10);
+  return window.toLocalISODate();
 };
 
 window.chunk = function(arr, n) {

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -586,7 +586,7 @@ function showStep1(){
 function showManualForm(){
   document.getElementById('logStep1').style.display='none';
   document.getElementById('logStep2').style.display='';
-  document.getElementById('mDate').value=new Date().toISOString().slice(0,10);
+  document.getElementById('mDate').value=todayISO();
   // Populate boats + locations
   const bSel=document.getElementById('mBoat');
   bSel.innerHTML='<option value="">'+s('logbook.selectBoat')+'</option>';
@@ -1628,7 +1628,7 @@ function exportLogbookCsv(){
     var url=URL.createObjectURL(blob);
     var a=document.createElement('a');
     a.href=url;
-    a.download='logbook-'+(user.kennitala||'export')+'-'+new Date().toISOString().slice(0,10)+'.csv';
+    a.download='logbook-'+(user.kennitala||'export')+'-'+todayISO()+'.csv';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/staff/index.html
+++ b/staff/index.html
@@ -975,7 +975,7 @@ async function submitCheckout() {
           linkedCheckoutId: _coId,
           boatId: bid, boatName: boat.name||bid, boatCategory: boat.category||'',
           locationId: lid, locationName: location.name||lid,
-          date: new Date().toISOString().slice(0,10),
+          date: todayISO(),
           timeOut: document.getElementById('coTimeOut').value,
           timeIn: document.getElementById('coReturnBy').value,
           role: 'crew', wxSnapshot: snap,
@@ -1007,7 +1007,7 @@ async function staffCheckIn(id) {
       try {
         await apiPost('saveTrip', {
           kennitala: co.memberKennitala, memberName: co.memberName || '',
-          date: new Date().toISOString().slice(0, 10),
+          date: todayISO(),
           timeOut, timeIn, hoursDecimal,
           boatId: co.boatId, boatName: co.boatName, boatCategory: co.boatCategory || '',
           locationId: co.locationId, locationName: co.locationName,
@@ -1499,7 +1499,7 @@ async function openDlLinkModal(checkoutId) {
   _dlLinkSelectedAct = null;
   // Fetch today's daily log activities
   try {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayISO();
     const res   = await apiGet('getDailyLog', { date: today });
     const log   = res.log || {};
     _dlLinkTodayActs = (typeof log.activities === 'string' ? JSON.parse(log.activities||'[]') : (log.activities||[]));


### PR DESCRIPTION
The prior fix (1b16269) only covered the READ side — sanitizeCell_ now formats Sheets Date cells with Session.getScriptTimeZone(). The WRITE side of the same flows was still slicing now_()/toISOString() (always UTC) for default values that round-trip as local HH:mm / yyyy-MM-dd, and several frontend spots set "today" from toISOString() too, so non-UTC users saw the wrong date near midnight.

Backend (code.gs): add nowLocalDate_/nowLocalTime_/nowLocalDateTime_ script-timezone formatters. Use them for checkedOutAt / checkedInAt / trip date defaults in saveCheckout_, saveGroupCheckout_, checkIn_, groupCheckIn_, saveTrip_, alert-driven auto check-ins (including resolveFromEmail_, which was writing a full UTC ISO into the HH:mm column), wxSnapshot ts, and the reservation/slot access-gate today checks. getActiveCheckouts_ keeps its UTC comparison (createdAt is stored as UTC ISO, so both sides must share a frame).

Frontend (shared/api.js): add toLocalISODate(d), reroute todayISO and fmtDateNow through it, and normalise fmtTimeNow to getHours/getMinutes. Swap the direct "new Date().toISOString().slice(0,10)" defaults in the checkout/trip flows (shared/logbook.js mDate + CSV filename, member crew-confirm + return + manual-trip modal + volunteer today, staff auto-skipper-trip + crew-confirm + dailylog-link, dailylog TODAY) over to todayISO() so they follow the helper.

https://claude.ai/code/session_01YYMymNn7vQWEiaqbzJEN47