### PR TITLE
Persist staff weather flag override via dedicated endpoint

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -128,6 +128,8 @@ const STAFF_ACTIONS_ = {
   resolveIncident:             true,
   addIncidentNote:             true,
   getVerificationRequests:     true,
+  saveFlagOverride:            true,   // staff-set weather flag override
+  saveStaffStatus:             true,   // staff on-duty / support-boat toggle
 };
 
 // Actions that mutate a specific member's own data. The caller's kennitala
@@ -1151,6 +1153,8 @@ function route_(action, b, caller) {
     case 'generateLaunamidlar': return generateLaunamidlar_(b);
     case 'getConfig': return getConfig_();
     case 'saveConfig': return saveConfig_(b);
+    case 'saveFlagOverride': return saveFlagOverride_(b);
+    case 'saveStaffStatus': return saveStaffStatus_(b);
     case 'saveCharterCalendars': return saveCharterCalendars_(b);
     case 'saveClubCalendars': return saveClubCalendars_(b);
     case 'saveActivityType': return saveActivityType_(b);
@@ -2574,6 +2578,30 @@ function saveConfig_(b) {
   if (b.allowBreaks !== undefined) { setConfigSheetValue_('allowBreaks', b.allowBreaks ? 'true' : 'false'); saved.allowBreaks = true; }
   cDel_('config');
   return okJ({ saved });
+}
+
+// Staff-accessible override save. saveConfig_ is admin-only, but the flag
+// override is designed for on-duty staff — persist just that field here so
+// the staff page can actually save (otherwise optimistic UI hides a 403 and
+// the override vanishes on the next config refresh).
+function saveFlagOverride_(b) {
+  if (!b.flagOverride || b.flagOverride.active === false) {
+    setConfigSheetValue_('flagOverride', '');
+  } else {
+    setConfigSheetValue_('flagOverride', JSON.stringify(b.flagOverride));
+  }
+  cDel_('config');
+  return okJ({ saved: { flagOverride: true } });
+}
+
+// Same rationale as saveFlagOverride_: the on-duty / support-boat toggle is
+// a staff control, so it needs its own staff-gated endpoint.
+function saveStaffStatus_(b) {
+  if (b.staffStatus !== undefined) {
+    setConfigSheetValue_('staffStatus', JSON.stringify(b.staffStatus));
+  }
+  cDel_('config');
+  return okJ({ saved: { staffStatus: true } });
 }
 
 function getFlagConfig_() {

--- a/shared/api.js
+++ b/shared/api.js
@@ -48,6 +48,7 @@ async function apiPost(action, payload) {
       action === 'saveVolunteerEvent' || action === 'deleteVolunteerEvent' ||
       action === 'volunteerSignup' || action === 'volunteerWithdraw' ||
       action === 'syncVolunteerEvents' ||
+      action === 'saveFlagOverride' || action === 'saveStaffStatus' ||
       action === 'saveRowingPassportDef' || action === 'importRowingPassportCsv') {
     try {
       sessionStorage.removeItem('ymir_getConfig_');

--- a/staff/staff.js
+++ b/staff/staff.js
@@ -1052,7 +1052,7 @@ async function toggleStaffStatus(field) {
   _staffStatus.updatedByName = (typeof user !== 'undefined' && user) ? (user.name || '') : '';
   renderStaffStatusStrip();
   document.getElementById('wxWidget')?._wxRefreshBadges?.();
-  try { await apiPost('saveConfig', { staffStatus: _staffStatus }); }
+  try { await apiPost('saveStaffStatus', { staffStatus: _staffStatus }); }
   catch(e) { showToast('Status saved — sync when online', 'warn'); }
 }
 
@@ -1127,21 +1127,35 @@ async function saveFlagOverride() {
     setByName: (typeof user !== 'undefined' && user) ? (user.name || '') : '',
     expiresAt: new Date(wxNextMidnightUTC()).toISOString(),
   };
+  const prev = _flagOverride;
   _flagOverride = ov;
   wxLoadFlagOverride(ov);
   renderFlagOverrideCard();
   document.getElementById('wxWidget')?._wxRefresh?.();
-  try { await apiPost('saveConfig', { flagOverride: ov }); }
-  catch(e) { showToast(s('staff.flagOverrideSaveFail'), 'warn'); }
+  try { await apiPost('saveFlagOverride', { flagOverride: ov }); }
+  catch(e) {
+    _flagOverride = prev;
+    wxLoadFlagOverride(prev);
+    renderFlagOverrideCard();
+    document.getElementById('wxWidget')?._wxRefresh?.();
+    showToast(s('staff.flagOverrideSaveFail'), 'warn');
+  }
 }
 
 async function clearFlagOverride() {
+  const prev = _flagOverride;
   _flagOverride = null;
   wxLoadFlagOverride(null);
   renderFlagOverrideCard();
   document.getElementById('wxWidget')?._wxRefresh?.();
-  try { await apiPost('saveConfig', { flagOverride: null }); }
-  catch(e) { showToast(s('staff.flagOverrideSaveFail'), 'warn'); }
+  try { await apiPost('saveFlagOverride', { flagOverride: null }); }
+  catch(e) {
+    _flagOverride = prev;
+    wxLoadFlagOverride(prev);
+    renderFlagOverrideCard();
+    document.getElementById('wxWidget')?._wxRefresh?.();
+    showToast(s('staff.flagOverrideSaveFail'), 'warn');
+  }
 }
 
 // ══ GUEST SUPPORT ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
saveConfig is admin-only, so when a non-admin staff member saved an override the backend returned 403; the optimistic UI hid the failure behind a "saved — sync when online" toast and the override vanished on the next config refresh (hard refresh or page revisit).

Split the flag override and on-duty toggle out into dedicated saveFlagOverride / saveStaffStatus actions gated by STAFF_ACTIONS_, wire cache invalidation for both in shared/api.js, and roll back the optimistic client state when the override POST actually fails so the UI no longer lies about having saved.

https://claude.ai/code/session_01EkcRBHdtygqY5XsSYevary