### PR TITLE
Restore frame-src for calendar.google.com on member portal

### DIFF
--- a/member/index.html
+++ b/member/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-GB">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-src https://calendar.google.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Ýmir — Member Hub</title>


### PR DESCRIPTION
The member hub embeds one or more Google Calendar iframes (club calendars list, member.js:1315). My earlier CSP tightening in 1346e54 dropped frame-src, falling back to default-src 'self' which blocked the embeds. Restoring frame-src https://calendar.google.com only — not re-adding to any other locked-down portal since none of them embed calendars.

https://claude.ai/code/session_01MiU5pjfVEtZbpf663FcSck