### PR TITLE
Fix estimated return time calculation on member checkout

### DIFF
--- a/member/member.js
+++ b/member/member.js
@@ -470,7 +470,7 @@ function renderLaunchChecklist(boat) {
 function _addToLaunchOut(mins) {
   var base=document.getElementById('launchTimeOut').value||fmtTimeNow();
   var parts=base.split(':').map(Number);
-  var total=parts[0]*60+parts[1]+mins;
+  var total=parts[0]*60+parts[1]+Number(mins);
   document.getElementById('launchReturnBy').value=String(Math.floor(total/60)%24).padStart(2,'0')+':'+String(total%60).padStart(2,'0');
 }
 function adjLaunchCrew(d) {


### PR DESCRIPTION
The +1h/+1.5h/+2h quick-add buttons were producing nonsense times (e.g. 19:00 instead of 11:30) because data-member-arg is passed as a string, and the `parts[1] + mins` expression was silently doing string concatenation ("30" + "60" → "3060") instead of numeric addition. Coerce `mins` to a number before adding.