### PR TITLE
Lock down admin portal CSP

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,3709 @@
+prefetch({Config:['getConfig'],Members:['getMembers']});
+
+// ── Auth ───────────────────────────────────────────────────────────────────────
+const user = requireAuth(isAdmin);
+
+let members = [], boats = [], locations = [], clItems = [], actTypes = [], volunteerEvents = [];
+let volunteerSignups = [];
+let _allBoats = [], _allLocations = [];
+let editingId = null, importResult = null;
+let certCategories = [];
+const bool = v => v === true || v === 'true' || v === 1 || v === '1' || v === 'TRUE';
+
+// ── Default boat categories (seeded if none in config) ────────────────────────
+const DEFAULT_BOAT_CATS = [
+  { key:'dinghy',        labelEN:'Dinghy',        labelIS:'Skíðbátur',    emoji:'⛵', active:true },
+  { key:'keelboat',      labelEN:'Keelboat',      labelIS:'Kjölbátur',    emoji:'⛵', active:true },
+  { key:'kayak',         labelEN:'Kayak',         labelIS:'Kajak',        emoji:'🛶', active:true },
+  { key:'rowing-shell',  labelEN:'Rowing Shell',  labelIS:'Róðrarbátur',  emoji:'🚣', active:true },
+  { key:'rowboat',       labelEN:'Rowboat',       labelIS:'Árabátur',     emoji:'🚣', active:true },
+  { key:'sup',           labelEN:'SUP',           labelIS:'SUP',          emoji:'🏄', active:true },
+  { key:'wingfoil',      labelEN:'Wingfoil',      labelIS:'Wingfoil',     emoji:'🪁', active:true },
+  { key:'other',         labelEN:'Other',         labelIS:'Annað',        emoji:'🚤', active:true },
+];
+let _allBoatCats = [];   // full list including inactive
+let boatCats     = [];   // active only
+let _bcEditingId = null;
+
+// ── Init ───────────────────────────────────────────────────────────────────────
+window.addEventListener('message', e => {
+  if (e.data && e.data.type === 'payroll-resize') {
+    const frame = document.getElementById('payrollFrame');
+    if (frame) frame.style.height = e.data.height + 'px';
+  }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  buildHeader('admin');
+  injectBoatModalHtml();
+  injectRecurringSlotModal({ showBoat: true, showNote: true,
+    previewFn: 'previewRecurringSlots', saveFn: 'saveRecurringSlots', saveKey: 'slot.create' });
+  injectSingleSlotModal({ showBoatName: true, showNote: true, showBookedInfo: true,
+    saveFn: 'saveCurrentSlot', deleteFn: 'deleteCurrentSlot' });
+  applyStrings();
+  _adminWireStrings();
+  // Enable unsaved-changes guard on all editable admin modals. The guard
+  // snapshots input state when a modal opens and confirms before closing
+  // if any field changed (bypassed when closeModal is called with force=true).
+  [
+    'memberModal', 'boatCatModal', 'boatModal', 'locationModal',
+    'clModal', 'launchCLModal', 'actTypeModal', 'volEventModal',
+    'certCatModal', 'certDefModal', 'recurSlotModal', 'slotModal',
+    'passportSettingsModal', 'passportItemModal', 'passportCategoryModal',
+    'memberCertModal',
+  ].forEach(id => { if (typeof guardUnsavedChanges === 'function') guardUnsavedChanges(id); });
+  loadAll().then(() => {
+    const p = new URLSearchParams(window.location.search);
+    const top = p.get('top') || 'members';
+    showTopTab(top);
+    if (top === 'settings') showTab(p.get('tab') || 'boats');
+  });
+
+  document.getElementById("bOOS").addEventListener("change", e => {
+    document.getElementById("oosReasonField").classList.toggle("hidden", !e.target.checked);
+  });
+
+  // Auto-generate key from EN label in category modal
+  document.getElementById("bcLabelEN").addEventListener("input", e => {
+    if (!_bcEditingId) {
+      document.getElementById("bcKey").value = e.target.value.toLowerCase().trim().replace(/\s+/g, '-');
+    }
+  });
+
+  warmContainer();
+});
+
+async function loadAll() {
+  const statusEl = document.getElementById("membersCard");
+  let cfgRes = {};
+  try {
+    if (statusEl) statusEl.innerHTML = '<div class="spinner"></div>';
+    const [mRes, cfgRes_] = await Promise.all([
+      window._earlyMembers || apiGet("getMembers"),
+      window._earlyConfig || apiGet("getConfig"),
+    ]);
+    members  = mRes.members || [];
+    cfgRes   = cfgRes_;
+  } catch(e) {
+    console.error("loadAll failed:", e);
+    if (statusEl) statusEl.innerHTML = `<div class="empty-state">${s('admin.loadFailed')}: ${e.message}</div>`;
+    return;
+  }
+
+  // Load volunteer signups in the background so the volunteer tab can show
+  // who signed up for each role (with phone if the member opted in).
+  apiPost('getVolunteerSignups', {}).then(res => {
+    volunteerSignups = (res && res.signups) || [];
+    renderVolunteerEvents();
+  }).catch(e => { console.warn('getVolunteerSignups failed:', e.message); });
+
+  // ── Assign data ───────────────────────────────────────────────────────────
+  actTypes        = cfgRes.activityTypes || [];
+  volunteerEvents = cfgRes.volunteerEvents || [];
+  clItems        = [ ...(cfgRes.dailyChecklist?.opening || []),
+                     ...(cfgRes.dailyChecklist?.closing  || []) ];
+  certDefs       = certDefsFromConfig(cfgRes.certDefs || []);
+  certCategories = certCategoriesFromConfig(cfgRes.certCategories || []);
+  _allBoats      = cfgRes.boats      || [];
+  _allLocations  = cfgRes.locations  || [];
+  _allBoatCats   = cfgRes.boatCategories?.length ? cfgRes.boatCategories : JSON.parse(JSON.stringify(DEFAULT_BOAT_CATS));
+  boats          = _allBoats    .filter(b => b.active !== false && b.active !== 'false');
+  locations      = _allLocations.filter(l => l.active !== false && l.active !== 'false');
+  boatCats       = _allBoatCats .filter(c => c.active !== false && c.active !== 'false');
+  registerBoatCats(boatCats);
+
+  try { loadCharterCalendars(cfgRes.charterCalendars || {}); } catch(e) { console.warn("loadCharterCalendars:", e.message); }
+  try { loadClubCalendars(cfgRes.clubCalendars || []); } catch(e) { console.warn("loadClubCalendars:", e.message); }
+  try { loadAlertConfig(cfgRes.overdueAlerts); }   catch(e) { console.warn("loadAlertConfig:", e.message); }
+  try { loadLaunchChecklists(cfgRes.launchChecklists || {}); } catch(e) { console.warn("loadLaunchChecklists:", e.message); }
+  try { loadFlagConfigPanel(cfgRes.flagConfig); }  catch(e) { console.warn("loadFlagConfigPanel:", e.message); }
+
+  renderMembers(); renderBoats(); renderLocations();
+  renderChecklists(); renderActTypes(); renderVolunteerEvents();
+  renderCertDefs(); renderCertCategories();
+  populateCategorySelects();
+}
+
+function _adminWireStrings() {
+  const search = document.getElementById('memberSearch');
+  if (search) search.placeholder = s('admin.searchMembers');
+  const bOwnerSearch = document.getElementById('bOwnerSearch');
+  if (bOwnerSearch) bOwnerSearch.placeholder = s('admin.searchMember');
+  const mInitials = document.getElementById('mInitials');
+  if (mInitials) mInitials.placeholder = s('admin.initialsPlaceholder');
+}
+
+// ── Collapsible sections ───────────────────────────────────────────────────────
+function toggleSection(head) {
+  const body   = head.nextElementSibling;
+  const toggle = head.querySelector(".col-toggle");
+  const isOpen = !body.classList.contains("hidden");
+  body.classList.toggle("hidden",  isOpen);
+  head.classList.toggle("open",   !isOpen);
+  toggle.classList.toggle("open", !isOpen);
+}
+
+// ── Top-level tab switching ────────────────────────────────────────────────────
+function showTopTab(top) {
+  document.querySelectorAll('#topTabBar .tab-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.top === top);
+  });
+  document.getElementById('top-members').classList.toggle('hidden', top !== 'members');
+  document.getElementById('top-settings').classList.toggle('hidden', top !== 'settings');
+  document.getElementById('top-payroll').classList.toggle('hidden', top !== 'payroll');
+  if (top === 'settings') {
+    const active = document.querySelector('#settingsTabBar .tab-btn.active');
+    showTab(active ? active.dataset.tab : 'boats');
+  }
+  if (top === 'payroll') {
+    const frame = document.getElementById('payrollFrame');
+    if (frame.src === 'about:blank' || !frame.src.includes('payroll/')) {
+      frame.src = 'payroll/?embed=1';
+    }
+  }
+  const url = new URL(window.location.href);
+  url.searchParams.set('top', top);
+  if (top !== 'settings') url.searchParams.delete('tab');
+  history.replaceState(null, '', url);
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+// ── Settings sub-tab switching ─────────────────────────────────────────────────
+function showTab(tab) {
+  document.querySelectorAll('#top-settings > [id^="tab-"]').forEach(el => el.classList.add('hidden'));
+  document.querySelectorAll('#settingsTabBar .tab-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.tab === tab);
+  });
+  const sel = document.getElementById('settingsTabSelect');
+  if (sel) sel.value = tab;
+  const el = document.getElementById('tab-' + tab);
+  if (el) el.classList.remove('hidden');
+
+  if (tab === 'certs') renderCertDefs();
+  if (tab === 'slotCal') initSlotCalendar();
+  if (tab === 'volunteers') renderVolunteerEvents();
+  if (tab === 'passport') renderPassportAdmin();
+
+  const url = new URL(window.location.href);
+  url.searchParams.set('tab', tab);
+  history.replaceState(null, '', url);
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+// ── Member sub-navigation ──────────────────────────────────────────────────────
+function showMemberSub(sub) {
+  document.getElementById('memberSubList').classList.toggle('hidden', sub === 'import');
+  document.getElementById('memberSubImport').classList.toggle('hidden', sub !== 'import');
+}
+
+// ── Generic entity save ────────────────────────────────────────────────────────
+async function saveEntity({ apiAction, getArray, setArray, payload, modalId, renderFn, btn }) {
+  if (btn) btn.disabled = true;
+  try {
+    const res = await apiPost(apiAction, payload);
+    const arr = getArray();
+    if (!payload.id && res.id) {
+      setArray([...arr, { ...payload, id: res.id }]);
+    } else {
+      setArray(arr.map(x => x.id === payload.id ? { ...x, ...payload } : x));
+      if (!arr.find(x => x.id === payload.id)) setArray([...arr, payload]);
+    }
+    if (modalId) closeModal(modalId, true);
+    if (renderFn) renderFn();
+    toast(s("toast.saved"));
+  } catch(e) {
+    toast(s("toast.saveFailed") + ": " + e.message, "err");
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+// ── Populate selects driven by boatCats ───────────────────────────────────────
+function populateCategorySelects() {
+  const L      = getLang();
+  const locale = L === 'IS' ? 'is' : 'en';
+  const sorted = boatCats.slice().sort((a, b) => {
+    const la = (L === 'IS' && a.labelIS ? a.labelIS : a.labelEN) || '';
+    const lb = (L === 'IS' && b.labelIS ? b.labelIS : b.labelEN) || '';
+    return la.localeCompare(lb, locale, { sensitivity: 'base' });
+  });
+  const opts = sorted.map(c =>
+    `<option value="${esc(c.key)}">${esc(c.emoji || '')} ${esc(L === 'IS' && c.labelIS ? c.labelIS : c.labelEN)}</option>`
+  ).join('');
+
+  // Boat modal category select
+  const bCat = document.getElementById("bCategory");
+  if (bCat) bCat.innerHTML = opts;
+
+  // Launch CL category filter
+  const lcFilter = document.getElementById("launchCLCatFilter");
+  if (lcFilter) {
+    const prev = lcFilter.value;
+    lcFilter.innerHTML = opts;
+    if (boatCats.find(c => c.key === prev)) lcFilter.value = prev;
+  }
+
+  // Launch CL modal category select
+  const lcCat = document.getElementById("lcCat");
+  if (lcCat) lcCat.innerHTML = opts;
+}
+
+// ══ MEMBERS ══════════════════════════════════════════════════════════════════
+
+function filterMembers() {
+  const q = document.getElementById("memberSearch").value.toLowerCase();
+  const active = members.filter(m => bool(m.active) &&
+    (String(m.name||"").toLowerCase().includes(q) || String(m.kennitala||"").includes(q)));
+  renderMemberList(active);
+}
+
+function renderMembers() {
+  const active = members.filter(m => bool(m.active));
+  document.getElementById("memberCountLabel").textContent = `(${active.length})`;
+  renderMemberList(active);
+}
+
+var _memberListData = [];
+var _memberDupNames = null;
+var _memberRendered = 0;
+var _memberObserver = null;
+var _MEMBER_BATCH = 50;
+
+function renderMemberList(list) {
+  const card = document.getElementById("membersCard");
+  if (!list.length) { card.innerHTML = `<div class="empty-state">${s('admin.noMembers')}</div>`; return; }
+  _memberListData = list;
+  _memberDupNames = duplicateMemberNames(list);
+  _memberRendered = 0;
+  card.innerHTML = '';
+  _renderMemberBatch(card);
+  _setupMemberScrollObserver(card);
+}
+
+function _renderMemberBatch(card) {
+  var end = Math.min(_memberRendered + _MEMBER_BATCH, _memberListData.length);
+  var frag = document.createDocumentFragment();
+  for (var i = _memberRendered; i < end; i++) {
+    var m = _memberListData[i];
+    var row = document.createElement('div');
+    row.className = 'member-row';
+    row.innerHTML =
+      `<span class="member-name">${esc((_memberDupNames && _memberDupNames.has(m.name) && m.birthYear) ? (m.name + ' (' + m.birthYear + ')') : (m.name || "—"))}</span>` +
+      `<span class="member-kt">${esc(m.kennitala || "")}</span>` +
+      `<button class="row-edit" data-admin-click="openMemberModal" data-admin-arg="${m.id}">Edit</button>` +
+      `<button class="row-edit" data-admin-click="openMemberCertModal" data-admin-arg="${m.id}" style="font-size:10px">${s('admin.manageCreds')}</button>`;
+    frag.appendChild(row);
+  }
+  var oldSentinel = card.querySelector('.member-scroll-sentinel');
+  if (oldSentinel) oldSentinel.remove();
+  card.appendChild(frag);
+  _memberRendered = end;
+  if (_memberRendered < _memberListData.length) {
+    var sentinel = document.createElement('div');
+    sentinel.className = 'member-scroll-sentinel';
+    sentinel.style.height = '1px';
+    card.appendChild(sentinel);
+  }
+}
+
+function _setupMemberScrollObserver(card) {
+  if (_memberObserver) _memberObserver.disconnect();
+  if (!('IntersectionObserver' in window)) return;
+  _memberObserver = new IntersectionObserver(function(entries) {
+    if (entries[0].isIntersecting && _memberRendered < _memberListData.length) {
+      _renderMemberBatch(card);
+    }
+  }, { rootMargin: '200px' });
+  var sentinel = card.querySelector('.member-scroll-sentinel');
+  if (sentinel) _memberObserver.observe(sentinel);
+}
+
+function openMemberModal(id) {
+  editingId = id || null;
+  const m   = id ? members.find(x => x.id === id) : null;
+  document.getElementById("memberModalTitle").textContent = m ? s('admin.memberModal.edit') : s('admin.memberModal.add');
+  document.getElementById("mName").value           = m ? (m.name         || "") : "";
+  document.getElementById("mKennitala").value      = m ? (m.kennitala    || "") : "";
+  document.getElementById("mEmail").value          = m ? (m.email        || "") : "";
+  document.getElementById("mPhone").value          = m ? (m.phone        || "") : "";
+  document.getElementById("mInitials").value       = m ? (m.initials     || "") : "";
+  document.getElementById("mDob").value            = m ? (m.dob          || "") : "";
+  document.getElementById("mRole").value           = m ? (m.role         || "member") : "member";
+  document.getElementById("mGuardianName").value   = m ? (m.guardianName  || "") : "";
+  document.getElementById("mGuardianKt").value     = m ? (m.guardianKt   || "") : "";
+  document.getElementById("mGuardianPhone").value  = m ? (m.guardianPhone || "") : "";
+  document.getElementById("mActive").checked       = m ? bool(m.active)  : true;
+  document.getElementById("mDeleteBtn").classList.toggle("hidden", !m);
+  // Show a compact password status + reset button for existing members.
+  var pwBox = document.getElementById("mPwBox");
+  if (m) {
+    pwBox.classList.remove("hidden");
+    var status = document.getElementById("mPwStatus");
+    if (m.hasPassword) {
+      status.textContent = s('admin.hasCustomPassword');
+      status.style.color = 'var(--muted)';
+    } else {
+      status.textContent = s('admin.usingDefaultPassword');
+      status.style.color = 'var(--brass)';
+    }
+    document.getElementById("mResetPwBtn").disabled = !m.hasPassword;
+  } else {
+    pwBox.classList.add("hidden");
+  }
+  openModal("memberModal");
+}
+
+async function resetMemberPassword() {
+  if (!editingId) return;
+  var m = members.find(function(x) { return x.id === editingId; });
+  if (!m) return;
+  var name = m.name || m.kennitala;
+  if (!(await ymConfirm(s('admin.resetPasswordConfirm').replace('{name}', name)))) return;
+  var btn = document.getElementById('mResetPwBtn');
+  btn.disabled = true;
+  try {
+    var res = await apiPost('adminResetMemberPassword', { kennitala: m.kennitala });
+    m.hasPassword = false;
+    var status = document.getElementById('mPwStatus');
+    status.textContent = s('admin.usingDefaultPassword');
+    status.style.color = 'var(--brass)';
+    var n = (res && typeof res.sessionsRevoked === 'number') ? res.sessionsRevoked : 0;
+    toast(s('admin.resetPasswordDone').replace('{n}', n), 'ok');
+    if (res && res.tempPassword) {
+      showTempPasswordDialog([{ name: name, kennitala: m.kennitala, tempPassword: res.tempPassword }]);
+    }
+  } catch (e) {
+    toast(s('toast.error') + ': ' + e.message, 'err');
+    btn.disabled = false;
+  }
+}
+
+// Show a modal listing one or more admin-issued temp passwords with copy
+// buttons. Called after saveMember/adminResetMemberPassword/importMembers
+// whenever the backend returns plaintext temp credentials. The modal must
+// stay open long enough for the admin to record the value — the server
+// never retains it.
+function showTempPasswordDialog(items) {
+  if (!items || !items.length) return;
+  var overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.style.zIndex = '300';
+  var box = document.createElement('div');
+  box.className = 'modal';
+  box.style.maxWidth = '480px';
+  var heading = document.createElement('h3');
+  heading.style.margin = '0 0 8px';
+  heading.textContent = items.length === 1 ? s('admin.tempPasswordTitle') : s('admin.tempPasswordTitlePlural');
+  var warn = document.createElement('p');
+  warn.style.cssText = 'color:var(--muted);margin:0 0 14px;font-size:13px';
+  warn.textContent = s('admin.tempPasswordWarning');
+  box.appendChild(heading);
+  box.appendChild(warn);
+  items.forEach(function(it) {
+    var row = document.createElement('div');
+    row.style.cssText = 'margin-bottom:10px;padding:8px;border:1px solid var(--border);border-radius:6px';
+    var label = document.createElement('div');
+    label.style.cssText = 'font-size:12px;color:var(--muted)';
+    label.textContent = (it.name || '') + (it.kennitala ? ' · ' + it.kennitala : '');
+    var pwRow = document.createElement('div');
+    pwRow.style.cssText = 'display:flex;gap:8px;align-items:center;margin-top:4px';
+    var code = document.createElement('code');
+    code.style.cssText = 'flex:1;font-size:16px;font-family:monospace;padding:4px 8px;background:var(--faint);border-radius:4px;user-select:all';
+    code.textContent = it.tempPassword;
+    var btn = document.createElement('button');
+    btn.className = 'btn btn-ghost';
+    btn.textContent = s('admin.tempPasswordCopy');
+    btn.onclick = function() {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(it.tempPassword).then(function() {
+          toast(s('admin.tempPasswordCopied'), 'ok');
+        });
+      }
+    };
+    pwRow.appendChild(code);
+    pwRow.appendChild(btn);
+    row.appendChild(label);
+    row.appendChild(pwRow);
+    box.appendChild(row);
+  });
+  var btnRow = document.createElement('div');
+  btnRow.className = 'ym-dialog-btns';
+  btnRow.style.marginTop = '14px';
+  var closeBtn = document.createElement('button');
+  closeBtn.className = 'btn btn-primary';
+  closeBtn.textContent = s('btn.close');
+  closeBtn.onclick = function() { overlay.remove(); };
+  btnRow.appendChild(closeBtn);
+  box.appendChild(btnRow);
+  overlay.appendChild(box);
+  overlay.addEventListener('click', function(e) { if (e.target === overlay) overlay.remove(); });
+  document.body.appendChild(overlay);
+}
+
+async function saveMember() {
+  const name      = document.getElementById("mName").value.trim();
+  const kennitala = document.getElementById("mKennitala").value.trim();
+  if (!name || !kennitala) { toast(s("admin.nameKtRequired"), "err"); return; }
+
+  const id      = editingId || ("mbr_" + Date.now().toString(36));
+  const payload = {
+    id, name, kennitala,
+    email:          document.getElementById("mEmail").value.trim(),
+    phone:          document.getElementById("mPhone").value.trim(),
+    initials:       document.getElementById("mInitials").value.trim().toUpperCase(),
+    dob:            document.getElementById("mDob").value,
+    role:           document.getElementById("mRole").value,
+    guardianName:   document.getElementById("mGuardianName").value.trim(),
+    guardianKt:     document.getElementById("mGuardianKt").value.trim(),
+    guardianPhone:  document.getElementById("mGuardianPhone").value.trim(),
+    active:         document.getElementById("mActive").checked,
+  };
+
+  try {
+    const res = await apiPost("saveMember", payload);
+    const idx = members.findIndex(x => x.id === id);
+    if (idx >= 0) members[idx] = { ...members[idx], ...payload };
+    else          members.push(payload);
+    closeModal("memberModal", true);
+    renderMembers();
+    toast(s("toast.saved"));
+    const temps = [];
+    if (res && res.tempPassword) temps.push({ name: name, kennitala: kennitala, tempPassword: res.tempPassword });
+    if (res && res.guardianTempPassword) temps.push(res.guardianTempPassword);
+    if (temps.length) showTempPasswordDialog(temps);
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+async function deactivateMember(id) {
+  if (!await ymConfirm(s("admin.confirmDeactivateMember"))) return;
+  try {
+    await apiPost("deleteMember", { id });
+    members = members.filter(m => m.id !== id);
+    renderMembers();
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+async function deleteMember() { await deactivateMember(editingId); closeModal("memberModal", true); }
+
+// ══ BOAT CATEGORIES ══════════════════════════════════════════════════════════
+
+function renderBoatCats() {
+  const card   = document.getElementById("boatCatsCard");
+  const locale = getLang() === 'IS' ? 'is' : 'en';
+  const active = _allBoatCats
+    .filter(c => c.active !== false && c.active !== 'false')
+    .sort((a, b) => {
+      const la = (getLang() === 'IS' && a.labelIS ? a.labelIS : a.labelEN) || '';
+      const lb = (getLang() === 'IS' && b.labelIS ? b.labelIS : b.labelEN) || '';
+      return la.localeCompare(lb, locale, { sensitivity: 'base' });
+    });
+  if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noCategories')}</div>`; return; }
+   card.innerHTML = active.map(c => `
+    <div class="list-row">
+      <span style="font-size:18px;width:28px;flex-shrink:0">${esc(c.emoji || '⛵')}</span>
+      <span class="list-name">
+        <strong>${esc(c.labelEN)}</strong>
+        ${c.labelIS ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(c.labelIS)}</span>` : ''}
+        <span style="color:var(--border);font-size:10px;margin-left:8px">${esc(c.key)}</span>
+      </span>
+      <button class="row-edit" data-admin-click="openBoatCatModal" data-admin-arg="${c.key}">Edit</button>
+    </div>`).join("");
+}
+
+function openBoatCatModal(key) {
+  _bcEditingId = key || null;
+  const c = key ? _allBoatCats.find(x => x.key === key) : null;
+  document.getElementById("boatCatModalTitle").textContent = c ? s('admin.boatCatModal.edit') : s('admin.boatCatModal.add');
+  document.getElementById("bcLabelEN").value   = c ? (c.labelEN || "") : "";
+  document.getElementById("bcLabelIS").value   = c ? (c.labelIS || "") : "";
+  document.getElementById("bcEmoji").value     = c ? (c.emoji   || "") : "";
+  document.getElementById("bcKey").value       = c ? c.key : "";
+  document.getElementById("bcKey").readOnly    = !!c;  // key immutable after creation
+  document.getElementById("bcActive").checked  = c ? bool(c.active) : true;
+  document.getElementById("bcDeleteBtn").classList.toggle("hidden", !c);
+  openModal("boatCatModal");
+}
+
+async function saveBoatCat() {
+  const labelEN = document.getElementById("bcLabelEN").value.trim();
+  const key     = document.getElementById("bcKey").value.trim().toLowerCase().replace(/\s+/g,'-');
+  if (!labelEN || !key) { toast(s("admin.nameKeyRequired"), "err"); return; }
+
+  const payload = {
+    key,
+    labelEN,
+    labelIS:  document.getElementById("bcLabelIS").value.trim(),
+    emoji:    document.getElementById("bcEmoji").value.trim(),
+    active:   document.getElementById("bcActive").checked,
+  };
+
+  const idx = _allBoatCats.findIndex(x => x.key === key);
+  if (idx >= 0) _allBoatCats[idx] = { ..._allBoatCats[idx], ...payload };
+  else          _allBoatCats.push(payload);
+
+  try {
+    await apiPost("saveConfig", { boatCategories: _allBoatCats });
+    boatCats = _allBoatCats.filter(c => c.active !== false && c.active !== 'false');
+    registerBoatCats(boatCats);
+    closeModal("boatCatModal", true);
+    renderBoatCats();
+    renderBoats();
+    populateCategorySelects();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+async function deleteBoatCat() {
+  const key = _bcEditingId;
+  if (!key || !await ymConfirm(s("admin.confirmRemoveBoatCat"))) return;
+  _allBoatCats = _allBoatCats.map(c => c.key === key ? { ...c, active: false } : c);
+  try {
+    await apiPost("saveConfig", { boatCategories: _allBoatCats });
+    boatCats = _allBoatCats.filter(c => c.active !== false && c.active !== 'false');
+    registerBoatCats(boatCats);
+    closeModal("boatCatModal", true);
+    renderBoatCats();
+    renderBoats();
+    populateCategorySelects();
+    toast(s("toast.deleted"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// ══ BOATS ═════════════════════════════════════════════════════════════════════
+
+function renderBoats() {
+  const el     = document.getElementById("boatSections");
+  const active = boats.filter(b => bool(b.active));
+  if (!active.length) { el.innerHTML = `<div class="empty-state">${s('admin.noBoats')}</div>`; return; }
+
+  const groups = {};
+  boatCats.forEach(c => { groups[c.key] = []; });
+  groups['other'] = groups['other'] || [];
+  active.forEach(b => {
+    const k = (b.category || 'other').toLowerCase();
+    if (groups[k]) groups[k].push(b); else groups['other'].push(b);
+  });
+
+  const L      = getLang();
+  const locale = L === 'IS' ? 'is' : 'en';
+  const sortedCats = boatCats.slice().sort((a, b) => {
+    const la = (L === 'IS' && a.labelIS ? a.labelIS : a.labelEN) || '';
+    const lb = (L === 'IS' && b.labelIS ? b.labelIS : b.labelEN) || '';
+    return la.localeCompare(lb, locale, { sensitivity: 'base' });
+  });
+  el.innerHTML = sortedCats
+    .map(cat => {
+      const label = (L === 'IS' && cat.labelIS) ? cat.labelIS : cat.labelEN;
+      const cards = (groups[cat.key] || []).map(b => `
+        <div class="boat-card${bool(b.oos) ? " oos" : ""}">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:6px;margin-bottom:4px">
+            <div class="boat-card-name">${cat.emoji || boatEmoji(cat.key)} ${esc(b.name)}</div>
+            <div style="display:flex;gap:4px;flex-shrink:0">
+              ${b.accessMode === 'controlled' ? `<span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass-fg)">${esc(s('fleet.badgeControlled'))}</span>` : ""}
+              ${bool(b.oos) ? `<span class="oos-badge">OOS</span>` : ""}
+              ${boatCatBadge(cat.key)}
+            </div>
+          </div>
+          ${b.oosReason ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${esc(b.oosReason)}</div>` : ""}
+          ${(b.registrationNo || b.typeModel) ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
+          <div class="boat-card-actions">
+            <button class="row-edit" style="flex:1" data-admin-click="openBoatModal" data-admin-arg="${b.id}">Edit</button>
+            <button class="row-edit" data-admin-click="showBoatQR" data-admin-arg="${b.id}" title="Show QR code">🔳</button>
+            <button class="row-del"  data-admin-click="deleteBoat" data-admin-arg="${b.id}" title="Delete">×</button>
+          </div>
+        </div>`).join("");
+
+      return `<div class="col-section">
+        <div class="col-head" data-admin-toggle-section>
+          <div class="col-title">${cat.emoji || boatEmoji(cat.key)} ${boatCatBadge(cat.key)}</div>
+          <div style="display:flex;align-items:center;gap:6px" data-admin-nobubble>
+            <button class="row-edit" data-admin-click="openBoatModalForCat" data-admin-arg="${cat.key}">+ Add boat</button>
+            <button class="row-edit" data-admin-click="openBoatCatModal" data-admin-arg="${cat.key}">Edit</button>
+            <span class="col-toggle">▼</span>
+          </div>
+        </div>
+        <div class="col-body hidden">
+          <div class="boat-grid">${cards}</div>
+        </div>
+      </div>`;
+    }).join("");
+}
+  
+function openBoatModalForCat(catKey) {
+  openBoatModal();
+  const sel = document.getElementById('bCategory');
+  if (sel) sel.value = catKey;
+}
+  
+function populateDefaultPortSelect(selectedId) {
+  const sel = document.getElementById("bDefaultPortId");
+  if (!sel) return;
+  const ports = _allLocations.filter(l => l.type === 'port' && (l.active !== false && l.active !== 'false'));
+  sel.innerHTML = `<option value="">${s('admin.optionNone')}</option>` +
+    ports.map(p => `<option value="${esc(p.id)}"${p.id === selectedId ? ' selected' : ''}>${esc(p.name)}</option>`).join('');
+}
+
+function updateBoatModalFields() {
+  const cat = document.getElementById("bCategory").value;
+  const isKeelboat = cat === 'keelboat';
+  const lbl = document.getElementById("bRegNoLabel");
+  const inp = document.getElementById("bRegNo");
+  lbl.setAttribute("data-s", isKeelboat ? "boat.registrationNo" : "boat.sailNo");
+  lbl.textContent = s(isKeelboat ? 'boat.registrationNo' : 'boat.sailNo');
+  inp.placeholder = isKeelboat ? "e.g. ÍS-342" : "e.g. 1234";
+}
+
+function openBoatModal(id) {
+  editingId = id || null;
+  const b   = id ? _allBoats.find(x => x.id === id) : null;
+  document.getElementById("boatModalTitle").textContent = b ? s('admin.boatModal.edit') : s('admin.boatModal.add');
+  populateCategorySelects();  // ensure select is fresh
+  document.getElementById("bName").value      = b ? b.name                     : "";
+  document.getElementById("bCategory").value  = b ? (b.category || boatCats[0]?.key || "dinghy") : (boatCats[0]?.key || "dinghy");
+  document.getElementById("bOOS").checked     = b ? bool(b.oos)                : false;
+  document.getElementById("bOOSReason").value = b ? (b.oosReason || "")       : "";
+  document.getElementById("oosReasonField").classList.toggle("hidden", !b || !bool(b.oos));
+  document.getElementById("bActive").checked  = b ? bool(b.active)            : true;
+  document.getElementById("bDeleteBtn").classList.toggle("hidden", !b);
+  // Keelboat-only fields
+  document.getElementById("bRegNo").value      = b ? (b.registrationNo || "") : "";
+  document.getElementById("bLoa").value        = b ? (b.loa || "")            : "";
+  document.getElementById("bTypeModel").value  = b ? (b.typeModel || "")      : "";
+  populateDefaultPortSelect(b ? (b.defaultPortId || "") : "");
+  // Ownership
+  document.getElementById("bOwnership").value = b && b.ownership === 'private' ? 'private' : 'club';
+  document.getElementById("bOwnerId").value   = b ? (b.ownerId || '') : '';
+  document.getElementById("bOwnerSearch").value = '';
+  document.getElementById("bOwnerName").textContent = b && b.ownerName ? b.ownerName : '';
+  document.getElementById("bOwnerSuggestions").innerHTML = '';
+  // Access mode
+  document.getElementById("bAccessMode").value = b && b.accessMode === 'controlled' ? 'controlled' : 'free';
+  populateGateCertSelect(_currentGateFor(b));
+  _editAllowlist = b && Array.isArray(b.accessAllowlist) ? b.accessAllowlist.slice() : [];
+  renderAllowlistChips();
+  updateAccessFields();
+  // Slot scheduling
+  document.getElementById("bSlotScheduling").checked = b && boolVal(b.slotSchedulingEnabled);
+  document.getElementById("bAvailOutside").checked = b ? (b.availableOutsideSlots === undefined || b.availableOutsideSlots === null || boolVal(b.availableOutsideSlots)) : true;
+  updateSlotFields();
+  // Reservations
+  document.getElementById("bReservationForm").classList.add("hidden");
+  document.getElementById("bResMemberKt").value = '';
+  document.getElementById("bResMemberSearch").value = '';
+  document.getElementById("bResMemberName").textContent = '';
+  document.getElementById("bResStart").value = '';
+  document.getElementById("bResEnd").value = '';
+  document.getElementById("bResNote").value = '';
+  renderReservationList(b);
+  updateOwnershipFields();
+  updateBoatModalFields();
+  applyStrings(document.getElementById("boatModal"));
+  openModal("boatModal");
+}
+
+// ── Ownership helpers ──────────────────────────────────────────────────────────
+function updateOwnershipFields() {
+  const isPrivate = document.getElementById("bOwnership").value === 'private';
+  document.getElementById("bOwnerField").classList.toggle("hidden", !isPrivate);
+}
+
+function searchBoatOwner(q) {
+  const drop = document.getElementById("bOwnerSuggestions");
+  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
+  const ql = q.toLowerCase();
+  const hits = members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
+  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
+  drop.innerHTML = hits.map(m => `<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"
+    data-admin-click="selectBoatOwner" data-admin-arg="${esc(m.kennitala)}" data-admin-arg2="${esc(memberDisplayName(m, members))}">${esc(memberDisplayName(m, members))}</div>`).join('');
+  drop.style.display = 'block';
+}
+
+function selectBoatOwner(kt, name) {
+  document.getElementById("bOwnerId").value = kt;
+  document.getElementById("bOwnerSearch").value = '';
+  document.getElementById("bOwnerName").textContent = name;
+  document.getElementById("bOwnerSuggestions").innerHTML = '';
+  document.getElementById("bOwnerSuggestions").style.display = 'none';
+}
+
+// ── Access control helpers ────────────────────────────────────────────────────
+var _editAllowlist = [];
+
+function updateAccessFields() {
+  var isControlled = document.getElementById("bAccessMode").value === 'controlled';
+  document.getElementById("bAccessControlledSection").classList.toggle("hidden", !isControlled);
+  document.getElementById("bSlotSchedulingSection").classList.toggle("hidden", !isControlled);
+}
+
+function updateSlotFields() {
+  var enabled = document.getElementById("bSlotScheduling").checked;
+  document.getElementById("bSlotOptions").classList.toggle("hidden", !enabled);
+}
+
+// Encode a gate descriptor as a stable option value. Empty fields are omitted
+// and the result is a compact JSON string. Decoded by _decodeGateValue().
+function _encodeGateValue(gate) {
+  if (!gate || !gate.certId) return '';
+  var out = { certId: gate.certId };
+  if (gate.sub) out.sub = gate.sub;
+  if (gate.minRank) out.minRank = Number(gate.minRank);
+  return JSON.stringify(out);
+}
+function _decodeGateValue(v) {
+  if (!v) return null;
+  try { var o = JSON.parse(v); return (o && o.certId) ? o : null; } catch (e) { return null; }
+}
+// Return the stored gate for a boat as a {certId, sub, minRank} object, or
+// null. Uses normalizeAccessGate (from shared/boats.js) so legacy boats with
+// just accessGateCert still resolve to the correct {certId, sub} pair.
+function _currentGateFor(boat) {
+  if (!boat) return null;
+  if (typeof normalizeAccessGate === 'function') {
+    return normalizeAccessGate(boat, certDefs);
+  }
+  // Defensive fallback — should not trigger in practice.
+  if (boat.accessGate && boat.accessGate.certId) return boat.accessGate;
+  return null;
+}
+
+function populateGateCertSelect(currentGate) {
+  var sel = document.getElementById("bGateCert");
+  sel.innerHTML = '<option value="">' + esc(s('boat.gateCertNone')) + '</option>';
+  var selectedVal = _encodeGateValue(currentGate);
+  // Build options: one entry per credential "grade".
+  //   Flat defs (no subcats) → a single def-level entry.
+  //   Defs with subcats → a def-level "(any level)" entry, one exact-match
+  //     entry per subcat, plus a "… or higher" entry for each ranked subcat.
+  var anyLbl   = s('boat.gateCertAny');
+  var orHigher = s('boat.gateCertOrHigher');
+  (certDefs || []).forEach(function(def) {
+    if (!def || !def.id) return;
+    var defName = certDefName(def);
+    var subs    = Array.isArray(def.subcats) ? def.subcats : [];
+    if (!subs.length) {
+      var v0 = _encodeGateValue({ certId: def.id });
+      sel.innerHTML += '<option value="' + esc(v0) + '"' + (v0 === selectedVal ? ' selected' : '') + '>'
+        + esc(defName) + '</option>';
+      return;
+    }
+    // def-level "(any level)" option
+    var vAny = _encodeGateValue({ certId: def.id });
+    sel.innerHTML += '<option value="' + esc(vAny) + '"' + (vAny === selectedVal ? ' selected' : '') + '>'
+      + esc(defName + ' — ' + anyLbl) + '</option>';
+    // exact-match subcat options
+    subs.forEach(function(sc) {
+      if (!sc || !sc.key) return;
+      var vExact = _encodeGateValue({ certId: def.id, sub: sc.key });
+      sel.innerHTML += '<option value="' + esc(vExact) + '"' + (vExact === selectedVal ? ' selected' : '') + '>'
+        + esc(defName + ' — ' + certSubcatLabel(sc)) + '</option>';
+    });
+    // rank-or-higher options (only for subcats with a numeric rank)
+    subs.forEach(function(sc) {
+      if (!sc || !sc.key || !sc.rank) return;
+      var vRank = _encodeGateValue({ certId: def.id, minRank: Number(sc.rank) });
+      sel.innerHTML += '<option value="' + esc(vRank) + '"' + (vRank === selectedVal ? ' selected' : '') + '>'
+        + esc(defName + ' — ' + certSubcatLabel(sc) + ' ' + orHigher) + '</option>';
+    });
+  });
+}
+
+function renderAllowlistChips() {
+  var el = document.getElementById("bAllowlistChips");
+  if (!_editAllowlist.length) { el.innerHTML = ''; return; }
+  el.innerHTML = _editAllowlist.map(function(kt) {
+    var m = members.find(function(x) { return x.kennitala === kt; });
+    var name = m ? memberDisplayName(m, members) : kt;
+    return '<span style="font-size:10px;padding:3px 8px;border-radius:12px;background:var(--surface);border:1px solid var(--border);color:var(--text);display:inline-flex;align-items:center;gap:4px">'
+      + esc(name)
+      + '<span style="cursor:pointer;color:var(--red);font-size:12px" data-admin-click="removeFromAllowlist" data-admin-arg="'+esc(kt)+'">&times;</span>'
+      + '</span>';
+  }).join('');
+}
+
+function searchAllowlistMember(q) {
+  var drop = document.getElementById("bAllowlistSuggestions");
+  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
+  var ql = q.toLowerCase();
+  var hits = members.filter(function(m) { return (m.name||'').toLowerCase().includes(ql) && _editAllowlist.indexOf(m.kennitala) === -1; }).slice(0, 8);
+  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
+  drop.innerHTML = hits.map(function(m) {
+    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
+      + 'data-admin-click="addToAllowlist" data-admin-arg="'+esc(m.kennitala)+'">' + esc(memberDisplayName(m, members)) + '</div>';
+  }).join('');
+  drop.style.display = 'block';
+}
+
+function addToAllowlist(kt) {
+  if (_editAllowlist.indexOf(kt) === -1) _editAllowlist.push(kt);
+  document.getElementById("bAllowlistSearch").value = '';
+  document.getElementById("bAllowlistSuggestions").innerHTML = '';
+  document.getElementById("bAllowlistSuggestions").style.display = 'none';
+  renderAllowlistChips();
+}
+
+function removeFromAllowlist(kt) {
+  _editAllowlist = _editAllowlist.filter(function(k) { return k !== kt; });
+  renderAllowlistChips();
+}
+
+// ── Reservation helpers ───────────────────────────────────────────────────────
+function renderReservationList(boat) {
+  var el = document.getElementById("bReservationList");
+  var actEl = document.getElementById("bReservationActions");
+  if (!boat || !boat.reservations || !boat.reservations.length) {
+    el.innerHTML = '';
+    actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" data-admin-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
+    return;
+  }
+  el.innerHTML = boat.reservations.map(function(r) {
+    return '<div style="font-size:11px;padding:6px 8px;background:var(--surface);border:1px solid var(--border);border-radius:6px;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center">'
+      + '<div><strong>' + esc(r.memberName) + '</strong> · ' + esc(r.startDate) + ' → ' + esc(r.endDate)
+      + (r.note ? ' · <span style="color:var(--muted)">' + esc(r.note) + '</span>' : '') + '</div>'
+      + '<button style="font-size:10px;background:none;border:none;color:var(--red);cursor:pointer" data-admin-click="removeResFromModal" data-admin-arg="'+esc(r.id)+'">&times;</button>'
+      + '</div>';
+  }).join('');
+  actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" data-admin-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
+}
+
+function showResForm() {
+  document.getElementById("bReservationForm").classList.remove("hidden");
+}
+
+function cancelResForm() {
+  document.getElementById("bReservationForm").classList.add("hidden");
+}
+
+function searchResMember(q) {
+  var drop = document.getElementById("bResMemberSuggestions");
+  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
+  var ql = q.toLowerCase();
+  var hits = members.filter(function(m) { return (m.name||'').toLowerCase().includes(ql); }).slice(0, 8);
+  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
+  drop.innerHTML = hits.map(function(m) {
+    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
+      + 'data-admin-click="selectResMember" data-admin-arg="'+esc(m.kennitala)+'" data-admin-arg2="'+esc(memberDisplayName(m, members))+'">' + esc(memberDisplayName(m, members)) + '</div>';
+  }).join('');
+  drop.style.display = 'block';
+}
+
+function selectResMember(kt, name) {
+  document.getElementById("bResMemberKt").value = kt;
+  document.getElementById("bResMemberSearch").value = '';
+  document.getElementById("bResMemberName").textContent = name;
+  document.getElementById("bResMemberSuggestions").innerHTML = '';
+  document.getElementById("bResMemberSuggestions").style.display = 'none';
+}
+
+async function saveResFromModal() {
+  var boatId = editingId;
+  if (!boatId) return;
+  var kt   = document.getElementById("bResMemberKt").value;
+  var name = document.getElementById("bResMemberName").textContent;
+  var start = document.getElementById("bResStart").value;
+  var end   = document.getElementById("bResEnd").value;
+  var note  = document.getElementById("bResNote").value.trim();
+  if (!kt || !name || !start || !end) { toast(s("admin.memberDatesRequired"), "err"); return; }
+  try {
+    var res = await apiPost('saveReservation', { boatId: boatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end, note: note });
+    var b = _allBoats.find(function(x) { return x.id === boatId; });
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
+    // Clear sub-form fields so the boat modal's dirty check doesn't flag
+    // the stale reservation inputs after a successful save.
+    document.getElementById("bResMemberKt").value = '';
+    document.getElementById("bResMemberSearch").value = '';
+    document.getElementById("bResMemberName").textContent = '';
+    document.getElementById("bResStart").value = '';
+    document.getElementById("bResEnd").value = '';
+    document.getElementById("bResNote").value = '';
+    cancelResForm();
+    renderReservationList(b);
+    if (typeof resnapshotModal === 'function') resnapshotModal('boatModal');
+    toast(s('boat.reservationSaved'));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+async function removeResFromModal(resId) {
+  var boatId = editingId;
+  if (!boatId) return;
+  if (!(await ymConfirm(s('boat.removeReservation') + '?'))) return;
+  try {
+    var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
+    var b = _allBoats.find(function(x) { return x.id === boatId; });
+    if (b && res.boat) { b.reservations = res.boat.reservations; }
+    renderReservationList(b);
+    toast(s('boat.reservationRemoved'));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+async function saveBoat() {
+  const name = document.getElementById("bName").value.trim();
+  if (!name) { toast(s("admin.nameRequired"), "err"); return; }
+
+  const id  = editingId || ("boat_" + Date.now().toString(36));
+  const cat = document.getElementById("bCategory").value;
+  const ownershipVal = document.getElementById("bOwnership").value;
+  const accessModeVal = document.getElementById("bAccessMode").value;
+  const payload = {
+    id, name,
+    category:      cat,
+    defaultPortId: document.getElementById("bDefaultPortId").value || "",
+    oos:           document.getElementById("bOOS").checked,
+    oosReason:     document.getElementById("bOOSReason").value.trim(),
+    active:        document.getElementById("bActive").checked,
+    registrationNo: document.getElementById("bRegNo").value.trim(),
+    // all boats
+    typeModel:      document.getElementById("bTypeModel").value.trim(),
+    loa:            parseFloat(document.getElementById("bLoa").value) || '',
+    // ownership
+    ownership:      ownershipVal,
+    ownerId:        ownershipVal === 'private' ? (document.getElementById("bOwnerId").value || '') : '',
+    ownerName:      ownershipVal === 'private' ? (document.getElementById("bOwnerName").textContent || '') : '',
+    // access control — new structured gate, plus legacy mirror for older readers
+    accessMode:     accessModeVal,
+    accessGate:     accessModeVal === 'controlled' ? _decodeGateValue(document.getElementById("bGateCert").value) : null,
+    accessGateCert: accessModeVal === 'controlled' ? (function() {
+      var _g = _decodeGateValue(document.getElementById("bGateCert").value);
+      return _g ? (_g.sub || _g.certId) : '';
+    })() : '',
+    accessAllowlist: accessModeVal === 'controlled' ? _editAllowlist.slice() : [],
+    // slot scheduling
+    slotSchedulingEnabled: accessModeVal === 'controlled' && document.getElementById("bSlotScheduling").checked,
+    availableOutsideSlots: accessModeVal === 'controlled' && document.getElementById("bSlotScheduling").checked ? document.getElementById("bAvailOutside").checked : true,
+  };
+
+  const idx = _allBoats.findIndex(x => x.id === id);
+  if (idx >= 0) {
+    // Preserve reservations (managed via separate endpoints)
+    payload.reservations = _allBoats[idx].reservations || [];
+    _allBoats[idx] = { ..._allBoats[idx], ...payload };
+  } else {
+    payload.reservations = [];
+    _allBoats.push(payload);
+  }
+
+  try {
+    await apiPost("saveConfig", { boats: _allBoats });
+    boats = _allBoats.filter(b => b.active !== false && b.active !== 'false');
+    closeModal("boatModal", true);
+    renderBoats();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+async function deleteBoat(id) {
+  const _id = id || editingId;
+  if (!await ymConfirm(s("admin.confirmDeleteBoat"))) return;
+  _allBoats = _allBoats.map(b => b.id === _id ? { ...b, active: false } : b);
+  try {
+    await apiPost("saveConfig", { boats: _allBoats });
+    boats = _allBoats.filter(b => b.active !== false && b.active !== 'false');
+    renderBoats();
+    closeModal("boatModal", true);
+    toast(s("toast.deleted"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+function showBoatQR(id) {
+  const b = boats.find(x => x.id === id);
+  if (!b) return;
+  const url = `${BASE_URL}/member/?boat=${id}`;
+  document.getElementById("qrBoatName").textContent = b.name;
+  document.getElementById("qrCategory").textContent = b.category || "";
+  document.getElementById("qrUrl").textContent = url;
+  document.getElementById("qrBoatId").textContent = id;
+  document.getElementById("qrImg").src = `https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(url)}`;
+  openModal("qrModal");
+}
+
+function printQR() {
+  const img = document.getElementById("qrImg").src;
+  const name = document.getElementById("qrBoatName").textContent;
+  const w = window.open("", "_blank");
+  w.document.write(`<html><body style="text-align:center;font-family:monospace;padding:20px">
+    <h2>${name}</h2><img src="${img}" style="width:200px"><br>
+    <small>${document.getElementById("qrUrl").textContent}</small>
+    <script>window.print();window.close();<\/script></body></html>`);
+}
+
+// ══ LOCATIONS ════════════════════════════════════════════════════════════════
+
+function renderLocations() {
+  const card   = document.getElementById("locationsCard");
+  const locale = getLang() === 'IS' ? 'is' : 'en';
+  const active = locations
+    .filter(l => bool(l.active))
+    .sort((a, b) => (a.name || '').localeCompare(b.name || '', locale, { sensitivity: 'base' }));
+  if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noLocations')}</div>`; return; }
+  card.innerHTML = active.map(l => `
+    <div class="list-row">
+      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass-fg);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓️ PORT</span>' : ' <span style="font-size:9px;color:var(--ice);border:1px solid var(--ice)44;border-radius:4px;padding:1px 5px;margin-left:4px">⛵ SAILING AREA</span>'}</span>
+      <button class="row-edit" data-admin-click="openLocationModal" data-admin-arg="${l.id}">Edit</button>
+      <button class="row-del"  data-admin-click="deleteLocation" data-admin-arg="${l.id}">×</button>
+    </div>`).join("");
+}
+
+function openLocationModal(id) {
+  editingId = id || null;
+  const l   = id ? _allLocations.find(x => x.id === id) : null;
+  document.getElementById("locationModalTitle").textContent = l ? s('admin.locModal.edit') : s('admin.locModal.add');
+  document.getElementById("lName").value     = l ? l.name              : "";
+  document.getElementById("lType").value     = l ? (l.type || 'location') : 'location';
+  var coords = (l && l.coordinates) ? l.coordinates.split(",") : [null, null];
+  document.getElementById("lLat").value      = coords[0] || "";
+  document.getElementById("lLng").value      = coords[1] || "";
+  document.getElementById("lActive").checked = l ? bool(l.active)      : true;
+  document.getElementById("lDeleteBtn").classList.toggle("hidden", !l);
+  applyStrings(document.getElementById("locationModal"));
+  openModal("locationModal");
+}
+
+async function saveLocation() {
+  const name = document.getElementById("lName").value.trim();
+  if (!name) { toast(s("admin.nameRequired"), "err"); return; }
+
+  const id      = editingId || ("loc_" + Date.now().toString(36));
+  var latVal = document.getElementById("lLat").value.trim();
+  var lngVal = document.getElementById("lLng").value.trim();
+  var coordinates = (latVal && lngVal) ? latVal + "," + lngVal : "";
+  const payload = { id, name, type: document.getElementById("lType").value || 'location', active: document.getElementById("lActive").checked, coordinates: coordinates };
+
+  const idx = _allLocations.findIndex(x => x.id === id);
+  if (idx >= 0) _allLocations[idx] = { ..._allLocations[idx], ...payload };
+  else          _allLocations.push(payload);
+
+  try {
+    await apiPost("saveConfig", { locations: _allLocations });
+    locations = _allLocations.filter(l => l.active !== false && l.active !== 'false');
+    closeModal("locationModal", true);
+    renderLocations();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+async function deleteLocation(id) {
+  const _id = id || editingId;
+  if (!await ymConfirm(s("admin.confirmDeleteLocation"))) return;
+  _allLocations = _allLocations.map(l => l.id === _id ? { ...l, active: false } : l);
+  try {
+    await apiPost("saveConfig", { locations: _allLocations });
+    locations = _allLocations.filter(l => l.active !== false && l.active !== 'false');
+    renderLocations();
+    closeModal("locationModal", true);
+    toast(s("toast.deleted"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// ══ OPENING / CLOSING CHECKLISTS ═════════════════════════════════════════════
+// Items stored in dailyChecklist.opening[] and dailyChecklist.closing[] in config.
+// Phase field on each item is "opening" or "closing".
+
+function renderChecklists() {
+  renderCLPhase("openingCLCard", "opening");
+  renderCLPhase("closingCLCard", "closing");
+}
+
+function renderCLPhase(cardId, phase) {
+  const card  = document.getElementById(cardId);
+  const items = clItems
+    .filter(i => String(i.phase).toLowerCase() === phase && bool(i.active))
+    .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+  if (!items.length) { card.innerHTML = `<div class="empty-state">${s('admin.noItems')}</div>`; return; }
+  const btnId = 'clUpdateOrder_' + phase;
+  card.innerHTML = items.map(i => `
+    <div class="cl-row">
+      <input type="number" class="cl-sort-input" data-cl-id="${i.id}" data-cl-phase="${phase}"
+        value="${i.sortOrder || 99}" min="0" data-admin-show-el="${btnId}">
+      <span style="flex:1;color:var(--text)">${esc(i.textEN || "")}${i.textIS
+        ? `<span style="color:var(--muted);font-size:11px;margin-left:6px">${esc(i.textIS)}</span>` : ""}</span>
+      <button class="row-edit" data-admin-click="openCLModal" data-admin-arg="${i.id}">Edit</button>
+      <button class="row-del"  data-admin-click="deleteCLItem" data-admin-arg="${i.id}">×</button>
+    </div>`).join("") +
+    `<button id="${btnId}" class="btn btn-primary cl-update-order hidden" data-admin-click="updateCLOrder" data-admin-arg="${phase}">Update Order</button>`;
+}
+
+function openCLModal(id) {
+  editingId    = id || null;
+  const item   = id ? clItems.find(x => x.id === id) : null;
+  document.getElementById("clModalTitle").textContent = item ? s('admin.clModal.edit') : s('admin.clModal.add');
+  document.getElementById("clPhase").value    = item ? (item.phase || 'opening') : "opening";
+  document.getElementById("clTextEN").value   = item ? (item.textEN  || "") : "";
+  document.getElementById("clTextIS").value   = item ? (item.textIS  || "") : "";
+  document.getElementById("clSort").value     = item ? (item.sortOrder || 99) : 99;
+  document.getElementById("clActive").checked = item ? bool(item.active) : true;
+  document.getElementById("clDeleteBtn").classList.toggle("hidden", !item);
+  openModal("clModal");
+}
+
+async function saveCLItem() {
+  const textEN = document.getElementById("clTextEN").value.trim();
+  if (!textEN) { toast(s("admin.textENRequired"), "err"); return; }
+  const payload = {
+    id:        editingId,
+    phase:     document.getElementById("clPhase").value,   // "opening" or "closing"
+    textEN,
+    textIS:    document.getElementById("clTextIS").value.trim(),
+    sortOrder: parseInt(document.getElementById("clSort").value) || 99,
+    active:    document.getElementById("clActive").checked,
+  };
+  await saveEntity({
+    apiAction: "saveChecklistItem",
+    getArray:  () => clItems,
+    setArray:  arr => { clItems = arr; },
+    payload, modalId: "clModal",
+    renderFn:  renderChecklists,
+  });
+}
+
+async function deleteCLItem(id) {
+  const _id = id || editingId;
+  if (!await ymConfirm(s("admin.confirmDeleteItem"))) return;
+  try {
+    await apiPost("deleteChecklistItem", { id: _id });
+    clItems = clItems.filter(i => i.id !== _id);
+    renderChecklists();
+    closeModal("clModal", true);
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+async function updateCLOrder(phase) {
+  const inputs = document.querySelectorAll(`input.cl-sort-input[data-cl-phase="${phase}"]`);
+  const updates = [];
+  inputs.forEach(inp => {
+    const id = inp.dataset.clId;
+    const val = parseInt(inp.value) || 99;
+    const item = clItems.find(x => x.id === id);
+    if (item && item.sortOrder !== val) { item.sortOrder = val; updates.push(item); }
+  });
+  if (!updates.length) { document.getElementById('clUpdateOrder_' + phase)?.classList.add('hidden'); return; }
+  try {
+    for (const item of updates) {
+      await apiPost("saveChecklistItem", { id: item.id, phase: item.phase, textEN: item.textEN, textIS: item.textIS || "", sortOrder: item.sortOrder, active: item.active });
+    }
+    renderChecklists();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+// ══ LAUNCH / LANDING CHECKLISTS ══════════════════════════════════════════════
+// Stored in config as: launchChecklists = {
+//   dinghy: { launch:[{id,text,textIS,sort}], landing:[...] }, ...
+// }
+let _launchCLs   = {};
+let _lcEditingId = null;
+
+function loadLaunchChecklists(cfgLaunchChecklists) {
+  _launchCLs = cfgLaunchChecklists || {};
+  populateCategorySelects();   // filter may not be populated yet on first load
+  renderLaunchCLSections();
+}
+
+function renderLaunchCLSections() {
+  const cat     = document.getElementById("launchCLCatFilter")?.value || boatCats[0]?.key || "dinghy";
+  const catData = _launchCLs[cat] || { launch:[], landing:[] };
+  ["launch", "landing"].forEach(phase => {
+    const el    = document.getElementById(phase === "launch" ? "launchCLLaunchList" : "launchCLLandingList");
+    if (!el) return;
+    const items = (catData[phase] || []).slice().sort((a, b) => (a.sort || 99) - (b.sort || 99));
+    if (!items.length) { el.innerHTML = '<div class="empty-state">' + s('admin.noItems') + '</div>'; return; }
+    const btnId = 'lcUpdateOrder_' + cat + '_' + phase;
+    el.innerHTML = items.map(i => `
+      <div class="cl-row">
+        <input type="number" class="cl-sort-input" data-lc-cat="${esc(cat)}" data-lc-phase="${phase}" data-lc-id="${esc(i.id)}"
+          value="${i.sort || 99}" min="0" data-admin-show-el="${btnId}">
+        <span style="flex:1;color:var(--text)">${esc(i.text || "")}${i.textIS
+          ? `<span style="color:var(--muted);font-size:11px;margin-left:6px">${esc(i.textIS)}</span>` : ""}</span>
+        <button class="row-edit" data-admin-click="openLaunchCLModal" data-admin-arg="${esc(cat)}" data-admin-arg2="${phase}" data-admin-arg3="${esc(i.id)}">Edit</button>
+        <button class="row-del"  data-admin-click="deleteLaunchCLItem" data-admin-arg="${esc(cat)}" data-admin-arg2="${phase}" data-admin-arg3="${esc(i.id)}">×</button>
+      </div>`).join("") +
+      `<button id="${btnId}" class="btn btn-primary cl-update-order hidden" data-admin-click="updateLaunchCLOrder" data-admin-arg="${esc(cat)}" data-admin-arg2="${phase}">Update Order</button>`;
+  });
+}
+
+function openLaunchCLModal(cat, phase, id) {
+  _lcEditingId  = id || null;
+  const curCat  = cat   || document.getElementById("launchCLCatFilter")?.value || boatCats[0]?.key || "dinghy";
+  const curPhase = phase || "launch";
+  let item = null;
+  if (id && _launchCLs[curCat]?.[curPhase]) {
+    item = _launchCLs[curCat][curPhase].find(x => x.id === id);
+  }
+  populateCategorySelects();
+  document.getElementById("launchCLModalTitle").textContent = item ? s('admin.lcModal.edit') : s('admin.lcModal.add');
+  document.getElementById("lcCat").value    = curCat;
+  document.getElementById("lcPhase").value  = curPhase;
+  document.getElementById("lcText").value   = item ? (item.text   || "") : "";
+  document.getElementById("lcTextIS").value = item ? (item.textIS || "") : "";
+  document.getElementById("lcSort").value   = item ? (item.sort   || 99) : 99;
+  document.getElementById("lcDeleteBtn").classList.toggle("hidden", !item);
+  openModal("launchCLModal");
+}
+
+async function saveLaunchCLItem() {
+  const cat    = document.getElementById("lcCat").value;
+  const phase  = document.getElementById("lcPhase").value;
+  const text   = document.getElementById("lcText").value.trim();
+  const textIS = document.getElementById("lcTextIS").value.trim();
+  const sort   = parseInt(document.getElementById("lcSort").value) || 99;
+  if (!text) { toast(s("admin.textENRequired"), "err"); return; }
+  if (!_launchCLs[cat])        _launchCLs[cat] = { launch:[], landing:[] };
+  if (!_launchCLs[cat][phase]) _launchCLs[cat][phase] = [];
+
+  const id   = _lcEditingId || ("lc_" + Date.now().toString(36));
+  const list = _launchCLs[cat][phase];
+  const idx  = list.findIndex(x => x.id === id);
+  const item = { id, text, textIS, sort };
+  if (idx >= 0) list[idx] = item; else list.push(item);
+
+  try {
+    await apiPost("saveConfig", { launchChecklists: _launchCLs });
+    closeModal("launchCLModal", true);
+    renderLaunchCLSections();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+async function updateLaunchCLOrder(cat, phase) {
+  const inputs = document.querySelectorAll(`input.cl-sort-input[data-lc-cat="${cat}"][data-lc-phase="${phase}"]`);
+  let changed = false;
+  inputs.forEach(inp => {
+    const id = inp.dataset.lcId;
+    const val = parseInt(inp.value) || 99;
+    const list = _launchCLs[cat]?.[phase] || [];
+    const item = list.find(x => x.id === id);
+    if (item && item.sort !== val) { item.sort = val; changed = true; }
+  });
+  if (!changed) { document.getElementById('lcUpdateOrder_' + cat + '_' + phase)?.classList.add('hidden'); return; }
+  try {
+    await apiPost("saveConfig", { launchChecklists: _launchCLs });
+    renderLaunchCLSections();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+async function deleteLaunchCLItem(cat, phase, id) {
+  // Can be called directly from row button (args supplied) or from modal delete btn
+  if (!cat) {
+    cat   = document.getElementById("lcCat").value;
+    phase = document.getElementById("lcPhase").value;
+    id    = _lcEditingId;
+  }
+  if (!await ymConfirm(s("admin.confirmDeleteItem"))) return;
+  if (_launchCLs[cat]?.[phase]) {
+    _launchCLs[cat][phase] = _launchCLs[cat][phase].filter(x => x.id !== id);
+  }
+  try {
+    await apiPost("saveConfig", { launchChecklists: _launchCLs });
+    closeModal("launchCLModal", true);
+    renderLaunchCLSections();
+    toast(s("toast.deleted"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// ══ ACTIVITY TYPES ════════════════════════════════════════════════════════════
+
+function renderActTypes() {
+  const card   = document.getElementById("actTypesCard");
+  const locale = getLang() === 'IS' ? 'is' : 'en';
+  const active = actTypes
+    .filter(a => bool(a.active))
+    .sort((a, b) => {
+      const la = (getLang() === 'IS' && a.nameIS ? a.nameIS : a.name) || '';
+      const lb = (getLang() === 'IS' && b.nameIS ? b.nameIS : b.name) || '';
+      return la.localeCompare(lb, locale, { sensitivity: 'base' });
+    });
+  if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noActTypes')}</div>`; return; }
+  card.innerHTML = active.map(a => {
+    const subs = Array.isArray(a.subtypes) ? a.subtypes : tryParse_(a.subtypes, []);
+    const roles = Array.isArray(a.roles) ? a.roles : tryParse_(a.roles, []);
+    const isVol = bool(a.volunteer);
+    return `<div class="list-row" style="flex-direction:column;align-items:stretch;gap:2px">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="list-name">${esc(a.name)}${a.nameIS
+          ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(a.nameIS)}</span>` : ""}${isVol
+          ? `<span style="color:var(--brass-fg);font-size:9px;margin-left:8px;letter-spacing:.5px">${s('admin.volunteerType').toUpperCase()}</span>` : ""}</span>
+        <button class="row-edit" data-admin-click="openActTypeModal" data-admin-arg="${a.id}">Edit</button>
+        <button class="row-del"  data-admin-click="deleteActType" data-admin-arg="${a.id}">×</button>
+      </div>
+      ${subs.map(st=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">→ ${esc(st.name)}${st.defaultStart?' · '+esc(st.defaultStart)+(st.defaultEnd?'–'+esc(st.defaultEnd):''):''}</div>`).join('')}
+      ${isVol && roles.length ? roles.map(r=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">⚑ ${esc(r.name||'')}${r.slots?' ('+r.slots+')':''}${r.requiredEndorsement?` <span style="color:var(--brass-fg)">[${esc(certDefName((certDefs||[]).find(d=>d.id===r.requiredEndorsement))||r.requiredEndorsement)}]</span>`:''}</div>`).join('') : ''}
+    </div>`;
+  }).join("");
+}
+
+function openActTypeModal(id) {
+  editingId = id || null;
+  const a   = id ? actTypes.find(x => x.id === id) : null;
+  document.getElementById("actTypeModalTitle").textContent = a ? s('admin.actTypeModal.edit') : s('admin.actTypeModal.add');
+  document.getElementById("atName").value     = a ? a.name            : "";
+  document.getElementById("atNameIS").value   = a ? (a.nameIS || "")  : "";
+  document.getElementById("atActive").checked = a ? bool(a.active)    : true;
+  document.getElementById("atVolunteer").checked = a ? bool(a.volunteer) : false;
+  document.getElementById("atCalendarId").value = a ? (a.calendarId || "") : "";
+  document.getElementById("atCalendarSyncActive").checked = a ? bool(a.calendarSyncActive) : false;
+  document.getElementById("atDeleteBtn").classList.toggle("hidden", !a);
+  window._atSubtypes = a && a.subtypes ? JSON.parse(JSON.stringify(
+    Array.isArray(a.subtypes) ? a.subtypes : tryParse_(a.subtypes, [])
+  )) : [];
+  // Migrate any legacy top-level bulkSchedule onto the first subtype on open
+  var legacyBs = (a && (typeof a.bulkSchedule === 'string' ? tryParse_(a.bulkSchedule, null) : a.bulkSchedule)) || null;
+  if (legacyBs && window._atSubtypes.length && !window._atSubtypes[0].bulkSchedule) {
+    window._atSubtypes[0].bulkSchedule = legacyBs;
+  }
+  // Load volunteer roles
+  window._atRoles = a && a.roles ? JSON.parse(JSON.stringify(
+    Array.isArray(a.roles) ? a.roles : tryParse_(a.roles, [])
+  )) : [];
+  toggleAtVolunteerSection();
+  renderAtRoles();
+  renderAtSubtypes();
+  openModal("actTypeModal");
+}
+
+async function saveActType() {
+  const name = document.getElementById("atName").value.trim();
+  if (!name) { toast(s("admin.nameRequired"), "err"); return; }
+  const isVol = document.getElementById("atVolunteer").checked;
+  const payload = {
+    id: editingId, name,
+    nameIS:   document.getElementById("atNameIS").value.trim(),
+    active:   document.getElementById("atActive").checked,
+    volunteer: isVol,
+    calendarId: document.getElementById("atCalendarId").value.trim(),
+    calendarSyncActive: document.getElementById("atCalendarSyncActive").checked,
+    subtypes: JSON.stringify(window._atSubtypes || []),
+    roles: isVol ? JSON.stringify(window._atRoles || []) : JSON.stringify([]),
+    bulkSchedule: null,
+  };
+  await saveEntity({
+    apiAction: "saveActivityType",
+    getArray:  () => actTypes,
+    setArray:  arr => { actTypes = arr; },
+    payload, modalId: "actTypeModal",
+    renderFn:  renderActTypes,
+  });
+  // Volunteer event materialization is deferred to syncVolunteerEvents.
+  // Trigger it in the background after a successful save so new events
+  // appear on the Volunteer tab without a manual refresh.
+  if (isVol) {
+    _volSyncDone = false;
+    apiPost('syncVolunteerEvents', {}).then(function(res) {
+      if (res && res.added > 0) {
+        apiGet('getConfig', { _fresh: true }).then(function(cfg) {
+          volunteerEvents = cfg.volunteerEvents || [];
+          renderVolunteerEvents();
+        }).catch(function() {});
+      }
+    }).catch(function() {});
+  }
+}
+
+async function deleteActType(id) {
+  const _id = id || editingId;
+  if (!await ymConfirm(s("admin.confirmDeleteActType"))) return;
+  // Count linked volunteer events and signups so we can warn the admin
+  // before cascading through real signup data.
+  var linkedEventIds = (volunteerEvents || [])
+    .filter(function(e) {
+      if (!e) return false;
+      return (e.sourceActivityTypeId && String(e.sourceActivityTypeId) === String(_id))
+          || (e.activityTypeId       && String(e.activityTypeId)       === String(_id));
+    })
+    .map(function(e) { return e.id; });
+  var linkedSignups = (volunteerSignups || [])
+    .filter(function(su) { return su && linkedEventIds.indexOf(su.eventId) !== -1; }).length;
+  if (linkedSignups > 0) {
+    var warn = s("admin.confirmDeleteActTypeCascade")
+      .replace("{n}", linkedEventIds.length)
+      .replace("{m}", linkedSignups);
+    if (!await ymConfirm(warn)) return;
+  }
+  try {
+    const res = await apiPost("deleteActivityType", { id: _id });
+    actTypes = actTypes.filter(a => a.id !== _id);
+    var removedE = (res && res.removedEvents) || 0;
+    var removedS = (res && res.removedSignups) || 0;
+    if (removedE > 0) {
+      // Drop cascaded events + signups from the in-memory arrays so the
+      // volunteer tab reflects the backend state without a full reload.
+      var droppedIds = {};
+      (volunteerEvents || []).forEach(function(e) {
+        if (!e) return;
+        var belongs = (e.sourceActivityTypeId && String(e.sourceActivityTypeId) === String(_id))
+                   || (e.activityTypeId       && String(e.activityTypeId)       === String(_id));
+        if (belongs) droppedIds[e.id] = true;
+      });
+      volunteerEvents = (volunteerEvents || []).filter(function(e) { return !(e && droppedIds[e.id]); });
+      volunteerSignups = (volunteerSignups || []).filter(function(su) { return !(su && droppedIds[su.eventId]); });
+      if (typeof renderVolunteerEvents === 'function') {
+        try { renderVolunteerEvents(); } catch(e) {}
+      }
+      toast(
+        s("admin.actTypeDeletedCascade")
+          .replace("{n}", removedE)
+          .replace("{m}", removedS),
+        "ok"
+      );
+    } else {
+      toast(s("toast.deleted"), "ok");
+    }
+    renderActTypes();
+    closeModal("actTypeModal", true);
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+function tryParse_(v, fallback) { try { return JSON.parse(v); } catch(e) { return fallback; } }
+
+function renderAtSubtypes() {
+  const list = document.getElementById("atSubtypesList");
+  if (!list) return;
+  if (!window._atSubtypes.length) {
+    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin-bottom:6px">' + s('admin.noSubtypes') + '</div>';
+    return;
+  }
+  const dayLabels = [
+    { v:'1', k:'day.mon', d:'Mon' }, { v:'2', k:'day.tue', d:'Tue' },
+    { v:'3', k:'day.wed', d:'Wed' }, { v:'4', k:'day.thu', d:'Thu' },
+    { v:'5', k:'day.fri', d:'Fri' }, { v:'6', k:'day.sat', d:'Sat' },
+    { v:'0', k:'day.sun', d:'Sun' },
+  ];
+  list.innerHTML = window._atSubtypes.map((st, i) => {
+    const bs = st.bulkSchedule || {};
+    const bsDays = Array.isArray(bs.daysOfWeek) ? bs.daysOfWeek.map(String) : [];
+    const daysHtml = dayLabels.map(d =>
+      `<label style="font-size:11px"><input type="checkbox" value="${d.v}" ${bsDays.indexOf(d.v)!==-1?'checked':''}
+        data-admin-toggle-atstbs-day data-admin-idx="${i}" data-admin-dayv="${d.v}"> <span data-s="${d.k}">${d.d}</span></label>`
+    ).join('');
+    return `
+    <div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:6px">
+        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">NAME (EN)</label>
+          <input type="text" value="${esc(st.name||"")}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
+            data-admin-set-at-subtype="name" data-admin-idx="${i}"></div>
+        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">NAME (IS)</label>
+          <input type="text" value="${esc(st.nameIS||"")}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
+            data-admin-set-at-subtype="nameIS" data-admin-idx="${i}"></div>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">
+        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">DEFAULT START</label>
+          <input type="text" value="${esc(st.defaultStart||"")}" placeholder="HH:MM" maxlength="5" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
+            data-admin-time-format-subtype="defaultStart" data-admin-idx="${i}"></div>
+        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">DEFAULT END</label>
+          <input type="text" value="${esc(st.defaultEnd||"")}" placeholder="HH:MM" maxlength="5" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
+            data-admin-time-format-subtype="defaultEnd" data-admin-idx="${i}"></div>
+        <button data-admin-click="_removeAtSubtype" data-admin-arg="${i}" title="Remove" style="background:none;border:none;color:var(--red);font-size:16px;cursor:pointer;padding:0 4px;line-height:1">✕</button>
+      </div>
+      <div style="margin-top:8px;padding-top:8px;border-top:1px dashed var(--border)">
+        <label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:4px" data-s="admin.bulkSchedule">BULK SCHEDULE</label>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:6px">
+          <div><label style="font-size:9px;color:var(--muted)" data-s="slot.fromDate">From date</label>
+            <input type="date" value="${esc(bs.fromDate||'')}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:11px;padding:5px 7px"
+              data-admin-set-at-stbs="fromDate" data-admin-idx="${i}"></div>
+          <div><label style="font-size:9px;color:var(--muted)" data-s="slot.toDate">To date</label>
+            <input type="date" value="${esc(bs.toDate||'')}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:11px;padding:5px 7px"
+              data-admin-set-at-stbs="toDate" data-admin-idx="${i}"></div>
+        </div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap">${daysHtml}</div>
+        ${(st.defaultStart || st.defaultEnd) ? '<div style="font-size:10px;color:var(--muted);margin-top:4px">' + s('admin.bulkUsesDefaultTimes') + ': ' + esc(st.defaultStart || '?') + '–' + esc(st.defaultEnd || '?') + '</div>' : '<div style="font-size:10px;color:var(--muted);margin-top:4px;font-style:italic">' + s('admin.bulkSetDefaultTimes') + '</div>'}
+      </div>
+    </div>`;
+  }).join("");
+}
+
+function ensureAtStBs(i) {
+  if (!window._atSubtypes[i].bulkSchedule) {
+    window._atSubtypes[i].bulkSchedule = { fromDate:'', toDate:'', daysOfWeek:[], startTime:'', endTime:'' };
+  }
+  return window._atSubtypes[i].bulkSchedule;
+}
+
+function toggleAtStBsDay(i, day, checked) {
+  var bs = ensureAtStBs(i);
+  if (!Array.isArray(bs.daysOfWeek)) bs.daysOfWeek = [];
+  var idx = bs.daysOfWeek.indexOf(day);
+  if (checked && idx === -1) bs.daysOfWeek.push(day);
+  else if (!checked && idx !== -1) bs.daysOfWeek.splice(idx, 1);
+}
+
+function addAtSubtypeRow() {
+  if (!window._atSubtypes) window._atSubtypes = [];
+  window._atSubtypes.push({ id: "st-"+Date.now(), name: "", nameIS: "", defaultStart: "", defaultEnd: "" });
+  renderAtSubtypes();
+}
+
+// ── Activity type: volunteer roles ────────────────────────────────────────────
+
+function toggleAtVolunteerSection() {
+  var show = document.getElementById("atVolunteer").checked;
+  document.getElementById("atRolesSection").classList.toggle("hidden", !show);
+}
+
+function renderAtRoles() {
+  var list = document.getElementById("atRolesList");
+  if (!list) return;
+  populateRolePresetPicker("atRolePresetPicker");
+  if (!window._atRoles || !window._atRoles.length) {
+    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin-bottom:6px">' + s('admin.noRoles') + '</div>';
+    return;
+  }
+  var endorsements = (certDefs || []).filter(function(d) { return !!d.clubEndorsement; });
+  var inputStyle = 'width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px';
+  var labelStyle = 'font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px';
+  list.innerHTML = window._atRoles.map(function(r, i) {
+    var endorseOpts = '<option value="">' + s('admin.roleNoRestriction') + '</option>'
+      + endorsements.map(function(e) {
+        return '<option value="' + esc(e.id) + '"' + (r.requiredEndorsement === e.id ? ' selected' : '') + '>' + esc(certDefName(e)) + '</option>';
+      }).join('');
+    return '<div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">'
+      + '<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleName') + '</label>'
+      + '<input type="text" value="' + esc(r.name || '') + '" style="' + inputStyle + '" data-admin-set-at-role="name" data-admin-idx="' + i + '"></div>'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleNameIS') + '</label>'
+      + '<input type="text" value="' + esc(r.nameIS || '') + '" style="' + inputStyle + '" data-admin-set-at-role="nameIS" data-admin-idx="' + i + '"></div>'
+      + '<button data-admin-click="_removeAtRole" data-admin-arg="' + i + '" title="Remove" style="background:none;border:none;color:var(--red);font-size:16px;cursor:pointer;padding:0 4px;line-height:1">✕</button>'
+      + '</div>'
+      + '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:6px">'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescEN') + '</label>'
+      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" data-admin-set-at-role="description" data-admin-idx="' + i + '">' + esc(r.description || '') + '</textarea></div>'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescIS') + '</label>'
+      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" data-admin-set-at-role="descriptionIS" data-admin-idx="' + i + '">' + esc(r.descriptionIS || '') + '</textarea></div>'
+      + '</div>'
+      + '<div style="display:grid;grid-template-columns:80px 1fr;gap:8px;margin-top:6px;align-items:end">'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volSlots') + '</label>'
+      + '<input type="number" min="1" value="' + (r.slots || '') + '" style="' + inputStyle + '" data-admin-set-at-role="slots" data-admin-idx="' + i + '"></div>'
+      + '<div><label style="' + labelStyle + '">' + s('admin.roleEndorsement') + '</label>'
+      + '<select style="' + inputStyle + '" data-admin-set-at-role="requiredEndorsement" data-admin-idx="' + i + '">' + endorseOpts + '</select></div>'
+      + '</div>'
+      + '</div>';
+  }).join('');
+}
+
+function addAtRoleRow() {
+  if (!window._atRoles) window._atRoles = [];
+  window._atRoles.push({ id: "r-" + Date.now(), name: "", nameIS: "", description: "", descriptionIS: "", slots: 1, requiredEndorsement: "" });
+  renderAtRoles();
+}
+
+function addAtRoleFromPreset(presetId) {
+  var preset = (typeof getVolunteerRolePreset === 'function') ? getVolunteerRolePreset(presetId) : null;
+  if (!preset) return;
+  if (!window._atRoles) window._atRoles = [];
+  window._atRoles.push({
+    id: "r-" + Date.now(),
+    name: preset.name || '',
+    nameIS: preset.nameIS || '',
+    description: preset.description || '',
+    descriptionIS: preset.descriptionIS || '',
+    slots: preset.slots || 1,
+    requiredEndorsement: '',
+  });
+  renderAtRoles();
+}
+
+// Populates a <select> element with a list of standard volunteer role presets.
+// First option is a placeholder; the rest come from shared/volunteer-role-presets.js.
+// Safe to call repeatedly — idempotent when called with the same language.
+function populateRolePresetPicker(selectId) {
+  var sel = document.getElementById(selectId);
+  if (!sel) return;
+  if (typeof listVolunteerRolePresets !== 'function') return;
+  var L = getLang();
+  var presets = listVolunteerRolePresets(L);
+  var placeholder = '<option value="">' + s('admin.volRolePickPreset') + '</option>';
+  sel.innerHTML = placeholder + presets.map(function(p) {
+    var label = (L === 'IS' && p.nameIS ? p.nameIS : p.name) || p.name || p.id;
+    return '<option value="' + esc(p.id) + '">' + esc(label) + '</option>';
+  }).join('');
+}
+
+// ══ VOLUNTEER EVENTS ═════════════════════════════════════════════════════════
+
+let _veEditingId = null;
+
+let _volSyncDone = false;
+let _volShowPast = false;
+
+function renderVolunteerEvents() {
+  const card = document.getElementById("volEventsCard");
+  // One-time backfill: ensure any bulk-scheduled events defined on activity
+  // types are materialized into config.volunteer_events. This is a no-op
+  // once events have been materialized. Runs in the background and triggers
+  // a re-render when it finishes.
+  if (!_volSyncDone) {
+    _volSyncDone = true;
+    (async function() {
+      try {
+        const res = await apiPost('syncVolunteerEvents', {});
+        if (res && res.added > 0) {
+          // apiPost invalidates the getConfig cache; re-fetch to pick up
+          // newly materialized events.
+          try {
+            const cfg = await apiGet('getConfig');
+            volunteerEvents = cfg.volunteerEvents || [];
+            renderVolunteerEvents();
+          } catch(e) {}
+        }
+      } catch(e) { /* non-fatal — keep showing what we have */ }
+    })();
+  }
+  const L = getLang();
+  const today = new Date().toISOString().slice(0, 10);
+  // Defense-in-depth: hide materialized events whose source activity type is
+  // missing, inactive, or no longer volunteer-flagged. Manually-created events
+  // (no sourceActivityTypeId) are shown regardless.
+  const activeAtIds = new Set((actTypes || [])
+    .filter(a => bool(a.active) && bool(a.volunteer))
+    .map(a => a.id));
+  const saved = (volunteerEvents || []).filter(e => {
+    if (!e || e.active === false) return false;
+    if (e.sourceActivityTypeId) return activeAtIds.has(e.sourceActivityTypeId);
+    return true;
+  });
+  // Expand virtual events from activity type bulk schedules so they appear
+  // immediately after saving, before the background sync materializes them.
+  // Use 365-day horizon to match the volunteer page.
+  const rangeTo = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const virtual = (typeof expandVolunteerActivityTypes === 'function')
+    ? expandVolunteerActivityTypes(actTypes || [], today, rangeTo)
+    : [];
+  const all = (typeof mergeVolunteerEvents === 'function')
+    ? mergeVolunteerEvents(saved, virtual)
+    : saved.concat(virtual);
+  // Store merged events so openVolEventModal can find virtual events too.
+  window._volMergedEvents = all;
+  const sorted = all.slice().sort((a, b) => (a.date || '').localeCompare(b.date || '')
+    || (a.startTime || '').localeCompare(b.startTime || ''));
+  const upcoming = sorted.filter(e => (e.date || '') >= today);
+  const past     = sorted.filter(e => (e.date || '') <  today);
+  const shown    = _volShowPast ? sorted : upcoming;
+  if (!shown.length) {
+    card.innerHTML = '<div class="empty-state">' + s('admin.noVolEvents') + '</div>'
+      + (past.length ? _volPastToggleHtml(past.length) : '');
+    return;
+  }
+  const rowsHtml = shown.map(ev => _volRowHtml(ev, L)).join('');
+  card.innerHTML = rowsHtml + (past.length ? _volPastToggleHtml(past.length) : '');
+}
+
+function _volPastToggleHtml(count) {
+  const lbl = _volShowPast
+    ? s('admin.volHidePast')
+    : s('admin.volShowPast').replace('{n}', count);
+  return '<div style="text-align:center;padding:10px 0 2px">'
+    + '<button class="btn btn-secondary" style="font-size:10px" data-admin-click="_volTogglePast">' + esc(lbl) + '</button>'
+    + '</div>';
+}
+
+function _volTogglePast() {
+  _volShowPast = !_volShowPast;
+  renderVolunteerEvents();
+}
+
+// Localized "Wed, 15 Apr" / "Wed 15 Apr – Fri 17 Apr" for a volunteer event.
+function _volFormatDayLabel(ev) {
+  const startIso = ev && ev.date ? ev.date : '';
+  if (!startIso) return '';
+  const endIso = (ev && ev.endDate && ev.endDate !== startIso) ? ev.endDate : '';
+  const dows = ['day.sun','day.mon','day.tue','day.wed','day.thu','day.fri','day.sat'];
+  const months = ['month.jan','month.feb','month.mar','month.apr','month.may','month.jun',
+                  'month.jul','month.aug','month.sep','month.oct','month.nov','month.dec'];
+  const a = new Date(startIso + 'T00:00:00');
+  const left = s(dows[a.getDay()]) + ', ' + a.getDate() + ' ' + s(months[a.getMonth()]);
+  if (!endIso) return left;
+  const b = new Date(endIso + 'T00:00:00');
+  const right = s(dows[b.getDay()]) + ' ' + b.getDate() + ' ' + s(months[b.getMonth()]);
+  return left + ' – ' + right;
+}
+
+function _volFormatTimeRange(ev) {
+  const a = (ev && ev.startTime || '').slice(0, 5);
+  const b = (ev && ev.endTime   || '').slice(0, 5);
+  if (a && b) return a + '–' + b;
+  if (a) return a;
+  return '';
+}
+
+// Admin volunteer row — reuses the shared /volunteer/ card renderer so the
+// two views stay visually identical. Adds an Edit button that opens the
+// full volunteer-event modal and a Delete button for destructive removal.
+function _volRowHtml(ev, L) {
+  if (typeof renderVolunteerCard !== 'function') return '';
+  return renderVolunteerCard(ev, {
+    mode: 'admin',
+    lang: L || getLang(),
+    signups: volunteerSignups,
+    members: members,
+    certDefs: certDefs,
+    certDefName: (typeof certDefName === 'function') ? certDefName : function(d) { return d && (d.name || d.id) || ''; },
+    esc: esc,
+    s: s,
+    formatDay: _volFormatDayLabel,
+    formatTime: _volFormatTimeRange,
+    onCardClick:   "openVolEventModal",
+    onEditClick:   "openVolEventModal",
+    onDeleteClick: "deleteVolEvent",
+  });
+}
+
+function openVolEventModal(id) {
+  _veEditingId = id || null;
+  // Search saved events first, then the merged list (which includes virtual events).
+  const ev = id
+    ? (volunteerEvents.find(x => x.id === id) || (window._volMergedEvents || []).find(x => x.id === id))
+    : null;
+  document.getElementById("volEventModalTitle").textContent = ev ? s('admin.volEventModal.edit') : s('admin.volEventModal.add');
+  document.getElementById("veTitle").value = ev ? (ev.title || '') : '';
+  document.getElementById("veTitleIS").value = ev ? (ev.titleIS || '') : '';
+  document.getElementById("veDate").value = ev ? (ev.date || '') : '';
+  document.getElementById("veEndDate").value = ev ? (ev.endDate || '') : '';
+  document.getElementById("veStartTime").value = ev ? (ev.startTime || '') : '';
+  document.getElementById("veEndTime").value = ev ? (ev.endTime || '') : '';
+  // Leader member lookup
+  document.getElementById("veLeaderMemberId").value = ev ? (ev.leaderMemberId || '') : '';
+  document.getElementById("veLeaderPhone").value = ev ? (ev.leaderPhone || '') : '';
+  document.getElementById("veShowPhone").checked = ev ? (ev.showLeaderPhone === true || ev.showLeaderPhone === 'true') : false;
+  // Show leader chip or search
+  var leaderM = ev && ev.leaderMemberId ? members.find(function(m){ return m.id === ev.leaderMemberId || m.kennitala === ev.leaderMemberId; }) : null;
+  if (!leaderM && ev && ev.leaderName) {
+    leaderM = members.find(function(m){ return (m.name||'') === ev.leaderName; });
+  }
+  if (leaderM) {
+    showVolLeaderChip(leaderM);
+  } else {
+    clearVolLeaderChip();
+    document.getElementById("veLeaderSearch").value = ev ? (ev.leaderName || '') : '';
+  }
+  document.getElementById("veNotes").value = ev ? (ev.notes || '') : '';
+  document.getElementById("veNotesIS").value = ev ? (ev.notesIS || '') : '';
+  document.getElementById("veDeleteBtn").classList.toggle("hidden", !ev);
+  // Populate activity type select (only volunteer-flagged types)
+  const sel = document.getElementById("veActType");
+  const L = getLang();
+  sel.innerHTML = '<option value="">' + s('admin.volActTypeNone') + '</option>'
+    + actTypes.filter(a => bool(a.volunteer) && bool(a.active)).map(a => {
+      const label = (L === 'IS' && a.nameIS ? a.nameIS : a.name) || a.name;
+      return '<option value="' + a.id + '"' + (ev && ev.activityTypeId === a.id ? ' selected' : '') + '>' + esc(label) + '</option>';
+    }).join('');
+  // Roles — inherit from activity type for new events, use saved roles for existing
+  if (ev && ev.roles && (Array.isArray(ev.roles) ? ev.roles.length : true)) {
+    window._volRoles = JSON.parse(JSON.stringify(Array.isArray(ev.roles) ? ev.roles : []));
+  } else {
+    window._volRoles = loadRolesFromActType(sel.value);
+  }
+  renderVolRoles();
+  openModal("volEventModal");
+}
+
+async function saveVolEvent() {
+  const title = document.getElementById("veTitle").value.trim();
+  if (!title) { toast(s("admin.nameRequired"), "err"); return; }
+  var memberId = document.getElementById("veLeaderMemberId").value.trim();
+  var leaderM = memberId ? members.find(function(m){ return m.id === memberId || m.kennitala === memberId; }) : null;
+  const payload = {
+    id: _veEditingId,
+    title,
+    titleIS: document.getElementById("veTitleIS").value.trim(),
+    activityTypeId: document.getElementById("veActType").value,
+    date: document.getElementById("veDate").value,
+    endDate: document.getElementById("veEndDate").value,
+    startTime: document.getElementById("veStartTime").value,
+    endTime: document.getElementById("veEndTime").value,
+    leaderMemberId: memberId,
+    leaderName: leaderM ? leaderM.name : document.getElementById("veLeaderSearch").value.trim(),
+    leaderPhone: document.getElementById("veLeaderPhone").value.trim(),
+    showLeaderPhone: document.getElementById("veShowPhone").checked,
+    notes: document.getElementById("veNotes").value.trim(),
+    notesIS: document.getElementById("veNotesIS").value.trim(),
+    roles: JSON.stringify(window._volRoles || []),
+    active: true,
+  };
+  await saveEntity({
+    apiAction: "saveVolunteerEvent",
+    getArray:  () => volunteerEvents,
+    setArray:  arr => { volunteerEvents = arr; },
+    payload, modalId: "volEventModal",
+    renderFn:  renderVolunteerEvents,
+  });
+}
+
+async function deleteVolEvent(id) {
+  const _id = id || _veEditingId;
+  if (!await ymConfirm(s("admin.confirmDeleteVolEvent"))) return;
+  try {
+    await apiPost("deleteVolunteerEvent", { id: _id });
+    volunteerEvents = volunteerEvents.filter(a => a.id !== _id);
+    renderVolunteerEvents();
+    closeModal("volEventModal", true);
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+function renderVolRoles() {
+  const list = document.getElementById("volRolesList");
+  if (!list) return;
+  populateRolePresetPicker("veRolePresetPicker");
+  if (!window._volRoles || !window._volRoles.length) {
+    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin-bottom:6px">' + s('admin.noRoles') + '</div>';
+    return;
+  }
+  var inputStyle = 'width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px';
+  var labelStyle = 'font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px';
+  list.innerHTML = window._volRoles.map(function(r, i) {
+    var endorseLabel = '';
+    if (r.requiredEndorsement) {
+      var eDef = (certDefs || []).find(function(d){ return d.id === r.requiredEndorsement; });
+      endorseLabel = '<div style="font-size:10px;color:var(--brass-fg);margin-top:4px">' + s('admin.roleEndorsement') + ': ' + esc(eDef ? certDefName(eDef) : r.requiredEndorsement) + '</div>';
+    }
+    return '<div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">'
+      + '<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleName') + '</label>'
+      + '<input type="text" value="' + esc(r.name || '') + '" style="' + inputStyle + '" data-admin-set-vol-role="name" data-admin-idx="' + i + '"></div>'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleNameIS') + '</label>'
+      + '<input type="text" value="' + esc(r.nameIS || '') + '" style="' + inputStyle + '" data-admin-set-vol-role="nameIS" data-admin-idx="' + i + '"></div>'
+      + '<button data-admin-click="_removeVolRole" data-admin-arg="' + i + '" title="Remove" style="background:none;border:none;color:var(--red);font-size:16px;cursor:pointer;padding:0 4px;line-height:1">✕</button>'
+      + '</div>'
+      + '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:6px">'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescEN') + '</label>'
+      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" data-admin-set-vol-role="description" data-admin-idx="' + i + '">' + esc(r.description || '') + '</textarea></div>'
+      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescIS') + '</label>'
+      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" data-admin-set-vol-role="descriptionIS" data-admin-idx="' + i + '">' + esc(r.descriptionIS || '') + '</textarea></div>'
+      + '</div>'
+      + '<div style="margin-top:6px"><label style="' + labelStyle + '">' + s('admin.volSlots') + '</label>'
+      + '<input type="number" min="1" value="' + (r.slots || '') + '" style="width:80px;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px" data-admin-set-vol-role="slots" data-admin-idx="' + i + '"></div>'
+      + endorseLabel
+      + '</div>';
+  }).join('');
+}
+
+function addVolRoleRow() {
+  if (!window._volRoles) window._volRoles = [];
+  window._volRoles.push({ id: "r-" + Date.now(), name: "", nameIS: "", description: "", descriptionIS: "", slots: 1, requiredEndorsement: "" });
+  renderVolRoles();
+}
+
+function addVolRoleFromPreset(presetId) {
+  var preset = (typeof getVolunteerRolePreset === 'function') ? getVolunteerRolePreset(presetId) : null;
+  if (!preset) return;
+  if (!window._volRoles) window._volRoles = [];
+  window._volRoles.push({
+    id: "r-" + Date.now(),
+    name: preset.name || '',
+    nameIS: preset.nameIS || '',
+    description: preset.description || '',
+    descriptionIS: preset.descriptionIS || '',
+    slots: preset.slots || 1,
+    requiredEndorsement: '',
+  });
+  renderVolRoles();
+}
+
+// ── Volunteer event: leader member autocomplete ──────────────────────────────
+
+function searchVolLeader(q) {
+  var drop = document.getElementById("veLeaderSuggestions");
+  if (!q || q.length < 2) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
+  var ql = q.toLowerCase();
+  var hits = members.filter(function(m) { return bool(m.active) && (m.name || '').toLowerCase().includes(ql); }).slice(0, 8);
+  if (!hits.length) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
+  drop.innerHTML = hits.map(function(m) {
+    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"'
+      + ' data-admin-click="selectVolLeader" data-admin-arg="'+esc(m.id || m.kennitala)+'">' + esc(memberDisplayName(m, members))
+      + (m.phone ? '<span style="color:var(--muted);margin-left:8px;font-size:10px">' + esc(m.phone) + '</span>' : '') + '</div>';
+  }).join('');
+  drop.style.display = 'block';
+}
+
+function selectVolLeader(id) {
+  var m = members.find(function(x) { return x.id === id || x.kennitala === id; });
+  if (!m) return;
+  document.getElementById("veLeaderMemberId").value = m.id || m.kennitala;
+  document.getElementById("veLeaderPhone").value = m.phone || '';
+  document.getElementById("veLeaderSuggestions").innerHTML = '';
+  document.getElementById("veLeaderSuggestions").style.display = 'none';
+  showVolLeaderChip(m);
+}
+
+function showVolLeaderChip(m) {
+  var chip = document.getElementById("veLeaderChip");
+  var search = document.getElementById("veLeaderSearch");
+  chip.innerHTML = '<span style="font-size:11px;padding:4px 10px;border-radius:12px;background:var(--surface);border:1px solid var(--border);color:var(--text);display:inline-flex;align-items:center;gap:6px">'
+    + esc(memberDisplayName(m, members))
+    + '<span style="cursor:pointer;color:var(--red);font-size:13px" data-admin-click="clearVolLeaderChip">&times;</span></span>';
+  chip.style.display = 'block';
+  search.style.display = 'none';
+}
+
+function clearVolLeaderChip() {
+  document.getElementById("veLeaderChip").style.display = 'none';
+  document.getElementById("veLeaderChip").innerHTML = '';
+  document.getElementById("veLeaderMemberId").value = '';
+  document.getElementById("veLeaderPhone").value = '';
+  var search = document.getElementById("veLeaderSearch");
+  search.value = '';
+  search.style.display = '';
+}
+
+// ── Volunteer event: inherit roles from activity type ────────────────────────
+
+function loadRolesFromActType(atId) {
+  if (!atId) return [];
+  var at = actTypes.find(function(a) { return a.id === atId; });
+  if (!at || !at.roles) return [];
+  var roles = Array.isArray(at.roles) ? at.roles : tryParse_(at.roles, []);
+  return roles.map(function(r) {
+    return {
+      id: "r-" + Date.now() + '-' + Math.random().toString(36).slice(2,6),
+      name: r.name || '',
+      nameIS: r.nameIS || '',
+      description: r.description || '',
+      descriptionIS: r.descriptionIS || '',
+      slots: r.slots || 1,
+      requiredEndorsement: r.requiredEndorsement || '',
+    };
+  });
+}
+
+function onVeActTypeChange() {
+  var atId = document.getElementById("veActType").value;
+  var newRoles = loadRolesFromActType(atId);
+  if (newRoles.length) {
+    window._volRoles = newRoles;
+    renderVolRoles();
+  }
+}
+
+// ══ CERTIFICATIONS ════════════════════════════════════════════════════════════
+// Top-level cert def has `expires` (bool) and `expiryDate` (absolute date).
+// Subcats supercede the parent: the most specific expiry shown/used is the subcat's.
+
+let certDefs     = [];
+let certEditId   = null;
+// Credential modal — uses shared/mcm.js
+window.mcmGetMembers        = function() { return members; };
+window.mcmGetCertDefs       = function() { return certDefs; };
+window.mcmGetCertCategories = function() { return certCategories; };
+
+// ── Credential categories ─────────────────────────────────────────────────────
+let _ccEditingKey = null;
+
+function renderCertCategories() {
+  const el = document.getElementById("certCatsCard");
+  const addWrap = document.getElementById("certCatsAddWrap");
+  if (!el) return;
+  if (!certCategories.length) {
+    el.innerHTML = `<div class="empty-state">${s('admin.noCertCategories')}</div>`;
+  } else {
+    el.innerHTML = certCategories.map((c) => {
+      const key     = certCategoryKey(c);
+      const labelEN = (c && c.labelEN) || key;
+      const labelIS = (c && c.labelIS) || '';
+      const safeKey = String(key).replace(/'/g, "\\'");
+      return `<div class="list-row">
+        <div style="flex:1;font-size:12px">
+          <strong>${esc(labelEN)}</strong>
+          ${labelIS ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(labelIS)}</span>` : ''}
+        </div>
+        <button class="row-edit" data-admin-click="openCertCatModal" data-admin-arg="${safeKey}">Edit</button>
+        <button class="row-del" data-admin-click="removeCertCategory" data-admin-arg="${safeKey}" title="Remove">×</button>
+      </div>`;
+    }).join('');
+  }
+  if (addWrap) addWrap.classList.remove("hidden");
+}
+
+async function addCertCategory() {
+  const inEN = document.getElementById("newCatInputEN");
+  const inIS = document.getElementById("newCatInputIS");
+  const labelEN = inEN.value.trim();
+  const labelIS = inIS ? inIS.value.trim() : '';
+  if (!labelEN) return;
+  // Stable key = labelEN unchanged, to keep legacy member-cert category
+  // references working. Dedupe by key.
+  const key = labelEN;
+  if (certCategories.some(c => certCategoryKey(c) === key)) {
+    toast(s("admin.categoryExists"), "err"); return;
+  }
+  certCategories.push({ key, labelEN, labelIS });
+  inEN.value = "";
+  if (inIS) inIS.value = "";
+  try {
+    await apiPost("saveCertCategories", { categories: certCategories });
+    renderCertCategories();
+    toast(s("admin.categoryAdded"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+function openCertCatModal(key) {
+  _ccEditingKey = key;
+  const cat = certCategoryByKey(certCategories, key) || { key, labelEN: key, labelIS: '' };
+  document.getElementById("certCatModalTitle").textContent = s('admin.certCatModal.edit');
+  document.getElementById("ccLabelEN").value = cat.labelEN || key;
+  document.getElementById("ccLabelIS").value = cat.labelIS || '';
+  document.getElementById("ccKey").value     = cat.key || key;
+  openModal("certCatModal");
+}
+
+async function saveCertCat() {
+  const key     = _ccEditingKey;
+  const labelEN = document.getElementById("ccLabelEN").value.trim();
+  const labelIS = document.getElementById("ccLabelIS").value.trim();
+  if (!key || !labelEN) { toast(s("admin.nameRequired"), "err"); return; }
+  const idx = certCategories.findIndex(c => certCategoryKey(c) === key);
+  if (idx < 0) { toast(s("toast.error"), "err"); return; }
+  // Update labels but keep key stable — member-cert records reference `key`.
+  const existing = certCategories[idx];
+  certCategories[idx] = Object.assign({}, (typeof existing === 'string' ? { key: existing } : existing), {
+    key, labelEN, labelIS,
+  });
+  try {
+    await apiPost("saveCertCategories", { categories: certCategories });
+    closeModal("certCatModal", true);
+    renderCertCategories();
+    renderCertDefs();
+    toast(s("toast.saved"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+async function removeCertCategory(key) {
+  if (!await ymConfirm(s("admin.confirmRemoveCategory"))) return;
+  const next = certCategories.filter(c => certCategoryKey(c) !== key);
+  if (next.length === certCategories.length) return;
+  certCategories = next;
+  try {
+    await apiPost("saveCertCategories", { categories: certCategories });
+    renderCertCategories();
+    toast(s("admin.categoryRemoved"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+function renderCertDefs() {
+  const el = document.getElementById("certDefsCard");
+  if (!el) return;
+  if (!certDefs.length) {
+    el.innerHTML = `<div class="empty-state">${s('admin.noCertDefs')}</div>`;
+    return;
+  }
+  const locale = getLang() === 'IS' ? 'is' : 'en';
+  const sortedCertDefs = certDefs.slice().sort((a, b) =>
+    certDefName(a).localeCompare(certDefName(b), locale, { sensitivity: 'base' })
+  );
+  const certifications = sortedCertDefs.filter(d => !d.clubEndorsement);
+  const endorsements   = sortedCertDefs.filter(d => !!d.clubEndorsement);
+
+  function certDefRow(d) {
+    const authority = d.issuingAuthority
+      ? `<span style="color:var(--muted)"> · ${esc(d.issuingAuthority)}</span>` : "";
+    const catObj = d.category ? certCategoryByKey(certCategories, d.category) : null;
+    const catLabel = catObj ? certCategoryLabel(catObj) : d.category;
+    const catStr = d.category
+      ? `<span style="color:var(--brass-fg);font-size:10px">[${esc(catLabel)}]</span> ` : "";
+    const expiryStr = d.expires
+      ? `<span style="color:var(--muted)"> · expires</span>` : "";
+    const nameEN = d.nameEN || d.name || '';
+    const nameIS = d.nameIS || '';
+    const name   = certDefName(d);
+    const altName = (getLang() === 'IS' && nameEN && nameEN !== name) ? nameEN
+                    : (getLang() === 'EN' && nameIS && nameIS !== name) ? nameIS
+                    : '';
+    const altHtml = altName
+      ? `<span style="color:var(--muted);font-size:11px;margin-left:6px">${esc(altName)}</span>` : '';
+    const subcatStr = d.subcats?.length
+      ? d.subcats.map(sc => {
+          const parts = [certSubcatLabel(sc)];
+          if (sc.rank != null) parts.push(`rank ${sc.rank}`);
+          if (sc.issuingAuthority) parts.push(sc.issuingAuthority);
+          return parts.join(" · ");
+        }).join(", ")
+      : s('admin.noSubcategories');
+    const descStr = certDefDescription(d);
+    return `<div class="list-row">
+      <div style="flex:1">
+        <div class="list-name">${catStr}${esc(name)}${altHtml}${authority}${expiryStr}</div>
+        <div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(subcatStr)}</div>
+        ${descStr ? `<div style="font-size:11px;color:var(--muted);margin-top:2px;font-style:italic">${esc(descStr)}</div>` : ""}
+      </div>
+      <button class="row-edit" data-admin-click="openCertDefModal" data-admin-arg="${d.id}">Edit</button>
+      <button class="row-del"  data-admin-click="deleteCertDefById" data-admin-arg="${d.id}" title="Delete">×</button>
+    </div>`;
+  }
+
+  let html = '';
+  if (certifications.length) {
+    html += `<div style="font-size:9px;color:var(--muted);letter-spacing:1.2px;margin:8px 0 6px">${s('admin.certTypes')}</div>`;
+    html += certifications.map(certDefRow).join('');
+  }
+  if (endorsements.length) {
+    html += `<div style="font-size:9px;color:var(--muted);letter-spacing:1.2px;margin:${certifications.length ? '16' : '8'}px 0 6px">${s('cert.clubEndorsements')}</div>`;
+    html += endorsements.map(certDefRow).join('');
+  }
+  el.innerHTML = html;
+}
+
+function openCertDefModal(id) {
+  certEditId = id || null;
+  const d    = id ? certDefs.find(x => x.id === id) : null;
+  document.getElementById("certDefModalTitle").textContent = d ? s('admin.certEditModal') : s('admin.certAddModal');
+  // Prefer new bilingual fields, fall back to legacy single-string fields.
+  document.getElementById("cdNameEN").value            = d ? (d.nameEN || d.name || "") : "";
+  document.getElementById("cdNameIS").value            = d ? (d.nameIS || "") : "";
+  document.getElementById("cdDescEN").value            = d ? (d.descriptionEN || d.description || "") : "";
+  document.getElementById("cdDescIS").value            = d ? (d.descriptionIS || "") : "";
+  document.getElementById("cdIssuingAuthority").value = d ? (d.issuingAuthority || "") : "";
+  document.getElementById("cdClubEndorsement").checked = d ? !!d.clubEndorsement : false;
+  document.getElementById("cdColor").value            = d?.color || "#b5890a";
+  document.getElementById("cdHasIdNumber").checked     = d ? !!d.hasIdNumber : false;
+  document.getElementById("cdExpires").checked        = d ? !!d.expires : false;
+  document.getElementById("certDefDeleteBtn").classList.toggle("hidden", !d);
+  // Category dropdown
+  populateCdCategorySelect(d?.category || '');
+  toggleCdEndorsement();
+  document.getElementById("subcatRows").innerHTML = "";
+  (d?.subcats || []).forEach(sc => addSubcatRow(sc));
+  openModal("certDefModal");
+}
+
+function populateCdCategorySelect(selected) {
+  const sel = document.getElementById("cdCategory");
+  sel.innerHTML = '<option value="">' + s('admin.certCategoryNone') + '</option>';
+  certCategories.forEach(c => {
+    const key   = certCategoryKey(c);
+    const label = certCategoryLabel(c);
+    if (!key) return;
+    const o = document.createElement("option");
+    o.value = key; o.textContent = label;
+    if (key === selected) o.selected = true;
+    sel.appendChild(o);
+  });
+}
+
+function toggleCdEndorsement() {
+  const isEndorsement = document.getElementById("cdClubEndorsement").checked;
+  document.getElementById("cdCategoryField").style.display = isEndorsement ? "none" : "";
+}
+
+async function saveCertDef() {
+  const btn    = document.getElementById("saveCertDefBtn");
+  const nameEN = document.getElementById("cdNameEN").value.trim();
+  const nameIS = document.getElementById("cdNameIS").value.trim();
+  if (!nameEN) { toast(s("admin.nameRequired"), "err"); return; }
+
+  const newId   = certEditId || ("cert_" + Date.now().toString(36));
+  const expires = document.getElementById("cdExpires").checked;
+  const isEndorsement = document.getElementById("cdClubEndorsement").checked;
+  const descEN  = document.getElementById("cdDescEN").value.trim();
+  const descIS  = document.getElementById("cdDescIS").value.trim();
+  const payload = {
+    id:               newId,
+    // New bilingual fields:
+    nameEN,
+    nameIS,
+    descriptionEN:    descEN,
+    descriptionIS:    descIS,
+    // Legacy mirrors for any half-upgraded consumer:
+    name:             nameEN,
+    description:      descEN,
+    category:         isEndorsement ? '' : document.getElementById("cdCategory").value.trim(),
+    issuingAuthority: document.getElementById("cdIssuingAuthority").value.trim(),
+    subcats:          gatherSubcats(),
+    clubEndorsement:  isEndorsement,
+    color:            document.getElementById("cdColor").value,
+    hasIdNumber:      document.getElementById("cdHasIdNumber").checked,
+    expires,
+  };
+
+  btn.disabled = true;
+  try {
+    const res     = await apiPost("saveCertDef", payload);
+    const savedId = res?.id || newId;
+    const saved   = { ...payload, id: savedId };
+    if (certEditId) {
+      certDefs = certDefs.map(d => d.id === certEditId ? saved : d);
+    } else {
+      certDefs = [...certDefs, saved];
+    }
+    certEditId = savedId;
+    renderCertDefs();
+
+    closeModal("certDefModal", true);
+    toast(s("admin.certDefSaved"));
+  } catch(e) {
+    toast(s("toast.saveFailed") + ": " + e.message, "err");
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function deleteCertDef() {
+  if (!certEditId || !await ymConfirm(s("admin.confirmDeleteCertDef"))) return;
+  try {
+    await apiPost("deleteCertDef", { id: certEditId });
+    certDefs = certDefs.filter(d => d.id !== certEditId);
+    renderCertDefs();
+
+    closeModal("certDefModal", true);
+    toast(s("toast.deleted"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+async function deleteCertDefById(id) {
+  if (!await ymConfirm(s("admin.confirmDeleteCertDef"))) return;
+  try {
+    await apiPost("deleteCertDef", { id });
+    certDefs = certDefs.filter(d => d.id !== id);
+    renderCertDefs();
+
+    toast(s("toast.deleted"));
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// Subcat row — bilingual label & description inputs. Key is still derived
+// from labelEN so existing data keeps matching.
+let _subcatCounter = 0;
+function addSubcatRow(sc) {
+  const i   = _subcatCounter++;
+  const row = document.createElement("div");
+  row.className = "list-row";
+  row.id = `scrow_${i}`;
+  row.style.cssText = "flex-direction:column;align-items:stretch;gap:6px;padding:10px 0;border-bottom:1px solid var(--border)44";
+  const labelEN = sc?.labelEN ?? sc?.label ?? "";
+  const labelIS = sc?.labelIS ?? "";
+  const descEN  = sc?.descriptionEN ?? sc?.description ?? "";
+  const descIS  = sc?.descriptionIS ?? "";
+  row.innerHTML = `
+    <div style="display:grid;grid-template-columns:1fr 1fr 60px auto;gap:8px;align-items:center">
+      <input type="text"   placeholder="${esc(s('admin.subcatLabelEN') || 'Label (EN)')}" value="${esc(labelEN)}"
+        style="font-size:12px" data-field="labelEN">
+      <input type="text"   placeholder="${esc(s('admin.subcatLabelIS') || 'Label (IS)')}" value="${esc(labelIS)}"
+        style="font-size:12px" data-field="labelIS">
+      <input type="number" placeholder="Rank" min="1" max="99" value="${sc?.rank ?? ""}"
+        style="font-size:12px" data-field="rank" title="Rank (higher replaces lower on assign)">
+      <button class="row-del" data-admin-remove-el="scrow_${i}" title="Remove" style="font-size:16px;padding:2px 6px">×</button>
+    </div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+      <input type="text" placeholder="${esc(s('admin.subcatDescEN') || 'Description (EN)')}" value="${esc(descEN)}"
+        style="font-size:12px" data-field="descEN">
+      <input type="text" placeholder="${esc(s('admin.subcatDescIS') || 'Description (IS)')}" value="${esc(descIS)}"
+        style="font-size:12px" data-field="descIS">
+    </div>
+    <div>
+      <label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">ISSUING AUTHORITY</label>
+      <input type="text" placeholder="e.g. World Sailing" value="${esc(sc?.issuingAuthority || "")}"
+        style="width:100%;box-sizing:border-box;font-size:12px" data-field="issuingAuthority">
+    </div>`;
+  document.getElementById("subcatRows").appendChild(row);
+}
+
+function gatherSubcats() {
+  return [...document.querySelectorAll("#subcatRows .list-row")].map(row => {
+    const labelEN = row.querySelector('[data-field="labelEN"]').value.trim();
+    const labelIS = row.querySelector('[data-field="labelIS"]').value.trim();
+    const descEN  = row.querySelector('[data-field="descEN"]').value.trim();
+    const descIS  = row.querySelector('[data-field="descIS"]').value.trim();
+    return {
+      key:              labelEN.toLowerCase().replace(/\s+/g, "_"),
+      // New bilingual fields:
+      labelEN,
+      labelIS,
+      descriptionEN:    descEN,
+      descriptionIS:    descIS,
+      // Legacy mirrors:
+      label:            labelEN,
+      description:      descEN,
+      rank:             parseInt(row.querySelector('[data-field="rank"]').value) || null,
+      issuingAuthority: row.querySelector('[data-field="issuingAuthority"]').value.trim(),
+    };
+  }).filter(sc => sc.labelEN);
+}
+
+// ══ ALERT SETTINGS ════════════════════════════════════════════════════════════
+
+function loadAlertConfig(cfg) {
+  if (!cfg) return;
+  document.getElementById("alertFirstMins").value  = cfg.firstAlertMins  || 30;
+  document.getElementById("alertRepeatMins").value = cfg.repeatMins       || 15;
+  document.getElementById("alertSnoozeMins").value = cfg.snoozeMins       || 10;
+  document.getElementById("alertEnabled").checked  = cfg.enabled !== false;
+  var ch=cfg.channels||{};
+  if(document.getElementById("chanWeb"))   document.getElementById("chanWeb").checked   = ch.web!==false;
+  if(document.getElementById("chanEmail")) document.getElementById("chanEmail").checked = !!ch.email;
+  if(document.getElementById("chanSms"))   document.getElementById("chanSms").checked   = !!ch.sms;
+  var emails=Array.isArray(cfg.staffEmailList)?cfg.staffEmailList.join(", "):(cfg.staffEmailList||"");
+  var sms=Array.isArray(cfg.staffSmsList)?cfg.staffSmsList.join(", "):(cfg.staffSmsList||"");
+  if(document.getElementById("alertEmailList")) document.getElementById("alertEmailList").value=emails;
+  if(document.getElementById("alertSmsList"))   document.getElementById("alertSmsList").value=sms;
+}
+
+async function saveAlertConfig() {
+  var emailRaw=(document.getElementById("alertEmailList")||{value:""}).value;
+  var smsRaw=(document.getElementById("alertSmsList")||{value:""}).value;
+  const cfg = {
+    firstAlertMins: parseInt(document.getElementById("alertFirstMins").value) || 30,
+    repeatMins:     parseInt(document.getElementById("alertRepeatMins").value) || 15,
+    snoozeMins:     parseInt(document.getElementById("alertSnoozeMins").value) || 10,
+    enabled:        document.getElementById("alertEnabled").checked,
+    channels: {
+      web:   document.getElementById("chanWeb")   ? document.getElementById("chanWeb").checked   : true,
+      email: document.getElementById("chanEmail") ? document.getElementById("chanEmail").checked : false,
+      sms:   document.getElementById("chanSms")   ? document.getElementById("chanSms").checked   : false,
+    },
+    staffEmailList: emailRaw.split(",").map(function(e){return e.trim();}).filter(function(e){return e.includes("@");}),
+    staffSmsList:   smsRaw.split(",").map(function(e){return e.trim();}).filter(function(e){return e.length>4;}),
+  };
+  try {
+    await apiPost("saveAlertConfig", cfg);
+    const msg = document.getElementById("alertSaveMsg");
+    msg.textContent = "✓ " + s("toast.saved");
+    setTimeout(() => { msg.textContent = ""; }, 2500);
+  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
+}
+
+// ══ FLAG CONFIG ═══════════════════════════════════════════════════════════════
+
+function _fcBandRow(cId,idx,fields,removeFn){
+  return '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px">'+fields.map(function(f){return '<div class="field" style="flex:1;min-width:80px;margin-bottom:0"><label style="font-size:10px">'+esc(f.label)+'</label><input type="number" id="'+cId+'_'+f.key+'_'+idx+'" value="'+f.val+'" step="'+(f.step||1)+'" min="'+(f.min!=null?f.min:-99)+'" style="width:100%" data-admin-input="updateFlagPreview"></div>';}).join('')+'<button data-admin-click="'+removeFn+'" data-admin-arg="'+idx+'" style="background:none;border:none;color:var(--muted);font-size:18px;cursor:pointer;padding:0 4px;margin-top:14px">×</button></div>';
+}
+function _fcReadBands(cId,keys){var rows=[],idx=0;while(document.getElementById(cId+'_'+keys[0]+'_'+idx)!==null){var row={};keys.forEach(function(k){var el=document.getElementById(cId+'_'+k+'_'+idx);row[k]=el?parseFloat(el.value):0;});rows.push(row);idx++;}return rows;}
+var _fcWindBands=[],_fcWaveBands=[],_fcSstBands=[],_fcFeelsBands=[];
+function fcRenderWindBands(){var el=document.getElementById('fcWindBands');if(!el)return;el.innerHTML=_fcWindBands.map(function(b,i){return _fcBandRow('fcWind',i,[{key:'maxBft',label:'Max Force',val:b.maxBft,min:0},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveWindBand');}).join('');}
+function fcRenderWaveBands(){var el=document.getElementById('fcWaveBands');if(!el)return;el.innerHTML=_fcWaveBands.map(function(b,i){return _fcBandRow('fcWave',i,[{key:'maxM',label:'Max m',val:b.maxM,min:0,step:0.1},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveWaveBand');}).join('');}
+function fcRenderSstBands(){var el=document.getElementById('fcSstBands');if(!el)return;el.innerHTML=_fcSstBands.map(function(b,i){return _fcBandRow('fcSst',i,[{key:'minC',label:'Min °C',val:b.minC},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveSstBand');}).join('');}
+function fcRenderFeelsBands(){var el=document.getElementById('fcFeelsBands');if(!el)return;el.innerHTML=_fcFeelsBands.map(function(b,i){return _fcBandRow('fcFeels',i,[{key:'minC',label:'Min °C',val:b.minC},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveFeelsBand');}).join('');}
+function fcAddWindBand(){_fcWindBands=fcReadWindBands();_fcWindBands.push({maxBft:12,pts:0});fcRenderWindBands();updateFlagPreview();}
+function fcRemoveWindBand(i){_fcWindBands=fcReadWindBands();_fcWindBands.splice(i,1);fcRenderWindBands();updateFlagPreview();}
+function fcReadWindBands(){return _fcReadBands('fcWind',['maxBft','pts']).map(function(r){return{maxBft:r.maxBft,pts:r.pts};});}
+function fcAddWaveBand(){_fcWaveBands=fcReadWaveBands();_fcWaveBands.push({maxM:99,pts:0});fcRenderWaveBands();updateFlagPreview();}
+function fcRemoveWaveBand(i){_fcWaveBands=fcReadWaveBands();_fcWaveBands.splice(i,1);fcRenderWaveBands();updateFlagPreview();}
+function fcReadWaveBands(){return _fcReadBands('fcWave',['maxM','pts']).map(function(r){return{maxM:r.maxM,pts:r.pts};});}
+function fcAddSstBand(){_fcSstBands=fcReadSstBands();_fcSstBands.push({minC:-99,pts:0});fcRenderSstBands();updateFlagPreview();}
+function fcRemoveSstBand(i){_fcSstBands=fcReadSstBands();_fcSstBands.splice(i,1);fcRenderSstBands();updateFlagPreview();}
+function fcReadSstBands(){return _fcReadBands('fcSst',['minC','pts']).map(function(r){return{minC:r.minC,pts:r.pts};});}
+function fcAddFeelsBand(){_fcFeelsBands=fcReadFeelsBands();_fcFeelsBands.push({minC:-99,pts:0});fcRenderFeelsBands();updateFlagPreview();}
+function fcRemoveFeelsBand(i){_fcFeelsBands=fcReadFeelsBands();_fcFeelsBands.splice(i,1);fcRenderFeelsBands();updateFlagPreview();}
+function fcReadFeelsBands(){return _fcReadBands('fcFeels',['minC','pts']).map(function(r){return{minC:r.minC,pts:r.pts};});}
+function loadFlagConfigPanel(c){
+  c=c||{};var sc=SCORE_CONFIG;var t=c.thresholds||sc.thresholds;
+  document.getElementById('fcThreshY').value=t.yellow!=null?t.yellow:25;
+  document.getElementById('fcThreshO').value=t.orange!=null?t.orange:45;
+  document.getElementById('fcThreshR').value=t.red!=null?t.red:65;
+  document.getElementById('fcThreshB').value=t.black!=null?t.black:80;
+  _fcWindBands=(c.wind||sc.wind).map(function(b){return{maxBft:b.maxBft,pts:b.pts};});
+  _fcWaveBands=(c.waves||sc.waves).map(function(b){return{maxM:b.maxM,pts:b.pts};});
+  _fcSstBands=(c.sst||sc.sst).map(function(b){return{minC:b.minC,pts:b.pts};});
+  _fcFeelsBands=(c.feelsLike||sc.feelsLike).map(function(b){return{minC:b.minC,pts:b.pts};});
+  fcRenderWindBands();fcRenderWaveBands();fcRenderSstBands();fcRenderFeelsBands();
+  var wdm=c.windDirModifier||sc.windDirModifier||{dirs:[],pts:0};
+  document.getElementById('fcWindDirPts').value=wdm.pts!=null?wdm.pts:0;
+  document.getElementById('fcGust1Pts').value=(c.gustModifier1Pts??sc.gustModifier1Pts)??0;
+  document.getElementById('fcGust2Pts').value=(c.gustModifier2Pts??sc.gustModifier2Pts)??0;
+  document.getElementById('fcWindDirDirs').value=(wdm.dirs||[]).join(',');
+  var vis=c.visibility||sc.visibility;
+  document.getElementById('fcVisGood').value=vis.good!=null?vis.good:0;
+  document.getElementById('fcVisReduced').value=vis.reduced!=null?vis.reduced:0;
+  document.getElementById('fcVisPoor').value=vis.poor!=null?vis.poor:0;
+  var advEl=document.getElementById('fcFlagAdvice');
+  if(advEl){advEl.innerHTML=['green','yellow','orange','red','black'].map(function(key){var fc=SCORE_CONFIG.flags[key],saved=(c.flags&&c.flags[key])||{};return '<div style="background:'+fc.bg+';border:1px solid '+fc.border+';border-radius:8px;padding:10px 12px;margin-bottom:4px">'+'<div style="font-size:12px;color:'+fc.color+';font-weight:500;margin-bottom:8px">'+fc.icon+' '+key+'</div>'+'<div class="field" style="margin-bottom:6px"><label style="font-size:10px">Short advice (EN)</label><input type="text" id="fcAdvice_'+key+'" value="'+esc(saved.advice||fc.advice||'')+'" style="font-size:11px"></div>'+'<div class="field" style="margin-bottom:6px"><label style="font-size:10px">Stutt ráðlegging (IS)</label><input type="text" id="fcAdviceIS_'+key+'" value="'+esc(saved.adviceIS||fc.adviceIS||'')+'" style="font-size:11px"></div>'+'<div class="field" style="margin-bottom:6px"><label style="font-size:10px">Full description (EN)</label><textarea id="fcDesc_'+key+'" rows="2" style="font-size:11px;width:100%;box-sizing:border-box;resize:vertical;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:5px 7px;font-family:inherit">'+esc(saved.description||fc.description||'')+'</textarea></div>'+'<div class="field" style="margin-bottom:0"><label style="font-size:10px">Full lýsingartexti (IS)</label><textarea id="fcDescIS_'+key+'" rows="2" style="font-size:11px;width:100%;box-sizing:border-box;resize:vertical;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:5px 7px;font-family:inherit">'+esc(saved.descriptionIS||fc.descriptionIS||'')+'</textarea></div>'+'</div>';}).join('');}
+  updateFlagPreview();
+}
+function getFlagFormValues(){
+  var t={yellow:parseInt(document.getElementById('fcThreshY').value)||25,orange:parseInt(document.getElementById('fcThreshO').value)||45,red:parseInt(document.getElementById('fcThreshR').value)||65,black:parseInt(document.getElementById('fcThreshB').value)||80};
+  var windDirDirs=(document.getElementById('fcWindDirDirs').value||'').split(',').map(function(s){return s.trim().toUpperCase();}).filter(Boolean);
+  var windDirModifier={dirs:windDirDirs,pts:parseInt(document.getElementById('fcWindDirPts').value)||0};
+  var cfg={thresholds:t,wind:fcReadWindBands(),waves:fcReadWaveBands(),sst:fcReadSstBands(),feelsLike:fcReadFeelsBands(),windDirModifier:windDirModifier,gustModifier1Pts:parseInt(document.getElementById('fcGust1Pts').value)||0,
+      gustModifier2Pts:parseInt(document.getElementById('fcGust2Pts').value)||0,visibility:{good:parseInt(document.getElementById('fcVisGood').value)||0,reduced:parseInt(document.getElementById('fcVisReduced').value)||0,poor:parseInt(document.getElementById('fcVisPoor').value)||0},flags:{}};
+  ['green','yellow','orange','red','black'].forEach(function(key){var en=document.getElementById('fcAdvice_'+key),is=document.getElementById('fcAdviceIS_'+key);var de=document.getElementById('fcDesc_'+key),dis=document.getElementById('fcDescIS_'+key);cfg.flags[key]={advice:en?en.value.trim():'',adviceIS:is?is.value.trim():'',description:de?de.value.trim():'',descriptionIS:dis?dis.value.trim():''};});
+  return cfg;
+}
+function validateFlagConfig(cfg){var errs=[],t=cfg.thresholds;if(t.yellow>=t.orange)errs.push('Yellow must be < orange.');if(t.orange>=t.red)errs.push('Orange must be < red.');if(t.red>=t.black)errs.push('Red must be < closed.');if(!cfg.wind.length)errs.push('At least one wind band required.');return errs;}
+function updateFlagPreview(){
+  var preview=document.getElementById('fcFlagPreview');if(!preview)return;
+  if(typeof wxScoreFlag!=='function'||typeof wxLoadFlagConfig!=='function'){
+    preview.innerHTML='<div style="font-size:11px;color:var(--muted)">Preview requires weather.js — check script imports.</div>';return;
+  }
+  var examples=[{label:'Force 2, calm',ws:1.6,wDir:'SW',waveH:0,airT:12,sst:10,wg:2},{label:'Force 4, 0.6m, 8°C',ws:5.5,wDir:'SW',waveH:0.6,airT:8,sst:7,wg:7},{label:'Force 5 NE, 1m, 4°C',ws:8.0,wDir:'NE',waveH:1.0,airT:4,sst:5,wg:11},{label:'Force 7 E, 1.8m, -2°C',ws:13.9,wDir:'E',waveH:1.8,airT:-2,sst:3,wg:17},{label:'Force 8, 2.2m, -5°C',ws:17.2,wDir:'NW',waveH:2.2,airT:-5,sst:2,wg:21}];
+  // Deep-clone SCORE_CONFIG, apply form values, render, then restore
+  var snap=JSON.parse(JSON.stringify(SCORE_CONFIG));
+  try{
+    var cfg=getFlagFormValues();
+    // Apply temporarily without persisting
+    Object.assign(SCORE_CONFIG.thresholds,cfg.thresholds);
+    SCORE_CONFIG.wind=cfg.wind;SCORE_CONFIG.waves=cfg.waves;
+    SCORE_CONFIG.sst=cfg.sst;SCORE_CONFIG.feelsLike=cfg.feelsLike;
+    Object.assign(SCORE_CONFIG.visibility,cfg.visibility);
+    SCORE_CONFIG.windDirModifier=cfg.windDirModifier;
+    SCORE_CONFIG.gustModifier1Pts=cfg.gustModifier1Pts;
+    SCORE_CONFIG.gustModifier2Pts=cfg.gustModifier2Pts;
+  }catch(e){}
+  preview.innerHTML=examples.map(function(ex){
+    var r=wxScoreFlag(ex.ws,ex.wDir,ex.waveH,ex.airT,ex.sst,ex.wg,'good');
+    var fk=r.flagKey,fl=SCORE_CONFIG.flags[fk];
+    return '<div style="flex:1;min-width:150px;background:'+fl.bg+';border:1px solid '+fl.border+';border-radius:8px;padding:8px 10px;color:'+fl.color+'">'
+      +'<div style="font-size:12px;font-weight:500">'+fl.icon+' · <b>'+r.score+'</b> pts</div>'
+      +'<div style="font-size:10px;opacity:.8;margin-top:3px">'+esc(ex.label)+'</div></div>';
+  }).join('');
+  // Restore
+  Object.assign(SCORE_CONFIG.thresholds,snap.thresholds);
+  SCORE_CONFIG.wind=snap.wind;SCORE_CONFIG.waves=snap.waves;
+  SCORE_CONFIG.sst=snap.sst;SCORE_CONFIG.feelsLike=snap.feelsLike;
+  Object.assign(SCORE_CONFIG.visibility,snap.visibility);
+  SCORE_CONFIG.windDirModifier=snap.windDirModifier;
+  SCORE_CONFIG.gustModifier1Pts=snap.gustModifier1Pts;
+  SCORE_CONFIG.gustModifier2Pts=snap.gustModifier2Pts;
+}
+async function saveFlagConfig(){
+  var errEl=document.getElementById('fcValidationError'),msgEl=document.getElementById('fcSaveMsg');errEl.style.display='none';msgEl.textContent='';
+  var cfg=getFlagFormValues(),errs=validateFlagConfig(cfg);if(errs.length){errEl.textContent=errs.join(' ');errEl.style.display='block';return;}
+  try{await apiPost('saveConfig',{flagConfig:cfg});if(typeof wxLoadFlagConfig==='function')wxLoadFlagConfig(cfg);updateFlagPreview();msgEl.style.color='var(--green)';msgEl.textContent='✓ '+s('toast.saved');setTimeout(function(){msgEl.textContent='';},3000);}catch(e){msgEl.style.color='var(--red)';msgEl.textContent=s('toast.saveFailed')+': '+e.message;}
+}
+async function resetFlagConfig(){if(!await ymConfirm(s('admin.confirmResetFlags')))return;loadFlagConfigPanel(null);}
+
+// ══ CSV IMPORT ════════════════════════════════════════════════════════════════
+
+function showImportStep(n) {
+  [1,2,3].forEach(i => {
+    document.getElementById("importStep" + i).classList.toggle("hidden", i !== n);
+  });
+}
+
+function handleCSVUpload(input) {
+  const file = input.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      importResult = parseAblerCSV(e.target.result, members);
+      renderImportPreview(importResult);
+    } catch(err) {
+      document.getElementById("importError").textContent = s("admin.parseError") + ": " + err.message;
+      document.getElementById("importError").style.display = "block";
+    }
+  };
+  reader.readAsText(file, "UTF-8");
+}
+
+function parseAblerCSV(text, existing) {
+  const lines  = text.split(/\r?\n/).filter(l => l.trim());
+  const header = lines[0].split(/[,;]/).map(h => h.trim().toLowerCase().replace(/\s+/g,'_'));
+  const col    = k => header.indexOf(k);
+  const rows   = lines.slice(1).map(l => {
+    const vals = l.split(/[,;]/);
+    const get  = k => (vals[col(k)] || "").trim().replace(/^"|"$/g,'');
+    return {
+      kennitala:      get('kennitala'),
+      name:           get('name') || get('full_name') || get('nafn'),
+      email:          get('email') || get('netfang'),
+      phone:          get('phone') || get('simi'),
+      dob:            get('dob') || get('date_of_birth'),
+    };
+  }).filter(r => r.kennitala && r.name);
+
+  const added   = [], updated = [], unchanged = [], flagged = [], ambiguous = [];
+  const existKt = new Map(existing.map(m => [m.kennitala, m]));
+  const existNames = new Map();
+  existing.forEach(m => {
+    const norm = (m.name||'').trim().toLowerCase();
+    if (norm) { if (!existNames.has(norm)) existNames.set(norm, []); existNames.get(norm).push(m); }
+  });
+
+  // Helper: count differing characters between two strings of same length
+  function ktDistance(a, b) {
+    if (!a || !b || a.length !== b.length) return Infinity;
+    let d = 0;
+    for (let i = 0; i < a.length; i++) { if (a[i] !== b[i]) d++; }
+    return d;
+  }
+
+  rows.forEach(r => {
+    const ex = existKt.get(r.kennitala);
+    if (ex) {
+      if (ex.name !== r.name || ex.email !== r.email) {
+        updated.push({ ...r, id: ex.id, _prev: ex });
+      } else { unchanged.push(r); }
+    } else {
+      // Check for possible duplicate: same name OR very similar kennitala
+      const norm = r.name.trim().toLowerCase();
+      const nameMatch = (existNames.get(norm) || []).find(m => m.kennitala !== r.kennitala);
+      // Also check for kennitala off by 1-2 digits (typo detection)
+      let ktMatch = null;
+      if (!nameMatch && r.kennitala.length >= 6) {
+        for (const m of existing) {
+          if (m.kennitala === r.kennitala) continue;
+          if (ktDistance(r.kennitala, m.kennitala) <= 2) { ktMatch = m; break; }
+        }
+      }
+      const match = nameMatch || ktMatch;
+      if (match) {
+        const reason = nameMatch ? 'Same name, different kennitala' : 'Similar kennitala (possible typo)';
+        ambiguous.push({ csvRow: r, existing: match, reason });
+      } else {
+        added.push(r);
+      }
+    }
+  });
+  const activeOnly = existing.filter(m => boolVal(m.active) !== false && m.active !== 'FALSE');
+  activeOnly.forEach(m => {
+    if (['admin','staff','guest','guardian'].includes(m.role)) return;
+    if (!rows.find(r => r.kennitala === m.kennitala)) flagged.push(m);
+  });
+  return { added, updated, unchanged, flagged, ambiguous };
+}
+
+function renderImportPreview(res) {
+  const chips = [
+    { label: `${res.added.length} new`,         cls: 'chip-green'  },
+    { label: `${res.updated.length} updated`,   cls: 'chip-brass'  },
+    { label: `${res.unchanged.length} unchanged`,cls: 'chip-muted' },
+    { label: `${res.flagged.length} not in import`, cls: 'chip-orange' },
+  ];
+  if (res.ambiguous.length) chips.push({ label: `${res.ambiguous.length} needs review`, cls: 'chip-red' });
+  document.getElementById("importSummary").innerHTML = chips.map(c =>
+    `<span class="import-chip ${c.cls}">${c.label}</span>`).join("");
+
+  let html = "";
+  // Ambiguous matches — admin must review before anything happens
+  if (res.ambiguous.length) {
+    html += `<div style="font-size:11px;color:#9b59b6;margin:10px 0 4px;font-weight:500">NEEDS REVIEW — possible duplicates (${res.ambiguous.length})</div>
+      <div style="font-size:10px;color:var(--muted);margin-bottom:6px">These rows are skipped by default. Only change if you are sure.</div>`;
+    res.ambiguous.forEach((a, idx) => {
+      html += `<div class="import-ambig" data-ambig-idx="${idx}">
+        <div style="flex:1">
+          <div><strong>CSV:</strong> ${esc(a.csvRow.name)} <span style="color:var(--muted)">(${esc(a.csvRow.kennitala)})</span></div>
+          <div><strong>Existing:</strong> ${esc(a.existing.name)} <span style="color:var(--muted)">(${esc(a.existing.kennitala)})</span></div>
+          <div style="color:#9b59b6;font-size:10px;margin-top:2px">${esc(a.reason || 'Possible match')}</div>
+        </div>
+        <div class="import-ambig-btns">
+          <button data-admin-click="resolveAmbig" data-admin-arg="${idx}" data-admin-arg2="same" title="Same person — update existing record with CSV kennitala &amp; data">Update existing</button>
+          <button data-admin-click="resolveAmbig" data-admin-arg="${idx}" data-admin-arg2="new" title="Different person — add CSV row as a separate new member">Add as new</button>
+          <button data-admin-click="resolveAmbig" data-admin-arg="${idx}" data-admin-arg2="skip" class="selected" title="Do nothing with this row">Skip</button>
+        </div>
+      </div>`;
+    });
+  }
+  if (res.added.length) {
+    html += `<div style="font-size:11px;color:var(--green);margin:10px 0 4px;font-weight:500">NEW (${res.added.length})</div>
+      <div class="import-list">${res.added.map(m => `
+        <div class="import-row">
+          <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
+          <span style="flex:1">${esc(m.name)}</span>
+          ${m.dob && (new Date().getFullYear() - parseInt(sstr(m.dob).slice(0,4))) < 18
+            ? `<span class="minor-badge">minor</span>` : ""}
+        </div>`).join("")}</div>`;
+  }
+  if (res.updated.length) {
+    html += `<div style="font-size:11px;color:var(--brass-fg);margin:10px 0 4px;font-weight:500">UPDATED (${res.updated.length})</div>
+      <div class="import-list">${res.updated.map(m => `
+        <div class="import-row">
+          <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
+          <span style="flex:1">${esc(m.name)}</span>
+          <span style="color:var(--muted);font-size:11px">was: ${esc(m._prev.name)}</span>
+        </div>`).join("")}</div>`;
+  }
+  if (res.flagged.length) {
+    html += `<div style="font-size:11px;color:var(--orange);margin:10px 0 4px;font-weight:500">NOT IN THIS IMPORT (${res.flagged.length})
+      <span style="font-weight:400;opacity:.7"> — check to deactivate</span></div>
+      <div style="margin-bottom:4px">
+        <label style="font-size:10px;color:var(--muted);cursor:pointer;display:inline-flex;align-items:center;gap:4px">
+          <input type="checkbox" id="flagSelectAll" data-admin-change-check="toggleFlagAll"> Select all
+        </label>
+      </div>
+      <div class="import-list">${res.flagged.map(m => `
+        <div class="import-row">
+          <label>
+            <input type="checkbox" class="flag-cb" value="${esc(m.id)}" data-kt="${esc(m.kennitala)}">
+            <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
+            <span style="flex:1">${esc(m.name)}</span>
+            <span style="color:var(--muted);font-size:10px">${esc(m.role||'member')}</span>
+          </label>
+        </div>`).join("")}</div>`;
+  }
+
+  document.getElementById("importLists").innerHTML = html;
+  document.getElementById("importError").style.display = "none";
+  showImportStep(2);
+}
+
+function toggleFlagAll(checked) {
+  document.querySelectorAll('.flag-cb').forEach(cb => { cb.checked = checked; });
+}
+
+// Ambiguous resolution: track decisions per index
+let _ambigDecisions = {};
+function resolveAmbig(idx, decision) {
+  _ambigDecisions[idx] = decision;
+  const row = document.querySelector(`[data-ambig-idx="${idx}"]`);
+  if (!row) return;
+  row.querySelectorAll('.import-ambig-btns button').forEach(btn => btn.classList.remove('selected'));
+  const labels = { same: 'Update existing', new: 'Add as new', skip: 'Skip' };
+  row.querySelectorAll('.import-ambig-btns button').forEach(btn => {
+    if (btn.textContent === labels[decision]) btn.classList.add('selected');
+  });
+}
+
+async function confirmImport() {
+  if (!importResult) return;
+  const btn = document.getElementById("confirmImportBtn");
+  btn.disabled = true; btn.textContent = s("admin.importing");
+  try {
+    // Resolve ambiguous entries based on admin decisions
+    const extraAdded = [], extraUpdated = [];
+    (importResult.ambiguous || []).forEach((a, idx) => {
+      const decision = _ambigDecisions[idx] || 'skip';
+      if (decision === 'new') { extraAdded.push(a.csvRow); }
+      else if (decision === 'same') { extraUpdated.push({ ...a.csvRow, id: a.existing.id, kennitala: a.existing.kennitala, _prev: a.existing }); }
+    });
+
+    const toSend = [...importResult.added, ...extraAdded, ...importResult.updated, ...extraUpdated].map(m => {
+      const c = { ...m }; delete c._s; delete c._prev; return c;
+    });
+    const importTemps = [];
+    if (toSend.length) {
+      const results = await Promise.all(chunk(toSend, 10).map(rows => apiPost("importMembers", { rows })));
+      results.forEach(r => {
+        if (r && Array.isArray(r.tempPasswords)) importTemps.push(...r.tempPasswords);
+      });
+    }
+
+    // Deactivate checked flagged members
+    const deactivateIds = Array.from(document.querySelectorAll('.flag-cb:checked')).map(cb => cb.value).filter(Boolean);
+    let deactivated = 0;
+    if (deactivateIds.length) {
+      const res = await apiPost("deactivateMembers", { ids: deactivateIds });
+      deactivated = res.deactivated || 0;
+      deactivateIds.forEach(id => {
+        const m = members.find(x => x.id === id);
+        if (m) m.active = false;
+      });
+    }
+
+    importResult.updated.forEach(u => {
+      members = members.map(m => m.kennitala === u.kennitala ? { ...m, ...u } : m);
+    });
+    extraUpdated.forEach(u => {
+      members = members.map(m => m.id === u.id ? { ...m, ...u } : m);
+    });
+    importResult.added.forEach(a => {
+      const c = { ...a }; delete c._s; members.push(c);
+    });
+    extraAdded.forEach(a => {
+      const c = { ...a }; delete c._s; members.push(c);
+    });
+
+    const totalAdded = importResult.added.length + extraAdded.length;
+    const totalUpdated = importResult.updated.length + extraUpdated.length;
+    let msg = s('admin.importComplete', { added: totalAdded, updated: totalUpdated });
+    if (deactivated) msg += ' ' + s('admin.importDeactivated', { count: deactivated });
+    document.getElementById("importDoneMsg").textContent = msg;
+    showImportStep(3);
+    if (importTemps.length) showTempPasswordDialog(importTemps);
+  } catch(e) {
+    document.getElementById("importError").textContent = s("admin.importFailed") + ": " + e.message;
+    document.getElementById("importError").style.display = "block";
+    btn.disabled = false; btn.textContent = s("admin.confirmImport");
+  }
+}
+
+function resetImport() {
+  importResult = null;
+  _ambigDecisions = {};
+  document.getElementById("csvFile").value = "";
+  showImportStep(1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RESERVATION SLOT CALENDAR
+// ═══════════════════════════════════════════════════════════════════════════════
+
+var _slotWeekStart = null; // Monday of current week
+var _slotData = [];        // loaded slots for current view
+var _editingSlot = null;   // slot being edited in modal
+
+function loadCharterCalendars(cc) {
+  document.getElementById("charterRowingCalId").value = cc.rowingCalendarId || "";
+  document.getElementById("charterRowingCalActive").checked = !!cc.rowingCalendarSyncActive;
+  document.getElementById("charterKeelboatCalId").value = cc.keelboatCalendarId || "";
+  document.getElementById("charterKeelboatCalActive").checked = !!cc.keelboatCalendarSyncActive;
+}
+
+async function saveCharterCalendars() {
+  const msg = document.getElementById("charterCalSaveMsg");
+  msg.textContent = "";
+  try {
+    await apiPost("saveCharterCalendars", {
+      rowingCalendarId: document.getElementById("charterRowingCalId").value.trim(),
+      rowingCalendarSyncActive: document.getElementById("charterRowingCalActive").checked,
+      keelboatCalendarId: document.getElementById("charterKeelboatCalId").value.trim(),
+      keelboatCalendarSyncActive: document.getElementById("charterKeelboatCalActive").checked,
+    });
+    msg.textContent = s("toast.saved") || "Saved";
+    msg.style.color = "var(--green)";
+  } catch (e) {
+    msg.textContent = (s("toast.error") || "Error") + ": " + e.message;
+    msg.style.color = "var(--red)";
+  }
+}
+
+// ── Club Calendars ────────────────────────────────────────────────────────────
+function loadClubCalendars(cals) {
+  var list = document.getElementById("clubCalList");
+  list.innerHTML = "";
+  if (!cals.length) {
+    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin:8px 0" data-s="admin.calEmpty"></div>';
+    applyStrings(list);
+    return;
+  }
+  cals.forEach(function(c) { addClubCalRow(c.name, c.calendarId); });
+}
+
+function addClubCalRow(name, calId) {
+  var list = document.getElementById("clubCalList");
+  // Remove empty-state message if present
+  var empty = list.querySelector("[data-s='admin.calEmpty']");
+  if (empty) empty.remove();
+  var row = document.createElement("div");
+  row.className = "grid2";
+  row.style.cssText = "margin-bottom:8px;align-items:end";
+  row.innerHTML =
+    '<div class="field"><label data-s="admin.calName"></label><input type="text" class="ccName" value="' + esc(name) + '"></div>' +
+    '<div style="display:flex;gap:6px;align-items:end"><div class="field" style="flex:1"><label data-s="admin.calId"></label><input type="text" class="ccId" value="' + esc(calId) + '" placeholder="' + (s("admin.calPlaceholder") || "") + '"></div>' +
+    '<button class="btn btn-ghost btn-danger" style="margin-bottom:4px;font-size:10px" data-admin-click-el="removeClubCalRow" data-s="admin.calRemove"></button></div>';
+  list.appendChild(row);
+  applyStrings(row);
+}
+
+function removeClubCalRow(btn) {
+  btn.closest(".grid2").remove();
+}
+
+async function saveClubCalendars() {
+  var msg = document.getElementById("clubCalSaveMsg");
+  msg.textContent = "";
+  var rows = document.querySelectorAll("#clubCalList .grid2");
+  var cals = [];
+  rows.forEach(function(r) {
+    var name = r.querySelector(".ccName").value.trim();
+    var calId = r.querySelector(".ccId").value.trim();
+    if (name && calId) cals.push({ name: name, calendarId: calId });
+  });
+  try {
+    await apiPost("saveClubCalendars", { calendars: cals });
+    msg.textContent = s("toast.saved") || "Saved";
+    msg.style.color = "var(--green)";
+  } catch (e) {
+    msg.textContent = (s("toast.error") || "Error") + ": " + e.message;
+    msg.style.color = "var(--red)";
+  }
+}
+
+function initSlotCalendar() {
+  // Set week start to this Monday
+  var d = new Date();
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7)); // Monday
+  d.setHours(0,0,0,0);
+  _slotWeekStart = d;
+  // Populate category filter
+  var sel = document.getElementById("slotCatFilter");
+  sel.innerHTML = '';
+  var cats = (boatCats || []).filter(function(c) {
+    return (_allBoats || []).some(function(b) { return b.category === c.key && b.accessMode === 'controlled' && boolVal(b.slotSchedulingEnabled); });
+  });
+  if (!cats.length) {
+    sel.innerHTML = '<option value="">(' + s('slot.noSlotBoats') + ')</option>';
+    return;
+  }
+  cats.forEach(function(c) {
+    sel.innerHTML += '<option value="' + esc(c.key) + '">' + esc(c.label || c.key) + '</option>';
+  });
+  loadSlotCalendar();
+}
+
+async function loadSlotCalendar() {
+  var cat = document.getElementById("slotCatFilter").value;
+  if (!cat) { document.getElementById("slotCalGrid").innerHTML = ''; return; }
+  var fromDate = _slotWeekStart.toISOString().slice(0, 10);
+  var toD = new Date(_slotWeekStart); toD.setDate(toD.getDate() + 6);
+  var toDate = toD.toISOString().slice(0, 10);
+  try {
+    var res = await apiGet("getSlots", { category: cat, fromDate: fromDate, toDate: toDate });
+    _slotData = res.slots || [];
+  } catch(e) { _slotData = []; }
+  // Populate boat filter
+  var boatSel = document.getElementById("slotBoatFilter");
+  var catBoats = (_allBoats || []).filter(function(b) { return b.category === cat && boolVal(b.slotSchedulingEnabled); });
+  boatSel.innerHTML = '<option value="">' + s('slot.allBoats') + '</option>';
+  catBoats.forEach(function(b) { boatSel.innerHTML += '<option value="' + esc(b.id) + '">' + esc(b.name) + '</option>'; });
+  renderSlotCalendar();
+}
+
+var _adminCalendars = {};
+
+function _resolveSlotColor(sl) {
+  if (!sl || !sl.bookedByKennitala) return null;
+  if (sl.bookingColor) return sl.bookingColor;
+  if (sl.bookedByCrewId && Array.isArray(window._allCrews)) {
+    var crew = window._allCrews.find(function(c) { return c.id === sl.bookedByCrewId; });
+    if (crew && crew.color) return crew.color;
+  }
+  return null;
+}
+
+function renderSlotCalendar() {
+  var cat = document.getElementById("slotCatFilter").value;
+  var boatFilter = document.getElementById("slotBoatFilter").value;
+  var catBoats = (_allBoats || []).filter(function(b) {
+    return b.category === cat && boolVal(b.slotSchedulingEnabled) && (!boatFilter || b.id === boatFilter);
+  });
+  var container = document.getElementById("slotCalGrid");
+  if (!catBoats.length) {
+    container.innerHTML = '<div style="font-size:11px;color:var(--muted)">' + s('slot.noSlotBoats') + '</div>';
+    _adminCalendars = {};
+    return;
+  }
+  // Update week label
+  var d0 = new Date(_slotWeekStart);
+  var d6 = new Date(_slotWeekStart); d6.setDate(d6.getDate() + 6);
+  document.getElementById("slotWeekLabel").textContent = fmtWeekRange(d0.toISOString(), d6.toISOString());
+
+  // One SlotCalendar per boat (to match captain/rowing calendar styling)
+  container.innerHTML = '';
+  var newCals = {};
+  catBoats.forEach(function(boat) {
+    var boatSlots = _slotData.filter(function(sl) { return sl.boatId === boat.id; });
+    // Enrich with crew name so the calendar identifies bookings by crew.
+    if (Array.isArray(window._allCrews)) {
+      boatSlots.forEach(function(sl) {
+        if (sl.bookedByCrewId && !sl.bookedByCrewName) {
+          var crew = window._allCrews.find(function(c) { return c.id === sl.bookedByCrewId; });
+          if (crew) sl.bookedByCrewName = crew.name;
+        }
+      });
+    }
+    var wrap = document.createElement('div');
+    wrap.style.marginBottom = '16px';
+    var hdr = document.createElement('div');
+    hdr.style.cssText = 'font-size:11px;font-weight:500;letter-spacing:.5px;margin-bottom:6px;color:var(--text)';
+    hdr.textContent = boat.name;
+    wrap.appendChild(hdr);
+    var gridEl = document.createElement('div');
+    wrap.appendChild(gridEl);
+    container.appendChild(wrap);
+
+    var cal = new SlotCalendar(gridEl, {
+      isMine: function() { return false; },
+      onBook: function(slotId) { openSlotModal(slotId); },
+      onUnbook: function(slotId) { openSlotModal(slotId); },
+      getSlotColor: _resolveSlotColor,
+    });
+    cal.setWeekStart(_slotWeekStart);
+    cal.setSlots(boatSlots);
+    newCals[boat.id] = cal;
+  });
+  _adminCalendars = newCals;
+}
+
+function shiftSlotWeek(dir) {
+  _slotWeekStart.setDate(_slotWeekStart.getDate() + dir * 7);
+  loadSlotCalendar();
+}
+
+function slotWeekToday() {
+  var d = new Date();
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  d.setHours(0,0,0,0);
+  _slotWeekStart = d;
+  loadSlotCalendar();
+}
+
+// Open slot modal for a cell (create new)
+function openSlotCell(boatId, date) {
+  _editingSlot = null;
+  var boat = (_allBoats || []).find(function(b) { return b.id === boatId; });
+  document.getElementById("slotModalTitle").textContent = s('slot.newTitle');
+  document.getElementById("slotModalBoatName").textContent = boat ? boat.name : boatId;
+  document.getElementById("smDate").value = date;
+  document.getElementById("smStartTime").value = '18:00';
+  document.getElementById("smEndTime").value = '21:00';
+  document.getElementById("smNote").value = '';
+  document.getElementById("smDeleteBtn").classList.add("hidden");
+  document.getElementById("slotBookedInfo").classList.add("hidden");
+  _editingSlot = { boatId: boatId };
+  applyStrings(document.getElementById("slotModal"));
+  openModal("slotModal");
+}
+
+// Open slot modal for existing slot (edit)
+function openSlotModal(slotId) {
+  var sl = _slotData.find(function(s) { return s.id === slotId; });
+  if (!sl) return;
+  var boat = (_allBoats || []).find(function(b) { return b.id === sl.boatId; });
+  var title = document.getElementById("slotModalTitle");
+  title.setAttribute('data-s', 'slot.editTitle');
+  title.textContent = s('slot.editTitle');
+  document.getElementById("slotModalBoatName").textContent = boat ? boat.name : sl.boatId;
+  document.getElementById("smDate").value = sl.date;
+  document.getElementById("smStartTime").value = sl.startTime;
+  document.getElementById("smEndTime").value = sl.endTime;
+  document.getElementById("smNote").value = sl.note || '';
+  document.getElementById("smDeleteBtn").classList.remove("hidden");
+  if (sl.bookedByKennitala) {
+    document.getElementById("slotBookedInfo").classList.remove("hidden");
+    document.getElementById("slotBookedInfo").textContent = s('slot.bookedBy') + ': ' + (sl.bookedByName || sl.bookedByKennitala);
+  } else {
+    document.getElementById("slotBookedInfo").classList.add("hidden");
+  }
+  _editingSlot = { boatId: sl.boatId, slotId: sl.id };
+  applyStrings(document.getElementById("slotModal"));
+  openModal("slotModal");
+}
+
+async function saveCurrentSlot() {
+  if (!_editingSlot) return;
+  var date = document.getElementById("smDate").value;
+  var startTime = document.getElementById("smStartTime").value;
+  var endTime = document.getElementById("smEndTime").value;
+  if (!date || !startTime || !endTime) { toast(s('slot.missingFields'), 'err'); return; }
+  try {
+    await apiPost("saveSlot", {
+      boatId: _editingSlot.boatId,
+      slotId: _editingSlot.slotId || '',
+      date: date, startTime: startTime, endTime: endTime,
+      note: document.getElementById("smNote").value || '',
+    });
+    closeModal("slotModal", true);
+    toast(s('toast.saved'));
+    loadSlotCalendar();
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+async function deleteCurrentSlot() {
+  if (!_editingSlot || !_editingSlot.slotId) return;
+  if (!(await ymConfirm(s('slot.confirmDelete')))) return;
+  try {
+    await apiPost("deleteSlot", { slotId: _editingSlot.slotId });
+    closeModal("slotModal", true);
+    toast(s('toast.deleted'));
+    loadSlotCalendar();
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// Open slot modal for NEW slot creation (requires a specific boat selected in filter)
+function openNewSlotModal() {
+  var boatId = document.getElementById("slotBoatFilter").value;
+  if (!boatId) { toast(s('slot.selectBoatFirst'), 'err'); return; }
+  var boat = (_allBoats || []).find(function(b) { return b.id === boatId; });
+  if (!boat) return;
+  var title = document.getElementById("slotModalTitle");
+  title.setAttribute('data-s', 'slot.newTitle');
+  title.textContent = s('slot.newTitle');
+  document.getElementById("slotModalBoatName").textContent = boat.name;
+  document.getElementById("smDate").value = new Date().toISOString().slice(0, 10);
+  document.getElementById("smStartTime").value = '18:00';
+  document.getElementById("smEndTime").value = '21:00';
+  document.getElementById("smNote").value = '';
+  document.getElementById("smDeleteBtn").classList.add("hidden");
+  document.getElementById("slotBookedInfo").classList.add("hidden");
+  _editingSlot = { boatId: boatId, slotId: '' };
+  applyStrings(document.getElementById("slotModal"));
+  openModal("slotModal");
+}
+
+// Recurring slot creation
+function openRecurringSlotModal() {
+  var cat = document.getElementById("slotCatFilter").value;
+  var catBoats = (_allBoats || []).filter(function(b) { return b.category === cat && boolVal(b.slotSchedulingEnabled); });
+  var sel = document.getElementById("rsBoat");
+  sel.innerHTML = '';
+  catBoats.forEach(function(b) { sel.innerHTML += '<option value="' + esc(b.id) + '">' + esc(b.name) + '</option>'; });
+  // Reset checkboxes
+  document.querySelectorAll('#rsDays input').forEach(function(cb) { cb.checked = false; });
+  document.getElementById("rsStartTime").value = '18:00';
+  document.getElementById("rsEndTime").value = '21:00';
+  var today = new Date().toISOString().slice(0, 10);
+  document.getElementById("rsFromDate").value = today;
+  var endD = new Date(); endD.setMonth(endD.getMonth() + 3);
+  document.getElementById("rsToDate").value = endD.toISOString().slice(0, 10);
+  document.getElementById("rsNote").value = '';
+  document.getElementById("rsPreview").textContent = '';
+  applyStrings(document.getElementById("recurSlotModal"));
+  openModal("recurSlotModal");
+}
+
+function previewRecurringSlots() {
+  var days = [];
+  document.querySelectorAll('#rsDays input:checked').forEach(function(cb) { days.push(parseInt(cb.value)); });
+  var from = document.getElementById("rsFromDate").value;
+  var to = document.getElementById("rsToDate").value;
+  if (!days.length || !from || !to) { document.getElementById("rsPreview").textContent = s('slot.selectDays'); return; }
+  var count = 0;
+  var d = new Date(from + 'T00:00:00');
+  var end = new Date(to + 'T00:00:00');
+  while (d <= end) {
+    if (days.indexOf(d.getDay()) !== -1) count++;
+    d.setDate(d.getDate() + 1);
+  }
+  document.getElementById("rsPreview").textContent = s('slot.previewCount', { count: count });
+}
+
+async function saveRecurringSlots() {
+  var boatId = document.getElementById("rsBoat").value;
+  var days = [];
+  document.querySelectorAll('#rsDays input:checked').forEach(function(cb) { days.push(parseInt(cb.value)); });
+  var startTime = document.getElementById("rsStartTime").value;
+  var endTime = document.getElementById("rsEndTime").value;
+  var fromDate = document.getElementById("rsFromDate").value;
+  var toDate = document.getElementById("rsToDate").value;
+  if (!boatId || !days.length || !startTime || !endTime || !fromDate || !toDate) {
+    toast(s('slot.missingFields'), 'err'); return;
+  }
+  try {
+    var res = await apiPost("saveRecurringSlots", {
+      boatId: boatId, daysOfWeek: days,
+      startTime: startTime, endTime: endTime,
+      fromDate: fromDate, toDate: toDate,
+      note: document.getElementById("rsNote").value || '',
+    });
+    closeModal("recurSlotModal", true);
+    toast(s('slot.created', { count: res.count || 0 }));
+    loadSlotCalendar();
+  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
+}
+
+// ── ROWING PASSPORT ADMIN ─────────────────────────────────────────────────────
+let _passportDef = null;
+let _passportDirty = false;
+// Sort mode: 'cat-mod' = Category → Module, 'mod-cat' = Module → Category
+let _passportSortMode = 'cat-mod';
+
+async function renderPassportAdmin() {
+  const card = document.getElementById('passportAdminPreview');
+  card.innerHTML = '<div class="loading-state"><span class="spinner"></span></div>';
+  try {
+    const res = await apiGet('getRowingPassport', {});
+    _passportDef = res.definition || { version: 1, passports: [] };
+    _passportDirty = false;
+    drawPassportEditor();
+  } catch(e) { card.innerHTML = '<div style="color:var(--red)">' + esc(e.message) + '</div>'; }
+}
+
+// In-memory edit targets for passport modals.
+let _ppEditing = { pi: null, ci: null, ii: null, mode: null };
+
+// Renders a single item row in the admin preview (used by both sort modes).
+// `pi, ci, ii` are the ORIGINAL indices into _passportDef so the edit/retire
+// handlers operate on the real underlying item regardless of display order.
+function _ppRenderItemRow(p, cat, it, pi, ci, ii) {
+  const retired = !!it.retired;
+  const assessment = it.assessment || 'practical';
+  const itemNameEN = it.name?.EN || it.id;
+  const itemNameIS = it.name?.IS || '';
+  const descEN = (it.desc && it.desc.EN) || '';
+  const descIS = (it.desc && it.desc.IS) || '';
+  const descPreview = descEN || descIS || '';
+  const assessmentLabel = assessment === 'theory' ? s('passport.theory') : s('passport.practical');
+  const assessmentColor = assessment === 'theory' ? 'var(--brass)' : 'var(--muted)';
+  const moduleNum = Number(it.module || 0);
+  const moduleBadge = moduleNum > 0
+    ? `<span style="font-size:9px;color:var(--brass-fg);border:1px solid var(--brass);border-radius:3px;padding:1px 4px;margin-left:4px;text-transform:uppercase;letter-spacing:.5px">${esc(s('passport.moduleShort'))} ${moduleNum}</span>`
+    : '';
+  return `<div style="border-top:1px solid var(--border);padding:8px 0;display:flex;align-items:flex-start;gap:8px;${retired ? 'opacity:.5' : ''}">
+    <div style="flex:1;min-width:0">
+      <div style="font-size:12px;font-weight:500">
+        ${esc(itemNameEN)}${itemNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(itemNameIS)}</span>` : ''}
+        <span style="font-size:9px;color:${assessmentColor};border:1px solid ${assessmentColor};border-radius:3px;padding:1px 4px;margin-left:6px;text-transform:uppercase;letter-spacing:.5px">${esc(assessmentLabel)}</span>
+        ${moduleBadge}
+        ${retired ? `<span style="font-size:9px;color:var(--red);border:1px solid var(--red);border-radius:3px;padding:1px 4px;margin-left:4px;text-transform:uppercase;letter-spacing:.5px">${esc(s('passport.retiredBadge'))}</span>` : ''}
+      </div>
+      <div style="font-size:10px;color:var(--muted);margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
+        ${descPreview ? esc(descPreview) : `<em>${esc(s('passport.noDescription'))}</em>`}
+      </div>
+      <div style="font-size:9px;color:var(--faint);margin-top:2px">${esc(it.id)}</div>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:4px">
+      <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="${ii}" data-s="passport.editItem">Edit</button>
+      <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="ppToggleRetire" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="${ii}">${retired ? esc(s('passport.unretire')) : esc(s('passport.retire'))}</button>
+    </div>
+  </div>`;
+}
+
+// Flatten all items of a passport, preserving original (ci, ii) coordinates.
+function _ppFlattenItems(p) {
+  const out = [];
+  (p.categories || []).forEach((cat, ci) => {
+    (cat.items || []).forEach((it, ii) => {
+      out.push({ cat, ci, it, ii });
+    });
+  });
+  return out;
+}
+
+function ppSetSortMode(mode) {
+  _passportSortMode = (mode === 'mod-cat') ? 'mod-cat' : 'cat-mod';
+  drawPassportEditor();
+}
+window.ppSetSortMode = ppSetSortMode;
+
+function drawPassportEditor() {
+  const card = document.getElementById('passportAdminPreview');
+  const def = _passportDef;
+  if (!def || !(def.passports || []).length) {
+    card.innerHTML = `<div style="color:var(--muted);padding:12px 0">No passports configured. Import a CSV to get started.</div>
+      <div style="margin-top:12px;display:flex;gap:8px;align-items:center">
+        <button class="btn btn-primary" style="font-size:11px" data-admin-click="ppSaveDef" data-s="passport.save">Save changes</button>
+        <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
+      </div>`;
+    applyStrings(card);
+    return;
+  }
+  const sortMode = _passportSortMode;
+  const isCatMod = sortMode !== 'mod-cat';
+  let html = '';
+
+  // Sort-mode toggle (shared across all passports in the editor)
+  html += `<div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
+    <span style="font-size:10px;color:var(--muted);letter-spacing:.5px;text-transform:uppercase" data-s="passport.sortBy">Sort by</span>
+    <button class="btn ${isCatMod ? 'btn-primary' : 'btn-secondary'}" style="font-size:10px;padding:3px 10px" data-admin-click="ppSetSortMode" data-admin-arg="cat-mod" data-s="passport.sortCatMod">Category → Module</button>
+    <button class="btn ${!isCatMod ? 'btn-primary' : 'btn-secondary'}" style="font-size:10px;padding:3px 10px" data-admin-click="ppSetSortMode" data-admin-arg="mod-cat" data-s="passport.sortModCat">Module → Category</button>
+  </div>`;
+
+  (def.passports || []).forEach((p, pi) => {
+    const totalItems   = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => !i.retired).length, 0);
+    const retiredItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i =>  i.retired).length, 0);
+    const reqSigs   = Number(p.requiredSigs || 2);
+    const promoteId = p.promoteCertId || 'rowing_division';
+    const nameEN = p.name?.EN || p.id;
+    const nameIS = p.name?.IS || '';
+    html += `<div style="border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:14px;background:var(--card)">
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:10px">
+        <div style="flex:1;min-width:0">
+          <div style="font-weight:700;font-size:14px;color:var(--text)">${esc(nameEN)} <span style="color:var(--muted);font-weight:400;font-size:10px">(${esc(p.id)})</span></div>
+          ${nameIS ? `<div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(nameIS)}</div>` : ''}
+          <div style="font-size:10px;color:var(--muted);margin-top:6px">
+            v${def.version || 1} ·
+            ${totalItems} ${s('passport.activeCount')}${retiredItems ? ' · ' + retiredItems + ' ' + s('passport.retiredBadge') : ''} ·
+            ${s('passport.requiresSignatures', { n: reqSigs })} ·
+            ${s('passport.promotesTo', { cert: esc(promoteId) })} (${esc(p.fromSub || 'restricted')} → ${esc(p.toSub || 'released')})
+          </div>
+        </div>
+        <button class="btn btn-secondary" style="font-size:10px;padding:4px 10px;white-space:nowrap" data-admin-click="openPassportSettingsModal" data-admin-arg="${pi}" data-s="passport.editSettings">Edit passport settings</button>
+      </div>`;
+
+    if (isCatMod) {
+      // Category → Module: preserve original category order; within each category
+      // sort items by (module asc, name asc). Adds/edits stay anchored per-category.
+      (p.categories || []).forEach((cat, ci) => {
+        const catNameEN = cat.name?.EN || cat.id;
+        const catNameIS = cat.name?.IS || '';
+        html += `<div style="margin-top:10px;border:1px solid var(--border);border-radius:6px;padding:10px;background:var(--surface)">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+            <div style="flex:1;min-width:0">
+              <div style="font-weight:600;font-size:12px">${esc(catNameEN)}${catNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(catNameIS)}</span>` : ''}</div>
+              <div style="font-size:9px;color:var(--muted)">${esc(cat.id)}</div>
+            </div>
+            <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-s="passport.editCategory">Edit category</button>
+          </div>`;
+
+        const items = (cat.items || []).map((it, ii) => ({ it, ii }));
+        if (!items.length) {
+          html += `<div style="font-size:10px;color:var(--muted);padding:6px 0">— no items —</div>`;
+        } else {
+          items.sort((a, b) => {
+            const ma = Number(a.it.module || 0);
+            const mb = Number(b.it.module || 0);
+            if (ma !== mb) return ma - mb;
+            return String(a.it.name?.EN || '').localeCompare(String(b.it.name?.EN || ''));
+          });
+          items.forEach(({ it, ii }) => {
+            html += _ppRenderItemRow(p, cat, it, pi, ci, ii);
+          });
+        }
+
+        html += `<div style="margin-top:8px">
+          <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="null" data-s="passport.addItem">+ Add item</button>
+        </div></div>`;
+      });
+    } else {
+      // Module → Category: bucket all items by module; within each module bucket
+      // group by their original category so edit handlers still line up. Module 0
+      // (unassigned) is shown last as a dedicated bucket.
+      const flat = _ppFlattenItems(p);
+      const modKeys = {};
+      flat.forEach(entry => {
+        const m = Number(entry.it.module || 0);
+        if (!modKeys[m]) modKeys[m] = [];
+        modKeys[m].push(entry);
+      });
+      const orderedMods = Object.keys(modKeys).map(Number).sort((a, b) => {
+        if (a === 0) return 1;  // unassigned last
+        if (b === 0) return -1;
+        return a - b;
+      });
+
+      if (!orderedMods.length) {
+        html += `<div style="font-size:10px;color:var(--muted);padding:8px 0">— no items —</div>`;
+      }
+
+      orderedMods.forEach(modNum => {
+        const bucket = modKeys[modNum];
+        const modLabel = modNum > 0
+          ? `${s('passport.moduleLabel')} ${modNum}`
+          : s('passport.unassignedModule');
+        html += `<div style="margin-top:10px;border:1px solid var(--border);border-radius:6px;padding:10px;background:var(--surface)">
+          <div style="font-weight:700;font-size:12px;color:var(--brass-fg);letter-spacing:.5px;text-transform:uppercase;margin-bottom:8px">${esc(modLabel)} <span style="color:var(--muted);font-weight:400;font-size:10px">· ${bucket.length}</span></div>`;
+
+        // Sub-group by category (preserving the passport's category order)
+        const byCat = {};
+        bucket.forEach(entry => {
+          if (!byCat[entry.ci]) byCat[entry.ci] = [];
+          byCat[entry.ci].push(entry);
+        });
+        const catOrder = Object.keys(byCat).map(Number).sort((a, b) => a - b);
+        catOrder.forEach(ci => {
+          const cat = p.categories[ci];
+          const catNameEN = cat.name?.EN || cat.id;
+          const catNameIS = cat.name?.IS || '';
+          html += `<div style="margin-top:8px;padding-left:8px;border-left:2px solid var(--border)">
+            <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+              <div style="flex:1;min-width:0">
+                <div style="font-weight:600;font-size:11px">${esc(catNameEN)}${catNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(catNameIS)}</span>` : ''}</div>
+              </div>
+              <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-s="passport.editCategory">Edit category</button>
+            </div>`;
+          const entries = byCat[ci].slice().sort((a, b) =>
+            String(a.it.name?.EN || '').localeCompare(String(b.it.name?.EN || '')));
+          entries.forEach(({ it, ii }) => {
+            html += _ppRenderItemRow(p, cat, it, pi, ci, ii);
+          });
+          html += `</div>`;
+        });
+
+        html += `</div>`;
+      });
+
+      // In Module → Category mode, "+Add item" is shown per-category at the bottom
+      // so authors can still create items (they'll be assigned a module via the modal).
+      html += `<div style="margin-top:10px;border:1px dashed var(--border);border-radius:6px;padding:10px;background:var(--surface)">
+        <div style="font-size:10px;color:var(--muted);margin-bottom:6px" data-s="passport.addItemHint">Add a new item to a category:</div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap">`;
+      (p.categories || []).forEach((cat, ci) => {
+        const catNameEN = cat.name?.EN || cat.id;
+        html += `<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="null">+ ${esc(catNameEN)}</button>`;
+      });
+      html += `</div></div>`;
+    }
+
+    html += `<div style="margin-top:12px">
+      <button class="btn btn-secondary" style="font-size:10px;padding:3px 10px" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="null" data-s="passport.addCategory">+ Add category</button>
+    </div>`;
+    html += '</div>';
+  });
+
+  html += `<div style="margin-top:14px;display:flex;gap:8px;align-items:center">
+    <button class="btn btn-primary" style="font-size:11px" data-admin-click="ppSaveDef" data-s="passport.save">Save changes</button>
+    <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
+  </div>`;
+  card.innerHTML = html;
+  applyStrings(card);
+}
+
+function _ppMarkDirty() { _passportDirty = true; const m = document.getElementById('ppDirtyMark'); if (m) m.textContent = '● unsaved'; }
+function _ppSlug(s) { return String(s || '').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') || ('item-' + Date.now().toString(36)); }
+
+// Existing items flagged with __new were added in this session and can be
+// spliced on delete; without the flag we soft-delete (retire) instead so
+// any backend sign-offs referencing the id remain valid.
+function _ppIsNewItem(it) { return !!(it && it.__new); }
+
+// ── Passport settings modal ────────────────────────────────────────────────
+function openPassportSettingsModal(pi) {
+  const p = _passportDef && _passportDef.passports[pi];
+  if (!p) return;
+  _ppEditing = { pi, ci: null, ii: null, mode: 'settings' };
+  document.getElementById('ppsId').value             = p.id || '';
+  document.getElementById('ppsNameEN').value         = (p.name && p.name.EN) || '';
+  document.getElementById('ppsNameIS').value         = (p.name && p.name.IS) || '';
+  document.getElementById('ppsRequiredSigs').value   = Number(p.requiredSigs || 2);
+  document.getElementById('ppsPromoteCertId').value  = p.promoteCertId || 'rowing_division';
+  document.getElementById('ppsFromSub').value        = p.fromSub || 'restricted';
+  document.getElementById('ppsToSub').value          = p.toSub || 'released';
+  openModal('passportSettingsModal');
+}
+
+function savePassportSettings() {
+  const pi = _ppEditing.pi;
+  const p  = _passportDef && _passportDef.passports[pi];
+  if (!p) return;
+  const nameEN = document.getElementById('ppsNameEN').value.trim();
+  if (!nameEN) { toast(s('passport.nameRequired'), 'err'); return; }
+  let req = parseInt(document.getElementById('ppsRequiredSigs').value, 10);
+  if (!(req >= 1)) req = 1;
+  p.name = p.name || {};
+  p.name.EN = nameEN;
+  p.name.IS = document.getElementById('ppsNameIS').value.trim();
+  p.requiredSigs  = req;
+  p.promoteCertId = document.getElementById('ppsPromoteCertId').value.trim() || 'rowing_division';
+  p.fromSub       = document.getElementById('ppsFromSub').value.trim() || 'restricted';
+  p.toSub         = document.getElementById('ppsToSub').value.trim() || 'released';
+  _ppMarkDirty();
+  closeModal('passportSettingsModal', true);
+  drawPassportEditor();
+}
+
+// ── Passport item modal (add + edit) ───────────────────────────────────────
+function openPassportItemModal(pi, ci, ii) {
+  const cat = _passportDef && _passportDef.passports[pi] && _passportDef.passports[pi].categories[ci];
+  if (!cat) return;
+  const adding = (ii === null || ii === undefined);
+  _ppEditing = { pi, ci, ii: adding ? null : ii, mode: adding ? 'item-add' : 'item-edit' };
+  const it = adding ? { id: '', name: { EN: '', IS: '' }, desc: { EN: '', IS: '' }, assessment: 'practical', module: 0, retired: false } : cat.items[ii];
+  document.getElementById('passportItemModalTitle').textContent =
+    adding ? s('passport.newItem') : s('passport.itemTitle');
+  document.getElementById('ppiId').value        = it.id || '';
+  document.getElementById('ppiNameEN').value    = (it.name && it.name.EN) || '';
+  document.getElementById('ppiNameIS').value    = (it.name && it.name.IS) || '';
+  document.getElementById('ppiDescEN').value    = (it.desc && it.desc.EN) || '';
+  document.getElementById('ppiDescIS').value    = (it.desc && it.desc.IS) || '';
+  document.getElementById('ppiAssessment').value = it.assessment || 'practical';
+  document.getElementById('ppiModule').value    = Number(it.module || 0) || '';
+  document.getElementById('ppiRetired').checked = !!it.retired;
+  document.getElementById('ppiDeleteBtn').classList.toggle('hidden', adding);
+  openModal('passportItemModal');
+}
+
+function savePassportItem() {
+  const { pi, ci, mode } = _ppEditing;
+  const cat = _passportDef && _passportDef.passports[pi] && _passportDef.passports[pi].categories[ci];
+  if (!cat) return;
+  const nameEN = document.getElementById('ppiNameEN').value.trim();
+  if (!nameEN) { toast(s('passport.nameRequired'), 'err'); return; }
+  let modNum = parseInt(document.getElementById('ppiModule').value, 10);
+  if (!(modNum >= 0)) modNum = 0;
+  const payload = {
+    name: {
+      EN: nameEN,
+      IS: document.getElementById('ppiNameIS').value.trim(),
+    },
+    desc: {
+      EN: document.getElementById('ppiDescEN').value.trim(),
+      IS: document.getElementById('ppiDescIS').value.trim(),
+    },
+    assessment: document.getElementById('ppiAssessment').value || 'practical',
+    module: modNum,
+    retired: document.getElementById('ppiRetired').checked,
+  };
+  if (mode === 'item-add') {
+    const id = _ppSlug(nameEN);
+    cat.items = cat.items || [];
+    cat.items.push({ id, __new: true, ...payload });
+  } else {
+    const it = cat.items[_ppEditing.ii];
+    if (!it) return;
+    it.name = payload.name;
+    it.desc = payload.desc;
+    it.assessment = payload.assessment;
+    it.module = payload.module;
+    it.retired = payload.retired;
+  }
+  _ppMarkDirty();
+  closeModal('passportItemModal', true);
+  drawPassportEditor();
+}
+
+async function deletePassportItem() {
+  const { pi, ci, ii } = _ppEditing;
+  const cat = _passportDef && _passportDef.passports[pi] && _passportDef.passports[pi].categories[ci];
+  if (!cat || ii === null || ii === undefined) return;
+  const it = cat.items[ii];
+  if (!it) return;
+  if (!await ymConfirm(s('passport.confirmDeleteItem'))) return;
+  if (_ppIsNewItem(it)) {
+    cat.items.splice(ii, 1);
+    toast(s('passport.itemDeleted'));
+  } else {
+    it.retired = true;
+    toast(s('passport.itemRetiredSoft'));
+  }
+  _ppMarkDirty();
+  closeModal('passportItemModal', true);
+  drawPassportEditor();
+}
+
+// ── Passport category modal (add + edit) ───────────────────────────────────
+function openPassportCategoryModal(pi, ci) {
+  const p = _passportDef && _passportDef.passports[pi];
+  if (!p) return;
+  const adding = (ci === null || ci === undefined);
+  _ppEditing = { pi, ci: adding ? null : ci, ii: null, mode: adding ? 'cat-add' : 'cat-edit' };
+  const cat = adding ? { id: '', name: { EN: '', IS: '' } } : p.categories[ci];
+  document.getElementById('passportCategoryModalTitle').textContent =
+    adding ? s('passport.newCategory') : s('passport.categoryTitle');
+  document.getElementById('ppcId').value     = cat.id || '';
+  document.getElementById('ppcNameEN').value = (cat.name && cat.name.EN) || '';
+  document.getElementById('ppcNameIS').value = (cat.name && cat.name.IS) || '';
+  document.getElementById('ppcDeleteBtn').classList.toggle('hidden', adding);
+  openModal('passportCategoryModal');
+}
+
+function savePassportCategory() {
+  const { pi, mode } = _ppEditing;
+  const p = _passportDef && _passportDef.passports[pi];
+  if (!p) return;
+  const nameEN = document.getElementById('ppcNameEN').value.trim();
+  if (!nameEN) { toast(s('passport.nameRequired'), 'err'); return; }
+  const nameIS = document.getElementById('ppcNameIS').value.trim();
+  if (mode === 'cat-add') {
+    const id = _ppSlug(nameEN);
+    p.categories = p.categories || [];
+    p.categories.push({ id, name: { EN: nameEN, IS: nameIS }, items: [] });
+  } else {
+    const cat = p.categories[_ppEditing.ci];
+    if (!cat) return;
+    cat.name = cat.name || {};
+    cat.name.EN = nameEN;
+    cat.name.IS = nameIS;
+  }
+  _ppMarkDirty();
+  closeModal('passportCategoryModal', true);
+  drawPassportEditor();
+}
+
+async function deletePassportCategory() {
+  const { pi, ci } = _ppEditing;
+  const p = _passportDef && _passportDef.passports[pi];
+  if (!p || ci === null || ci === undefined) return;
+  if (!await ymConfirm(s('passport.confirmDeleteCategory'))) return;
+  p.categories.splice(ci, 1);
+  _ppMarkDirty();
+  toast(s('passport.categoryDeleted'));
+  closeModal('passportCategoryModal', true);
+  drawPassportEditor();
+}
+
+function ppToggleRetire(pi, ci, ii) {
+  const it = _passportDef.passports[pi].categories[ci].items[ii];
+  it.retired = !it.retired;
+  _ppMarkDirty();
+  drawPassportEditor();
+}
+
+async function ppSaveDef() {
+  if (!_passportDef) return;
+  // Bump version on save
+  _passportDef.version = (_passportDef.version || 0) + 1;
+  // Strip transient __new flags before sending to backend
+  (_passportDef.passports || []).forEach(p => {
+    (p.categories || []).forEach(c => {
+      (c.items || []).forEach(it => { if (it.__new) delete it.__new; });
+    });
+  });
+  try {
+    await apiPost('saveRowingPassportDef', { definition: _passportDef });
+    _passportDirty = false;
+    toast(s('passport.saved'));
+    renderPassportAdmin();
+  } catch(e) { toast(e.message, 'err'); }
+}
+
+window.openPassportSettingsModal = openPassportSettingsModal;
+window.savePassportSettings      = savePassportSettings;
+window.openPassportItemModal     = openPassportItemModal;
+window.savePassportItem          = savePassportItem;
+window.deletePassportItem        = deletePassportItem;
+window.openPassportCategoryModal = openPassportCategoryModal;
+window.savePassportCategory      = savePassportCategory;
+window.deletePassportCategory    = deletePassportCategory;
+window.ppToggleRetire            = ppToggleRetire;
+window.ppSaveDef                 = ppSaveDef;
+
+async function passportImportCsv() {
+  const file = document.getElementById('passportCsvFile').files[0];
+  if (!file) { toast('Choose a CSV file first', 'err'); return; }
+  const text = await file.text();
+  if (!(await ymConfirm('Import this CSV? Items missing from the CSV will be marked retired (not deleted).'))) return;
+  try {
+    await apiPost('importRowingPassportCsv', { csv: text });
+    toast('Passport imported.');
+    renderPassportAdmin();
+  } catch(e) { toast(e.message, 'err'); }
+}
+
+async function passportExportCsv() {
+  try {
+    const res = await apiGet('getRowingPassport', {});
+    const def = res.definition || { passports: [] };
+    const lines = ['passport_id,category_id,category_label_en,category_label_is,item_id,assessment,module,item_label_en,item_label_is,description_en,description_is'];
+    const q = v => '"' + String(v || '').replace(/"/g,'""') + '"';
+    (def.passports || []).forEach(p => {
+      (p.categories || []).forEach(cat => {
+        (cat.items || []).forEach(it => {
+          if (it.retired) return;
+          const mod = Number(it.module || 0) || '';
+          lines.push([p.id, cat.id, cat.name?.EN || '', cat.name?.IS || '', it.id, it.assessment || 'practical', mod, it.name?.EN || '', it.name?.IS || '', it.desc?.EN || '', it.desc?.IS || ''].map(q).join(','));
+        });
+      });
+    });
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'rowing-passport.csv';
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch(e) { toast(e.message, 'err'); }
+}
+
+// ── Utilities ──────────────────────────────────────────────────────────────────
+// bool, esc, parseJson, toast, chunk, openModal, closeModal, todayISO
+// all come from shared/api.js and shared/ui.js — no local redefinitions needed.
+
+// ─── Named helpers for state-mutation handlers ───────────────────────────────
+function _setArrField(arrName, idx, field, value, asInt) {
+  var a = window[arrName]; if (!a || !a[idx]) return;
+  a[idx][field] = asInt ? (parseInt(value) || 0) : value;
+}
+function _setAtRoleField(idx, field, value) {
+  _setArrField('_atRoles', idx, field, value, field === 'slots');
+}
+function _setVolRoleField(idx, field, value) {
+  _setArrField('_volRoles', idx, field, value, field === 'slots');
+}
+function _setAtSubtypeField(idx, field, value) {
+  _setArrField('_atSubtypes', idx, field, value, false);
+}
+function _setAtStBsField(idx, field, value) {
+  if (typeof ensureAtStBs !== 'function') return;
+  ensureAtStBs(idx)[field] = value;
+}
+function _removeAtRole(idx)    { window._atRoles.splice(+idx, 1);    renderAtRoles();    }
+function _removeAtSubtype(idx) { window._atSubtypes.splice(+idx, 1); renderAtSubtypes(); }
+function _removeVolRole(idx)   { window._volRoles.splice(+idx, 1);   renderVolRoles();   }
+function _timeFormatSubtype(el, idx, field) {
+  var v = el.value.replace(/[^0-9]/g, '');
+  if (v.length >= 3) v = v.slice(0, 2) + ':' + v.slice(2);
+  el.value = v;
+  _setAtSubtypeField(idx, field, v);
+}
+function _showElement(id)       { var e = document.getElementById(id); if (e) e.classList.remove('hidden'); }
+function _removeElementById(id) { var e = document.getElementById(id); if (e) e.remove(); }
+
+// ─── Delegated handlers for data-admin-* attrs ──────────────────────────────
+(function () {
+  if (typeof document === 'undefined' || document._adminListeners) return;
+  document._adminListeners = true;
+
+  function argsFrom(el) {
+    var a = [];
+    if ('adminArg'  in el.dataset) a.push(el.dataset.adminArg);
+    if ('adminArg2' in el.dataset) a.push(el.dataset.adminArg2);
+    if ('adminArg3' in el.dataset) a.push(el.dataset.adminArg3);
+    // 'null' string → JS null (for openPassport* handlers)
+    return a.map(function (v) { return v === 'null' ? null : v; });
+  }
+
+  document.addEventListener('click', function (e) {
+    // stopPropagation-only marker
+    if (e.target.closest('[data-admin-nobubble]')) { e.stopPropagation(); return; }
+
+    // Modal close-self (click on the overlay element itself)
+    var cs = e.target.closest('[data-admin-close-self]');
+    if (cs && e.target === cs) { closeModal(cs.id); return; }
+
+    // Explicit close target
+    var cl = e.target.closest('[data-admin-close]');
+    if (cl) { closeModal(cl.dataset.adminClose); return; }
+
+    // Toggle section (expandable panels)
+    var ts = e.target.closest('[data-admin-toggle-section]');
+    if (ts) { if (typeof toggleSection === 'function') toggleSection(ts); return; }
+
+    // Show element by id
+    var se = e.target.closest('[data-admin-show-el]');
+    if (se) { _showElement(se.dataset.adminShowEl); return; }
+
+    // Remove element by id
+    var re = e.target.closest('[data-admin-remove-el]');
+    if (re) { _removeElementById(re.dataset.adminRemoveEl); return; }
+
+    // Click handler that needs the element (e.g. removeClubCalRow(this))
+    var cle = e.target.closest('[data-admin-click-el]');
+    if (cle && typeof window[cle.dataset.adminClickEl] === 'function') {
+      window[cle.dataset.adminClickEl](cle);
+      return;
+    }
+
+    // Generic click with 0-3 args
+    var clk = e.target.closest('[data-admin-click]');
+    if (clk && typeof window[clk.dataset.adminClick] === 'function') {
+      window[clk.dataset.adminClick].apply(null, argsFrom(clk));
+    }
+  });
+
+  document.addEventListener('change', function (e) {
+    // Preset-change: calls fn(value) then resets the select
+    var p = e.target.closest('[data-admin-preset-change]');
+    if (p && typeof window[p.dataset.adminPresetChange] === 'function') {
+      window[p.dataset.adminPresetChange](p.value);
+      p.value = '';
+      return;
+    }
+
+    // State-mutation setters on array+idx+field
+    var ar = e.target.closest('[data-admin-set-at-role]');
+    if (ar) { _setAtRoleField(ar.dataset.adminIdx, ar.dataset.adminSetAtRole, ar.value); return; }
+    var vr = e.target.closest('[data-admin-set-vol-role]');
+    if (vr) { _setVolRoleField(vr.dataset.adminIdx, vr.dataset.adminSetVolRole, vr.value); return; }
+    var st = e.target.closest('[data-admin-set-at-subtype]');
+    if (st) { _setAtSubtypeField(st.dataset.adminIdx, st.dataset.adminSetAtSubtype, st.value); return; }
+    var sb = e.target.closest('[data-admin-set-at-stbs]');
+    if (sb) { _setAtStBsField(sb.dataset.adminIdx, sb.dataset.adminSetAtStbs, sb.value); return; }
+
+    // Day-toggle checkbox
+    var dt = e.target.closest('[data-admin-toggle-atstbs-day]');
+    if (dt && typeof toggleAtStBsDay === 'function') {
+      toggleAtStBsDay(+dt.dataset.adminIdx, +dt.dataset.adminDayv, dt.checked);
+      return;
+    }
+
+    // change-check (checkbox → fn(checked))
+    var cc = e.target.closest('[data-admin-change-check]');
+    if (cc && typeof window[cc.dataset.adminChangeCheck] === 'function') {
+      window[cc.dataset.adminChangeCheck](cc.checked);
+      return;
+    }
+
+    // change-val (fn(value))
+    var cv = e.target.closest('[data-admin-change-val]');
+    if (cv && typeof window[cv.dataset.adminChangeVal] === 'function') {
+      window[cv.dataset.adminChangeVal](cv.value);
+      return;
+    }
+
+    // change-el (fn(element))
+    var ce = e.target.closest('[data-admin-change-el]');
+    if (ce && typeof window[ce.dataset.adminChangeEl] === 'function') {
+      window[ce.dataset.adminChangeEl](ce);
+      return;
+    }
+
+    // No-arg change
+    var c = e.target.closest('[data-admin-change]');
+    if (c && typeof window[c.dataset.adminChange] === 'function') {
+      window[c.dataset.adminChange]();
+    }
+  });
+
+  document.addEventListener('input', function (e) {
+    // Time-format + subtype assignment
+    var tf = e.target.closest('[data-admin-time-format-subtype]');
+    if (tf) {
+      _timeFormatSubtype(tf, tf.dataset.adminIdx, tf.dataset.adminTimeFormatSubtype);
+      return;
+    }
+
+    // input-val (fn(value))
+    var iv = e.target.closest('[data-admin-input-val]');
+    if (iv && typeof window[iv.dataset.adminInputVal] === 'function') {
+      window[iv.dataset.adminInputVal](iv.value);
+      return;
+    }
+
+    // No-arg input
+    var i = e.target.closest('[data-admin-input]');
+    if (i && typeof window[i.dataset.adminInput] === 'function') {
+      window[i.dataset.adminInput]();
+    }
+  });
+})();

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com https://nominatim.openstreetmap.org https://unpkg.com; frame-src 'self' https://calendar.google.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ýmir — Admin</title>
@@ -9,7 +9,6 @@
   <link rel="preconnect" href="https://script.google.com">
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js"></script>
-  <script>prefetch({Config:['getConfig'],Members:['getMembers']});</script>
   <script src="../shared/strings.js"></script>
   <script src="../shared/boats.js" defer></script>
   <script src="../shared/weather.js" defer></script>
@@ -158,9 +157,9 @@
   <main>
     <!-- Top-level tab bar -->
     <div class="tab-bar" id="topTabBar">
-      <button class="tab-btn active" data-top="members"  onclick="showTopTab('members')"  data-s="admin.tabMembers"></button>
-      <button class="tab-btn"        data-top="settings" onclick="showTopTab('settings')" data-s="admin.tabSettings"></button>
-      <button class="tab-btn"        data-top="payroll"  onclick="showTopTab('payroll')"  data-s="admin.tabPayroll"></button>
+      <button class="tab-btn active" data-top="members"  data-admin-click="showTopTab" data-admin-arg="members"  data-s="admin.tabMembers"></button>
+      <button class="tab-btn"        data-top="settings" data-admin-click="showTopTab" data-admin-arg="settings" data-s="admin.tabSettings"></button>
+      <button class="tab-btn"        data-top="payroll"  data-admin-click="showTopTab" data-admin-arg="payroll"  data-s="admin.tabPayroll"></button>
     </div>
 
     <!-- ══ TOP: MEMBERS ══════════════════════════════════════════════════════ -->
@@ -169,15 +168,15 @@
 
         <div class="flex-center flex-wrap gap-8 mb-14">
           <div class="search-bar flex-1" style="min-width:200px">
-            <input type="text" id="memberSearch" oninput="filterMembers()">
+            <input type="text" id="memberSearch" data-admin-input="filterMembers">
           </div>
-          <button class="btn btn-secondary" onclick="showMemberSub('import')" data-s="admin.importCsv"></button>
-          <button class="btn btn-primary"   onclick="openMemberModal()" data-s="admin.addMember"></button>
+          <button class="btn btn-secondary" data-admin-click="showMemberSub" data-admin-arg="import" data-s="admin.importCsv"></button>
+          <button class="btn btn-primary"   data-admin-click="openMemberModal" data-s="admin.addMember"></button>
         </div>
 
         <div id="memberSubList">
           <div class="col-section">
-            <div class="col-head" onclick="toggleSection(this)">
+            <div class="col-head" data-admin-toggle-section>
               <div class="col-title">MEMBERS <strong id="memberCountLabel"></strong></div>
               <span class="col-toggle">▼</span>
             </div>
@@ -189,7 +188,7 @@
 
         <div id="memberSubImport" class="hidden">
           <div class="flex-center gap-10 mb-12">
-            <button class="btn-ghost" onclick="showMemberSub('list')" data-s="admin.backToList"></button>
+            <button class="btn-ghost" data-admin-click="showMemberSub" data-admin-arg="list" data-s="admin.backToList"></button>
             <span class="text-md text-muted" data-s="admin.importFromCsv"></span>
           </div>
           <div id="importStep1" data-step="1">
@@ -206,7 +205,7 @@
                 <div style="font-size:24px">📄</div>
                 <div class="text-base fw-500">Drop CSV here or click to browse</div>
                 <div class="text-sm text-muted">UTF-8 encoded, comma or semicolon delimited</div>
-                <input type="file" id="csvFile" accept=".csv" class="hidden" onchange="handleCSVUpload(this)">
+                <input type="file" id="csvFile" accept=".csv" class="hidden" data-admin-change-el="handleCSVUpload">
               </label>
             </div>
           </div>
@@ -218,8 +217,8 @@
               <div id="importLists"></div>
               <div id="importError" class="text-red text-md mb-8 hidden" style="padding:8px;background:color-mix(in srgb, var(--red) 8%, transparent);border-radius:4px;border:1px solid color-mix(in srgb, var(--red) 27%, transparent)"></div>
               <div class="btn-row mt-14">
-                <button class="btn btn-secondary" onclick="resetImport()" data-s="admin.backToList"></button>
-                <button class="btn btn-primary" onclick="confirmImport()" id="confirmImportBtn" data-s="admin.confirmImport"></button>
+                <button class="btn btn-secondary" data-admin-click="resetImport" data-s="admin.backToList"></button>
+                <button class="btn btn-primary" data-admin-click="confirmImport" id="confirmImportBtn" data-s="admin.confirmImport"></button>
               </div>
             </div>
           </div>
@@ -228,8 +227,8 @@
               <div class="mb-10" style="font-size:30px">✓</div>
               <div class="text-lg fw-500 text-green" id="importDoneMsg"></div>
               <div style="margin-top:18px">
-                <button class="btn btn-secondary" onclick="resetImport()">Import another</button>
-                <button class="btn btn-primary ml-auto" onclick="showMemberSub('list')" style="margin-left:8px">View members</button>
+                <button class="btn btn-secondary" data-admin-click="resetImport">Import another</button>
+                <button class="btn btn-primary ml-auto" data-admin-click="showMemberSub" data-admin-arg="list" style="margin-left:8px">View members</button>
               </div>
             </div>
           </div>
@@ -242,20 +241,20 @@
     <div id="top-settings" class="hidden">
       <!-- Settings inner tab bar (desktop) -->
       <div class="tab-bar" id="settingsTabBar">
-        <button class="tab-btn active" data-tab="boats"      onclick="showTab('boats')"      data-s="admin.tabBoats"></button>
-        <button class="tab-btn"        data-tab="locations"  onclick="showTab('locations')"  data-s="admin.tabLocations"></button>
-        <button class="tab-btn"        data-tab="checklists" onclick="showTab('checklists')" data-s="admin.tabChecklists"></button>
-        <button class="tab-btn"        data-tab="actTypes"   onclick="showTab('actTypes')"   data-s="admin.tabActTypes"></button>
-        <button class="tab-btn"        data-tab="certs"      onclick="showTab('certs')"      data-s="admin.tabCerts"></button>
-        <button class="tab-btn"        data-tab="flags"      onclick="showTab('flags')"      data-s="admin.tabFlags"></button>
-        <button class="tab-btn"        data-tab="alerts"     onclick="showTab('alerts')"     data-s="admin.tabAlerts"></button>
-        <button class="tab-btn"        data-tab="slotCal"    onclick="showTab('slotCal')"    data-s="admin.tabReservations"></button>
-        <button class="tab-btn"        data-tab="volunteers" onclick="showTab('volunteers')" data-s="admin.tabVolunteers"></button>
-        <button class="tab-btn"        data-tab="passport"   onclick="showTab('passport')"   data-s="passport.adminTitle">Rowing Passport</button>
-        <button class="tab-btn"        data-tab="clubCal"    onclick="showTab('clubCal')"    data-s="admin.tabCalendars"></button>
+        <button class="tab-btn active" data-tab="boats"      data-admin-click="showTab" data-admin-arg="boats"      data-s="admin.tabBoats"></button>
+        <button class="tab-btn"        data-tab="locations"  data-admin-click="showTab" data-admin-arg="locations"  data-s="admin.tabLocations"></button>
+        <button class="tab-btn"        data-tab="checklists" data-admin-click="showTab" data-admin-arg="checklists" data-s="admin.tabChecklists"></button>
+        <button class="tab-btn"        data-tab="actTypes"   data-admin-click="showTab" data-admin-arg="actTypes"   data-s="admin.tabActTypes"></button>
+        <button class="tab-btn"        data-tab="certs"      data-admin-click="showTab" data-admin-arg="certs"      data-s="admin.tabCerts"></button>
+        <button class="tab-btn"        data-tab="flags"      data-admin-click="showTab" data-admin-arg="flags"      data-s="admin.tabFlags"></button>
+        <button class="tab-btn"        data-tab="alerts"     data-admin-click="showTab" data-admin-arg="alerts"     data-s="admin.tabAlerts"></button>
+        <button class="tab-btn"        data-tab="slotCal"    data-admin-click="showTab" data-admin-arg="slotCal"    data-s="admin.tabReservations"></button>
+        <button class="tab-btn"        data-tab="volunteers" data-admin-click="showTab" data-admin-arg="volunteers" data-s="admin.tabVolunteers"></button>
+        <button class="tab-btn"        data-tab="passport"   data-admin-click="showTab" data-admin-arg="passport"   data-s="passport.adminTitle">Rowing Passport</button>
+        <button class="tab-btn"        data-tab="clubCal"    data-admin-click="showTab" data-admin-arg="clubCal"    data-s="admin.tabCalendars"></button>
       </div>
       <!-- Settings tab dropdown (mobile) -->
-      <select class="tab-select" id="settingsTabSelect" onchange="showTab(this.value)">
+      <select class="tab-select" id="settingsTabSelect" data-admin-change-val="showTab">
         <option value="boats"      data-s="admin.tabBoats"></option>
         <option value="locations"  data-s="admin.tabLocations"></option>
         <option value="checklists" data-s="admin.tabChecklists"></option>
@@ -276,14 +275,14 @@
         <div class="loading-state"><span class="spinner"></span></div>
       </div>
       <div style="padding:8px 0 4px">
-        <button class="btn btn-secondary" onclick="openBoatCatModal()" data-s="admin.addCategory"></button>
+        <button class="btn btn-secondary" data-admin-click="openBoatCatModal" data-s="admin.addCategory"></button>
       </div>
     </div>
 
     <!-- ══ LOCATIONS ════════════════════════════════════════════════════════ -->
     <div id="tab-locations" class="hidden">
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title">LOCATIONS</div>
           <span class="col-toggle open">▼</span>
         </div>
@@ -291,7 +290,7 @@
           <div class="loading-state"><span class="spinner"></span></div>
         </div>
         <div style="padding:8px 0 4px">
-          <button class="btn btn-primary" onclick="openLocationModal()" data-s="admin.addLocation"></button>
+          <button class="btn btn-primary" data-admin-click="openLocationModal" data-s="admin.addLocation"></button>
         </div>
       </div>
     </div>
@@ -302,21 +301,21 @@
       <!-- Opening / Closing checklists -->
       <div class="section-label mb-8">DAILY CHECKLISTS</div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)">
+        <div class="col-head" data-admin-toggle-section>
           <div class="col-title" data-s="admin.openingChecklist"></div>
           <span class="col-toggle">▼</span>
         </div>
         <div class="col-body hidden" id="openingCLCard"><div class="loading-state"><span class="spinner"></span></div></div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)">
+        <div class="col-head" data-admin-toggle-section>
           <div class="col-title" data-s="admin.closingChecklist"></div>
           <span class="col-toggle">▼</span>
         </div>
         <div class="col-body hidden" id="closingCLCard"><div class="loading-state"><span class="spinner"></span></div></div>
       </div>
       <div style="padding:8px 0 12px">
-        <button class="btn btn-primary" onclick="openCLModal()" data-s="admin.addItem"></button>
+        <button class="btn btn-primary" data-admin-click="openCLModal" data-s="admin.addItem"></button>
       </div>
 
       <!-- Launch / Landing checklists per category -->
@@ -324,7 +323,7 @@
         <div class="section-label mb-12">PRE-LAUNCH &amp; LANDING CHECKLISTS (per category)</div>
         <div class="flex-center gap-8 mb-8">
           <label class="text-sm text-muted">Category:</label>
-          <select id="launchCLCatFilter" onchange="renderLaunchCLSections()"
+          <select id="launchCLCatFilter" data-admin-change="renderLaunchCLSections"
             style="font-size:11px;padding:3px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text)">
           </select>
         </div>
@@ -335,7 +334,7 @@
           <div id="launchCLLandingList"></div>
         </div>
         <div style="padding:8px 0 4px">
-          <button class="btn btn-primary" onclick="openLaunchCLModal()" data-s="admin.addItem"></button>
+          <button class="btn btn-primary" data-admin-click="openLaunchCLModal" data-s="admin.addItem"></button>
         </div>
       </div>
     </div>
@@ -343,7 +342,7 @@
     <!-- ══ ACTIVITY TYPES ════════════════════════════════════════════════════ -->
     <div id="tab-actTypes" class="hidden">
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title" data-s="admin.actTypesTitle"></div>
           <span class="col-toggle open">▼</span>
         </div>
@@ -351,7 +350,7 @@
           <div class="loading-state"><span class="spinner"></span></div>
         </div>
         <div style="padding:8px 0 4px">
-          <button class="btn btn-primary" onclick="openActTypeModal()" data-s="admin.addType"></button>
+          <button class="btn btn-primary" data-admin-click="openActTypeModal" data-s="admin.addType"></button>
         </div>
       </div>
     </div>
@@ -359,7 +358,7 @@
     <!-- ══ VOLUNTEERS ════════════════════════════════════════════════════════ -->
     <div id="tab-volunteers" class="hidden">
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title" data-s="admin.volEventsTitle"></div>
           <span class="col-toggle open">▼</span>
         </div>
@@ -367,7 +366,7 @@
           <div class="loading-state"><span class="spinner"></span></div>
         </div>
         <div style="padding:8px 0 4px">
-          <button class="btn btn-primary" onclick="openVolEventModal()" data-s="admin.addVolEvent"></button>
+          <button class="btn btn-primary" data-admin-click="openVolEventModal" data-s="admin.addVolEvent"></button>
         </div>
       </div>
     </div>
@@ -377,7 +376,7 @@
 
       <!-- Credential Categories -->
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)">
+        <div class="col-head" data-admin-toggle-section>
           <div class="col-title" data-s="admin.certCategoriesTitle"></div>
           <span class="col-toggle">▼</span>
         </div>
@@ -388,14 +387,14 @@
           <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
             <input type="text" id="newCatInputEN" placeholder="Name (EN)" style="flex:1;min-width:120px;font-size:12px">
             <input type="text" id="newCatInputIS" placeholder="Nafn (IS)" style="flex:1;min-width:120px;font-size:12px">
-            <button class="btn btn-primary" style="font-size:11px;padding:5px 12px" onclick="addCertCategory()">+ Add</button>
+            <button class="btn btn-primary" style="font-size:11px;padding:5px 12px" data-admin-click="addCertCategory">+ Add</button>
           </div>
         </div>
       </div>
 
       <!-- Credential Types -->
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title" data-s="admin.credentialsTitle"></div>
           <span class="col-toggle open">▼</span>
         </div>
@@ -403,7 +402,7 @@
           <div class="loading-state"><span class="spinner"></span></div>
         </div>
         <div style="padding:12px 0 4px">
-          <button class="btn btn-primary" onclick="openCertDefModal()" data-s="admin.certAddType"></button>
+          <button class="btn btn-primary" data-admin-click="openCertDefModal" data-s="admin.certAddType"></button>
         </div>
       </div>
 
@@ -412,7 +411,7 @@
     <!-- ══ ALERT SETTINGS ═══════════════════════════════════════════════════ -->
     <div id="tab-alerts" class="hidden">
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title">⚠️ <span data-s="admin.overdueAlerts"></span></div>
           <span class="col-toggle open">▼</span>
         </div>
@@ -452,7 +451,7 @@
               <textarea id="alertSmsList" rows="2" class="text-sm" style="width:100%;resize:vertical" placeholder="+3546001234, +3547001234"></textarea>
             </div>
           </div>
-          <button class="btn btn-primary" onclick="saveAlertConfig()">Save alert settings</button>
+          <button class="btn btn-primary" data-admin-click="saveAlertConfig">Save alert settings</button>
           <span id="alertSaveMsg" class="text-sm text-green" style="margin-left:10px"></span>
         </div>
       </div>
@@ -461,84 +460,84 @@
     <!-- ══ FLAGS ════════════════════════════════════════════════════════════════ -->
     <div id="tab-flags" class="hidden">
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title"><span data-s="admin.scoreThresholds"></span> <span style="font-size:10px;color:var(--muted);font-weight:normal">(<span data-s="admin.scoreThresholdsSub"></span>)</span></div>
           <span class="col-toggle open">▼</span>
         </div>
         <div class="col-body" id="flagThresholdsCard">
           <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:12px">
-            <div class="field"><label style="color:var(--yellow)">🟡 <span data-s="admin.yellowGte"></span></label><input type="number" id="fcThreshY" min="1" max="99" value="25" oninput="updateFlagPreview()"></div>
-            <div class="field"><label style="color:var(--orange)">🟠 <span data-s="admin.orangeGte"></span></label><input type="number" id="fcThreshO" min="1" max="99" value="45" oninput="updateFlagPreview()"></div>
-            <div class="field"><label style="color:var(--red)">🔴 <span data-s="admin.redGte"></span></label><input type="number" id="fcThreshR" min="1" max="99" value="65" oninput="updateFlagPreview()"></div>
-            <div class="field"><label style="color:#999">⚫️ <span data-s="admin.closedGte"></span></label><input type="number" id="fcThreshB" min="1" max="120" value="80" oninput="updateFlagPreview()"></div>
+            <div class="field"><label style="color:var(--yellow)">🟡 <span data-s="admin.yellowGte"></span></label><input type="number" id="fcThreshY" min="1" max="99" value="25" data-admin-input="updateFlagPreview"></div>
+            <div class="field"><label style="color:var(--orange)">🟠 <span data-s="admin.orangeGte"></span></label><input type="number" id="fcThreshO" min="1" max="99" value="45" data-admin-input="updateFlagPreview"></div>
+            <div class="field"><label style="color:var(--red)">🔴 <span data-s="admin.redGte"></span></label><input type="number" id="fcThreshR" min="1" max="99" value="65" data-admin-input="updateFlagPreview"></div>
+            <div class="field"><label style="color:#999">⚫️ <span data-s="admin.closedGte"></span></label><input type="number" id="fcThreshB" min="1" max="120" value="80" data-admin-input="updateFlagPreview"></div>
           </div>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.windScoring"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.windScoring"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagWindCard">
           <div style="font-size:11px;color:var(--muted);margin-bottom:10px" data-s="admin.windScoringHint"></div>
           <div id="fcWindBands" style="display:flex;flex-direction:column;gap:6px"></div>
-          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" onclick="fcAddWindBand()" data-s="admin.addBand"></button>
+          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" data-admin-click="fcAddWindBand" data-s="admin.addBand"></button>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.dirGustMods"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.dirGustMods"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagDirCard">
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:12px">
-            <div class="field"><label data-s="admin.windDirMod"></label><input type="number" id="fcWindDirPts" min="0" max="20" value="0" oninput="updateFlagPreview()"><div style="font-size:10px;color:var(--muted);margin-top:3px" data-s="admin.windDirModHint"></div></div>
-            <div class="field"><label data-s="admin.gustMod1"></label><input type="number" id="fcGust1Pts" min="0" max="20" value="0" oninput="updateFlagPreview()"><div style="font-size:10px;color:var(--muted);margin-top:3px" data-s="admin.gustMod1Hint"></div></div><div class="field"><label data-s="admin.gustMod2"></label><input type="number" id="fcGust2Pts" min="0" max="20" value="0" oninput="updateFlagPreview()"><div style="font-size:10px;color:var(--muted);margin-top:3px" data-s="admin.gustMod2Hint"></div></div></div>
+            <div class="field"><label data-s="admin.windDirMod"></label><input type="number" id="fcWindDirPts" min="0" max="20" value="0" data-admin-input="updateFlagPreview"><div style="font-size:10px;color:var(--muted);margin-top:3px" data-s="admin.windDirModHint"></div></div>
+            <div class="field"><label data-s="admin.gustMod1"></label><input type="number" id="fcGust1Pts" min="0" max="20" value="0" data-admin-input="updateFlagPreview"><div style="font-size:10px;color:var(--muted);margin-top:3px" data-s="admin.gustMod1Hint"></div></div><div class="field"><label data-s="admin.gustMod2"></label><input type="number" id="fcGust2Pts" min="0" max="20" value="0" data-admin-input="updateFlagPreview"><div style="font-size:10px;color:var(--muted);margin-top:3px" data-s="admin.gustMod2Hint"></div></div></div>
           </div>
-          <div class="field"><label data-s="admin.windDirDirs"></label><input type="text" id="fcWindDirDirs" value="" placeholder="E,NE,SE" oninput="updateFlagPreview()"></div>
+          <div class="field"><label data-s="admin.windDirDirs"></label><input type="text" id="fcWindDirDirs" value="" placeholder="E,NE,SE" data-admin-input="updateFlagPreview"></div>
         </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.waveScoring"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.waveScoring"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagWaveCard">
           <div id="fcWaveBands" style="display:flex;flex-direction:column;gap:6px"></div>
-          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" onclick="fcAddWaveBand()" data-s="admin.addBand"></button>
+          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" data-admin-click="fcAddWaveBand" data-s="admin.addBand"></button>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.sstScoring"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.sstScoring"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagSstCard">
           <div style="font-size:11px;color:var(--muted);margin-bottom:10px" data-s="admin.sstHint"></div>
           <div id="fcSstBands" style="display:flex;flex-direction:column;gap:6px"></div>
-          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" onclick="fcAddSstBand()" data-s="admin.addBand"></button>
+          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" data-admin-click="fcAddSstBand" data-s="admin.addBand"></button>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.airTempScoring"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.airTempScoring"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagFeelsCard" data-note="uses apparent_temperature, falls back to temperature_2m">
           <div id="fcFeelsBands" style="display:flex;flex-direction:column;gap:6px"></div>
-          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" onclick="fcAddFeelsBand()" data-s="admin.addBand"></button>
+          <button class="btn btn-secondary" style="margin-top:8px;font-size:11px" data-admin-click="fcAddFeelsBand" data-s="admin.addBand"></button>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.visScoring"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.visScoring"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagVisCard">
           <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:12px">
-            <div class="field"><label data-s="admin.visGood"></label><input type="number" id="fcVisGood" min="0" max="20" value="0" oninput="updateFlagPreview()"></div>
-            <div class="field"><label data-s="admin.visReduced"></label><input type="number" id="fcVisReduced" min="0" max="20" value="0" oninput="updateFlagPreview()"></div>
-            <div class="field"><label data-s="admin.visPoor"></label><input type="number" id="fcVisPoor" min="0" max="20" value="0" oninput="updateFlagPreview()"></div>
+            <div class="field"><label data-s="admin.visGood"></label><input type="number" id="fcVisGood" min="0" max="20" value="0" data-admin-input="updateFlagPreview"></div>
+            <div class="field"><label data-s="admin.visReduced"></label><input type="number" id="fcVisReduced" min="0" max="20" value="0" data-admin-input="updateFlagPreview"></div>
+            <div class="field"><label data-s="admin.visPoor"></label><input type="number" id="fcVisPoor" min="0" max="20" value="0" data-admin-input="updateFlagPreview"></div>
           </div>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)"><div class="col-title" data-s="admin.flagLabelsAdvice"></div><span class="col-toggle">▼</span></div>
+        <div class="col-head" data-admin-toggle-section><div class="col-title" data-s="admin.flagLabelsAdvice"></div><span class="col-toggle">▼</span></div>
         <div class="col-body hidden" id="flagAdviceCard">
           <div id="fcFlagAdvice" style="display:flex;flex-direction:column;gap:12px;margin-bottom:14px"></div>
         </div>
       </div>
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)"><div class="col-title" data-s="admin.livePreview"></div><span class="col-toggle open">▼</span></div>
+        <div class="col-head open" data-admin-toggle-section><div class="col-title" data-s="admin.livePreview"></div><span class="col-toggle open">▼</span></div>
         <div class="col-body" id="flagPreviewCard">
           <div id="fcFlagPreview" style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px"></div>
         </div>
       </div>
       <div id="fcValidationError" style="color:var(--red);font-size:11px;margin-bottom:8px;display:none"></div>
       <div style="display:flex;gap:8px;align-items:center;margin-bottom:24px">
-        <button class="btn btn-primary" onclick="saveFlagConfig()" data-s="admin.saveFlagSettings"></button>
-        <button class="btn btn-secondary" onclick="resetFlagConfig()" data-s="admin.resetDefaults"></button>
+        <button class="btn btn-primary" data-admin-click="saveFlagConfig" data-s="admin.saveFlagSettings"></button>
+        <button class="btn btn-secondary" data-admin-click="resetFlagConfig" data-s="admin.resetDefaults"></button>
         <span id="fcSaveMsg" style="font-size:11px;margin-left:4px"></span>
       </div>
     </div><!-- /tab-flags -->
@@ -546,7 +545,7 @@
     <!-- ══ ROWING PASSPORT ═════════════════════════════════════════════════ -->
     <div id="tab-passport" class="hidden">
       <div class="col-section">
-        <div class="col-head open" onclick="toggleSection(this)">
+        <div class="col-head open" data-admin-toggle-section>
           <div class="col-title" data-s="passport.adminTitle">Rowing Passport</div>
           <span class="col-toggle open">▼</span>
         </div>
@@ -554,8 +553,8 @@
           <div style="font-size:11px;color:var(--muted);margin-bottom:10px;line-height:1.5" data-s="passport.csvHelp"></div>
           <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
             <input type="file" id="passportCsvFile" accept=".csv,text/csv" style="font-size:11px">
-            <button class="btn btn-primary" style="font-size:11px" onclick="passportImportCsv()" data-s="passport.importCsv">Import CSV</button>
-            <button class="btn btn-secondary" style="font-size:11px" onclick="passportExportCsv()" data-s="passport.exportCsv">Export CSV</button>
+            <button class="btn btn-primary" style="font-size:11px" data-admin-click="passportImportCsv" data-s="passport.importCsv">Import CSV</button>
+            <button class="btn btn-secondary" style="font-size:11px" data-admin-click="passportExportCsv" data-s="passport.exportCsv">Export CSV</button>
           </div>
           <div id="passportAdminPreview" style="font-size:11px"></div>
         </div>
@@ -592,24 +591,24 @@
           </div>
         </div>
         <div style="display:flex;gap:8px;align-items:center;margin-top:8px">
-          <button class="btn btn-primary" onclick="saveCharterCalendars()">Save calendar settings</button>
+          <button class="btn btn-primary" data-admin-click="saveCharterCalendars">Save calendar settings</button>
           <span id="charterCalSaveMsg" style="font-size:11px"></span>
         </div>
         <div style="font-size:10px;color:var(--muted);margin-top:6px">Ymir only adds, updates, or deletes events it created itself — other items on the calendar are never touched. Use a dedicated secondary calendar and share it with the people who need to see bookings.</div>
       </div>
       <div style="margin-bottom:12px">
         <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;flex-wrap:wrap">
-          <select id="slotCatFilter" onchange="loadSlotCalendar()" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px"></select>
-          <select id="slotBoatFilter" onchange="renderSlotCalendar()" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px">
+          <select id="slotCatFilter" data-admin-change="loadSlotCalendar" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px"></select>
+          <select id="slotBoatFilter" data-admin-change="renderSlotCalendar" style="background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:11px;padding:4px 8px">
             <option value="" data-s="slot.allBoats">All boats</option>
           </select>
           <div class="slot-week-nav">
-            <button class="btn btn-secondary" onclick="shiftSlotWeek(-1)">&larr;</button>
+            <button class="btn btn-secondary" data-admin-click="shiftSlotWeek" data-admin-arg="-1">&larr;</button>
             <span id="slotWeekLabel" class="week-label"></span>
-            <button class="btn btn-secondary" onclick="shiftSlotWeek(1)">&rarr;</button>
-            <button class="btn btn-secondary" onclick="slotWeekToday()" data-s="slot.today">Today</button>
-            <button class="btn btn-primary" data-s="slot.addSingle" data-s-attr="title" onclick="openNewSlotModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.addSingle">+ Single</span></button>
-            <button class="btn btn-primary" data-s="slot.addRecurring" data-s-attr="title" onclick="openRecurringSlotModal()"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.addRecurring">+ Recurring</span></button>
+            <button class="btn btn-secondary" data-admin-click="shiftSlotWeek" data-admin-arg="1">&rarr;</button>
+            <button class="btn btn-secondary" data-admin-click="slotWeekToday" data-s="slot.today">Today</button>
+            <button class="btn btn-primary" data-s="slot.addSingle" data-s-attr="title" data-admin-click="openNewSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.addSingle">+ Single</span></button>
+            <button class="btn btn-primary" data-s="slot.addRecurring" data-s-attr="title" data-admin-click="openRecurringSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.addRecurring">+ Recurring</span></button>
           </div>
         </div>
       </div>
@@ -624,9 +623,9 @@
     <div id="tab-clubCal" class="hidden">
       <div style="font-size:11px;color:var(--muted);margin-bottom:10px;line-height:1.5" data-s="admin.calDesc"></div>
       <div id="clubCalList"></div>
-      <button class="btn btn-secondary" style="margin-top:8px" onclick="addClubCalRow('','')" data-s="admin.calAdd"></button>
+      <button class="btn btn-secondary" style="margin-top:8px" data-admin-click="addClubCalRow" data-admin-arg="" data-admin-arg2="" data-s="admin.calAdd"></button>
       <div style="display:flex;gap:8px;align-items:center;margin-top:12px">
-        <button class="btn btn-primary" onclick="saveClubCalendars()" data-s="btn.save"></button>
+        <button class="btn btn-primary" data-admin-click="saveClubCalendars" data-s="btn.save"></button>
         <span id="clubCalSaveMsg" style="font-size:11px"></span>
       </div>
     </div>
@@ -641,11 +640,11 @@
 <!-- ══ MODALS ════════════════════════════════════════════════════════════════ -->
 
 <!-- Member modal -->
-<div class="modal-overlay hidden" id="memberModal" onclick="if(event.target===this)closeModal('memberModal')">
+<div class="modal-overlay hidden" id="memberModal" data-admin-close-self>
   <div class="modal" style="max-width:520px">
     <div class="modal-header">
       <h3 id="memberModalTitle" data-s="admin.memberModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('memberModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="memberModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="lbl.name"></label><input type="text" id="mName"></div>
@@ -679,22 +678,22 @@
         <div style="font-size:9px;color:var(--muted);letter-spacing:1px;margin-bottom:4px" data-s="admin.password"></div>
         <div id="mPwStatus" style="font-size:12px"></div>
       </div>
-      <button type="button" class="btn btn-ghost" id="mResetPwBtn" onclick="resetMemberPassword()" data-s="admin.resetPassword"></button>
+      <button type="button" class="btn btn-ghost" id="mResetPwBtn" data-admin-click="resetMemberPassword" data-s="admin.resetPassword"></button>
     </div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('memberModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="mDeleteBtn" onclick="deleteMember()" data-s="admin.deactivate"></button>
-      <button id="saveMemberBtn" class="btn btn-primary" onclick="saveMember()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="memberModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="mDeleteBtn" data-admin-click="deleteMember" data-s="admin.deactivate"></button>
+      <button id="saveMemberBtn" class="btn btn-primary" data-admin-click="saveMember" data-s="btn.save"></button>
     </div>
   </div>
 </div>
 
 <!-- Boat category modal -->
-<div class="modal-overlay hidden" id="boatCatModal" onclick="if(event.target===this)closeModal('boatCatModal')">
+<div class="modal-overlay hidden" id="boatCatModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 id="boatCatModalTitle" data-s="admin.boatCatModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('boatCatModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="boatCatModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="admin.nameEN"></label><input type="text" id="bcLabelEN" placeholder="e.g. Dinghy"></div>
@@ -709,9 +708,9 @@
       <input type="checkbox" id="bcActive" checked> <label for="bcActive" data-s="lbl.active"></label>
     </div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('boatCatModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="bcDeleteBtn" onclick="deleteBoatCat()" data-s="btn.delete"></button>
-      <button class="btn btn-primary" onclick="saveBoatCat()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="boatCatModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="bcDeleteBtn" data-admin-click="deleteBoatCat" data-s="btn.delete"></button>
+      <button class="btn btn-primary" data-admin-click="saveBoatCat" data-s="btn.save"></button>
     </div>
   </div>
 </div>
@@ -719,11 +718,11 @@
 <!-- Boat modal — markup injected by shared/boat-modal.js (injectBoatModalHtml()). -->
 
 <!-- Location modal -->
-<div class="modal-overlay hidden" id="locationModal" onclick="if(event.target===this)closeModal('locationModal')">
+<div class="modal-overlay hidden" id="locationModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 id="locationModalTitle" data-s="admin.locModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('locationModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="locationModal">&times;</button>
     </div>
     <div class="field"><label data-s="lbl.name"></label><input type="text" id="lName"></div>
     <div class="field">
@@ -741,9 +740,9 @@
       <input type="checkbox" id="lActive" checked> <label for="lActive" data-s="lbl.active"></label>
     </div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('locationModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="lDeleteBtn" onclick="deleteLocation()" data-s="btn.delete"></button>
-      <button class="btn btn-primary" onclick="saveLocation()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="locationModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="lDeleteBtn" data-admin-click="deleteLocation" data-s="btn.delete"></button>
+      <button class="btn btn-primary" data-admin-click="saveLocation" data-s="btn.save"></button>
     </div>
   </div>
 </div>
@@ -752,11 +751,11 @@
      Sibling: #launchCLModal below (launch/landing phase, with category).
      Both share the textEN / textIS / sort-order fields; kept as separate
      modals because their phase enums + ancillary fields differ. -->
-<div class="modal-overlay hidden" id="clModal" onclick="if(event.target===this)closeModal('clModal')">
+<div class="modal-overlay hidden" id="clModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 id="clModalTitle" data-s="admin.clModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('clModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="clModal">&times;</button>
     </div>
     <div class="field"><label data-s="admin.clPhase"></label>
       <select id="clPhase">
@@ -771,19 +770,19 @@
       <input type="checkbox" id="clActive" checked> <label for="clActive" data-s="lbl.active"></label>
     </div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('clModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="clDeleteBtn" onclick="deleteCLItem()" data-s="btn.delete"></button>
-      <button class="btn btn-primary" onclick="saveCLItem()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="clModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="clDeleteBtn" data-admin-click="deleteCLItem" data-s="btn.delete"></button>
+      <button class="btn btn-primary" data-admin-click="saveCLItem" data-s="btn.save"></button>
     </div>
   </div>
 </div>
 
 <!-- Launch/landing checklist item modal -->
-<div class="modal-overlay hidden" id="launchCLModal" onclick="if(event.target===this)closeModal('launchCLModal')">
+<div class="modal-overlay hidden" id="launchCLModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 id="launchCLModalTitle" data-s="admin.clModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('launchCLModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="launchCLModal">&times;</button>
     </div>
     <div class="field"><label data-s="lbl.category"></label>
       <select id="lcCat"></select>
@@ -795,19 +794,19 @@
     <div class="field"><label data-s="admin.clTextIS"></label><input type="text" id="lcTextIS"></div>
     <div class="field"><label data-s="lbl.sortOrder"></label><input type="number" id="lcSort" value="1" min="1"></div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('launchCLModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="lcDeleteBtn" onclick="deleteLaunchCLItem()" data-s="btn.delete"></button>
-      <button class="btn btn-primary" onclick="saveLaunchCLItem()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="launchCLModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="lcDeleteBtn" data-admin-click="deleteLaunchCLItem" data-s="btn.delete"></button>
+      <button class="btn btn-primary" data-admin-click="saveLaunchCLItem" data-s="btn.save"></button>
     </div>
   </div>
 </div>
 
 <!-- Activity type modal -->
-<div class="modal-overlay hidden" id="actTypeModal" onclick="if(event.target===this)closeModal('actTypeModal')">
+<div class="modal-overlay hidden" id="actTypeModal" data-admin-close-self>
   <div class="modal" style="max-width:520px">
     <div class="modal-header">
       <h3 id="actTypeModalTitle" data-s="admin.actTypeModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('actTypeModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="actTypeModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="admin.actTypeEN"></label><input type="text" id="atName"></div>
@@ -817,14 +816,14 @@
       <input type="checkbox" id="atActive" checked> <label for="atActive" data-s="lbl.active"></label>
     </div>
     <div class="check-row" style="margin-bottom:10px">
-      <input type="checkbox" id="atVolunteer" onchange="toggleAtVolunteerSection()"> <label for="atVolunteer" data-s="admin.volunteerType"></label>
+      <input type="checkbox" id="atVolunteer" data-admin-change="toggleAtVolunteerSection"> <label for="atVolunteer" data-s="admin.volunteerType"></label>
     </div>
     <div id="atRolesSection" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px 12px;margin-bottom:10px">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;gap:8px;flex-wrap:wrap">
         <label style="font-size:10px;color:var(--muted);letter-spacing:.8px" data-s="admin.volRoles"></label>
         <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-          <select id="atRolePresetPicker" onchange="addAtRoleFromPreset(this.value);this.value=''" style="font-size:11px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit"></select>
-          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="addAtRoleRow()" data-s="btn.add"></button>
+          <select id="atRolePresetPicker" data-admin-preset-change="addAtRoleFromPreset" style="font-size:11px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit"></select>
+          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" data-admin-click="addAtRoleRow" data-s="btn.add"></button>
         </div>
       </div>
       <div id="atRolesList"></div>
@@ -844,24 +843,24 @@
     <div style="margin-top:10px">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
         <label style="font-size:10px;color:var(--muted);letter-spacing:.8px" data-s="admin.subtypes"></label>
-        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="addAtSubtypeRow()" data-s="btn.add"></button>
+        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" data-admin-click="addAtSubtypeRow" data-s="btn.add"></button>
       </div>
       <div id="atSubtypesList"></div>
     </div>
     <div class="btn-row" style="margin-top:14px">
-      <button class="btn btn-secondary" onclick="closeModal('actTypeModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="atDeleteBtn" onclick="deleteActType()" data-s="btn.delete"></button>
-      <button class="btn btn-primary" onclick="saveActType()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="actTypeModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="atDeleteBtn" data-admin-click="deleteActType" data-s="btn.delete"></button>
+      <button class="btn btn-primary" data-admin-click="saveActType" data-s="btn.save"></button>
     </div>
   </div>
 </div>
 
 <!-- Volunteer event modal -->
-<div class="modal-overlay hidden" id="volEventModal" onclick="if(event.target===this)closeModal('volEventModal')">
+<div class="modal-overlay hidden" id="volEventModal" data-admin-close-self>
   <div class="modal" style="max-width:560px;max-height:92vh;overflow-y:auto">
     <div class="modal-header">
       <h3 id="volEventModalTitle" data-s="admin.volEventModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('volEventModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="volEventModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="admin.volTitle"></label><input type="text" id="veTitle"></div>
@@ -869,7 +868,7 @@
     </div>
     <div class="field">
       <label data-s="admin.volActType"></label>
-      <select id="veActType" onchange="onVeActTypeChange()"><option value="" data-s="admin.volActTypeNone"></option></select>
+      <select id="veActType" data-admin-change="onVeActTypeChange"><option value="" data-s="admin.volActTypeNone"></option></select>
     </div>
     <div class="grid2" style="margin-top:2px">
       <div class="field"><label data-s="admin.volDate"></label><input type="date" id="veDate"></div>
@@ -884,7 +883,7 @@
       <div style="font-size:9px;color:var(--muted);letter-spacing:1px;margin-bottom:8px" data-s="admin.volLeader"></div>
       <div class="field" style="position:relative;margin-bottom:6px">
         <label data-s="admin.volLeader"></label>
-        <input type="text" id="veLeaderSearch" autocomplete="off" oninput="searchVolLeader(this.value)" placeholder="">
+        <input type="text" id="veLeaderSearch" autocomplete="off" data-admin-input-val="searchVolLeader" placeholder="">
         <div id="veLeaderSuggestions" style="display:none;position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:4px;z-index:10;max-height:160px;overflow-y:auto"></div>
         <input type="hidden" id="veLeaderMemberId">
       </div>
@@ -905,26 +904,26 @@
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;gap:8px;flex-wrap:wrap">
         <label style="font-size:10px;color:var(--muted);letter-spacing:.8px" data-s="admin.volRoles"></label>
         <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-          <select id="veRolePresetPicker" onchange="addVolRoleFromPreset(this.value);this.value=''" style="font-size:11px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit"></select>
-          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="addVolRoleRow()" data-s="btn.add"></button>
+          <select id="veRolePresetPicker" data-admin-preset-change="addVolRoleFromPreset" style="font-size:11px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit"></select>
+          <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" data-admin-click="addVolRoleRow" data-s="btn.add"></button>
         </div>
       </div>
       <div id="volRolesList"></div>
     </div>
     <div class="btn-row" style="margin-top:14px">
-      <button class="btn btn-secondary" onclick="closeModal('volEventModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-danger hidden" id="veDeleteBtn" onclick="deleteVolEvent()" data-s="btn.delete"></button>
-      <button class="btn btn-primary" onclick="saveVolEvent()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="volEventModal" data-s="btn.cancel"></button>
+      <button class="btn btn-danger hidden" id="veDeleteBtn" data-admin-click="deleteVolEvent" data-s="btn.delete"></button>
+      <button class="btn btn-primary" data-admin-click="saveVolEvent" data-s="btn.save"></button>
     </div>
   </div>
 </div>
 
 <!-- Credential category modal -->
-<div class="modal-overlay hidden" id="certCatModal" onclick="if(event.target===this)closeModal('certCatModal')">
+<div class="modal-overlay hidden" id="certCatModal" data-admin-close-self>
   <div class="modal" style="max-width:480px">
     <div class="modal-header">
       <h3 id="certCatModalTitle" data-s="admin.certCatModal.edit"></h3>
-      <button class="modal-close-x" onclick="closeModal('certCatModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="certCatModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="admin.nameEN"></label><input type="text" id="ccLabelEN"></div>
@@ -936,18 +935,18 @@
     </div>
     <div style="font-size:11px;color:var(--muted);margin-bottom:10px" data-s="admin.certCatKeyHint"></div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('certCatModal')" data-s="btn.cancel"></button>
-      <button class="btn btn-primary" onclick="saveCertCat()" data-s="btn.save"></button>
+      <button class="btn btn-secondary" data-admin-close="certCatModal" data-s="btn.cancel"></button>
+      <button class="btn btn-primary" data-admin-click="saveCertCat" data-s="btn.save"></button>
     </div>
   </div>
 </div>
 
 <!-- Credential type modal -->
-<div class="modal-overlay hidden" id="certDefModal" onclick="if(event.target===this)closeModal('certDefModal')">
+<div class="modal-overlay hidden" id="certDefModal" data-admin-close-self>
   <div class="modal" style="max-width:560px">
     <div class="modal-header">
       <h3 id="certDefModalTitle" data-s="admin.certDefModal.add"></h3>
-      <button class="modal-close-x" onclick="closeModal('certDefModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="certDefModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="admin.nameEN"></label><input type="text" id="cdNameEN"></div>
@@ -976,7 +975,7 @@
 
     <div class="field" style="display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:4px">
       <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-        <input type="checkbox" id="cdClubEndorsement" onchange="toggleCdEndorsement()"> <span data-s="admin.certClubEndorsement"></span>
+        <input type="checkbox" id="cdClubEndorsement" data-admin-change="toggleCdEndorsement"> <span data-s="admin.certClubEndorsement"></span>
       </label>
       <label style="display:flex;align-items:center;gap:8px"><span data-s="admin.certCardColour"></span>
         <input type="color" id="cdColor" style="width:36px;height:26px;padding:2px;border:1px solid var(--border);border-radius:4px;cursor:pointer">
@@ -996,7 +995,7 @@
     <div style="margin-top:14px">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
         <label style="font-size:10px;color:var(--muted);letter-spacing:.8px" data-s="admin.certSubcategories"></label>
-        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" onclick="addSubcatRow()" data-s="btn.add"></button>
+        <button class="btn btn-secondary" style="font-size:11px;padding:4px 10px" data-admin-click="addSubcatRow" data-s="btn.add"></button>
       </div>
       <div id="subcatRows"></div>
       <div style="font-size:11px;color:var(--muted);margin-top:6px;padding-top:6px" data-s="admin.certSubcatHint">
@@ -1004,21 +1003,21 @@
     </div>
 
     <div style="display:flex;gap:8px;margin-top:18px;justify-content:space-between;align-items:center">
-      <button class="btn btn-danger hidden" id="certDefDeleteBtn" onclick="deleteCertDef()" data-s="btn.delete"></button>
+      <button class="btn btn-danger hidden" id="certDefDeleteBtn" data-admin-click="deleteCertDef" data-s="btn.delete"></button>
       <div style="display:flex;gap:8px">
-        <button class="btn btn-secondary" onclick="closeModal('certDefModal')" data-s="btn.cancel"></button>
-        <button class="btn btn-primary" id="saveCertDefBtn" onclick="saveCertDef()" data-s="btn.save"></button>
+        <button class="btn btn-secondary" data-admin-close="certDefModal" data-s="btn.cancel"></button>
+        <button class="btn btn-primary" id="saveCertDefBtn" data-admin-click="saveCertDef" data-s="btn.save"></button>
       </div>
     </div>
   </div>
 </div>
 
 <!-- Boat QR modal -->
-<div class="modal-overlay hidden" id="qrModal" onclick="if(event.target===this)closeModal('qrModal')">
+<div class="modal-overlay hidden" id="qrModal" data-admin-close-self>
   <div class="modal" style="max-width:360px;text-align:center">
     <div class="modal-header">
       <h3 id="qrBoatName" style="font-size:18px"></h3>
-      <button class="modal-close-x" onclick="closeModal('qrModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="qrModal">&times;</button>
     </div>
     <div style="font-size:11px;color:var(--muted);margin-bottom:16px" id="qrCategory"></div>
     <img id="qrImg" src="" alt="QR code" style="width:220px;height:220px;border-radius:8px;border:1px solid var(--border)">
@@ -1027,8 +1026,8 @@
     <div style="font-size:11px;color:var(--muted);margin-top:12px;line-height:1.5" data-s="admin.qrScanHint">
     </div>
     <div style="display:flex;gap:8px;margin-top:12px">
-      <button class="btn btn-secondary" onclick="closeModal('qrModal')" data-s="btn.close"></button>
-      <button class="btn btn-primary" onclick="printQR()">🖨 <span data-s="admin.printPdf"></span></button>
+      <button class="btn btn-secondary" data-admin-close="qrModal" data-s="btn.close"></button>
+      <button class="btn btn-primary" data-admin-click="printQR">🖨 <span data-s="admin.printPdf"></span></button>
     </div>
   </div>
 </div>
@@ -1036,11 +1035,11 @@
 <!-- Slot modals (recurring + single) — markup injected by shared/slot-modal.js -->
 
 <!-- Passport settings modal -->
-<div class="modal-overlay hidden" id="passportSettingsModal" onclick="if(event.target===this)closeModal('passportSettingsModal')">
+<div class="modal-overlay hidden" id="passportSettingsModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 data-s="passport.settingsTitle">Passport settings</h3>
-      <button class="modal-close-x" onclick="closeModal('passportSettingsModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="passportSettingsModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="passport.nameEN">Name (English)</label><input type="text" id="ppsNameEN"></div>
@@ -1056,18 +1055,18 @@
       <div class="field"><label data-s="passport.toSub">To sub-category</label><input type="text" id="ppsToSub" placeholder="released"></div>
     </div>
     <div class="btn-row">
-      <button class="btn btn-secondary" onclick="closeModal('passportSettingsModal')" data-s="btn.cancel">Cancel</button>
-      <button class="btn btn-primary" onclick="savePassportSettings()" data-s="btn.save">Save</button>
+      <button class="btn btn-secondary" data-admin-close="passportSettingsModal" data-s="btn.cancel">Cancel</button>
+      <button class="btn btn-primary" data-admin-click="savePassportSettings" data-s="btn.save">Save</button>
     </div>
   </div>
 </div>
 
 <!-- Passport item modal -->
-<div class="modal-overlay hidden" id="passportItemModal" onclick="if(event.target===this)closeModal('passportItemModal')">
+<div class="modal-overlay hidden" id="passportItemModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 id="passportItemModalTitle" data-s="passport.itemTitle">Passport item</h3>
-      <button class="modal-close-x" onclick="closeModal('passportItemModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="passportItemModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="passport.itemNameEN">Item name (English)</label><input type="text" id="ppiNameEN"></div>
@@ -1099,19 +1098,19 @@
       <input type="checkbox" id="ppiRetired"> <label for="ppiRetired" data-s="passport.retire">Retire</label>
     </div>
     <div class="btn-row">
-      <button class="btn btn-danger hidden" id="ppiDeleteBtn" onclick="deletePassportItem()" data-s="btn.delete">Delete</button>
-      <button class="btn btn-secondary" onclick="closeModal('passportItemModal')" data-s="btn.cancel">Cancel</button>
-      <button class="btn btn-primary" onclick="savePassportItem()" data-s="btn.save">Save</button>
+      <button class="btn btn-danger hidden" id="ppiDeleteBtn" data-admin-click="deletePassportItem" data-s="btn.delete">Delete</button>
+      <button class="btn btn-secondary" data-admin-close="passportItemModal" data-s="btn.cancel">Cancel</button>
+      <button class="btn btn-primary" data-admin-click="savePassportItem" data-s="btn.save">Save</button>
     </div>
   </div>
 </div>
 
 <!-- Passport category modal -->
-<div class="modal-overlay hidden" id="passportCategoryModal" onclick="if(event.target===this)closeModal('passportCategoryModal')">
+<div class="modal-overlay hidden" id="passportCategoryModal" data-admin-close-self>
   <div class="modal">
     <div class="modal-header">
       <h3 id="passportCategoryModalTitle" data-s="passport.categoryTitle">Passport category</h3>
-      <button class="modal-close-x" onclick="closeModal('passportCategoryModal')">&times;</button>
+      <button class="modal-close-x" data-admin-close="passportCategoryModal">&times;</button>
     </div>
     <div class="grid2">
       <div class="field"><label data-s="passport.categoryNameEN">Category name (English)</label><input type="text" id="ppcNameEN"></div>
@@ -1119,3562 +1118,13 @@
     </div>
     <div class="field"><label data-s="passport.idReadOnly">ID (read-only)</label><input type="text" id="ppcId" readonly style="color:var(--muted)"></div>
     <div class="btn-row">
-      <button class="btn btn-danger hidden" id="ppcDeleteBtn" onclick="deletePassportCategory()" data-s="passport.deleteCategory">Delete category</button>
-      <button class="btn btn-secondary" onclick="closeModal('passportCategoryModal')" data-s="btn.cancel">Cancel</button>
-      <button class="btn btn-primary" onclick="savePassportCategory()" data-s="btn.save">Save</button>
+      <button class="btn btn-danger hidden" id="ppcDeleteBtn" data-admin-click="deletePassportCategory" data-s="passport.deleteCategory">Delete category</button>
+      <button class="btn btn-secondary" data-admin-close="passportCategoryModal" data-s="btn.cancel">Cancel</button>
+      <button class="btn btn-primary" data-admin-click="savePassportCategory" data-s="btn.save">Save</button>
     </div>
   </div>
 </div>
 
-<script>
-// ── Auth ───────────────────────────────────────────────────────────────────────
-const user = requireAuth(isAdmin);
-
-let members = [], boats = [], locations = [], clItems = [], actTypes = [], volunteerEvents = [];
-let volunteerSignups = [];
-let _allBoats = [], _allLocations = [];
-let editingId = null, importResult = null;
-let certCategories = [];
-const bool = v => v === true || v === 'true' || v === 1 || v === '1' || v === 'TRUE';
-
-// ── Default boat categories (seeded if none in config) ────────────────────────
-const DEFAULT_BOAT_CATS = [
-  { key:'dinghy',        labelEN:'Dinghy',        labelIS:'Skíðbátur',    emoji:'⛵', active:true },
-  { key:'keelboat',      labelEN:'Keelboat',      labelIS:'Kjölbátur',    emoji:'⛵', active:true },
-  { key:'kayak',         labelEN:'Kayak',         labelIS:'Kajak',        emoji:'🛶', active:true },
-  { key:'rowing-shell',  labelEN:'Rowing Shell',  labelIS:'Róðrarbátur',  emoji:'🚣', active:true },
-  { key:'rowboat',       labelEN:'Rowboat',       labelIS:'Árabátur',     emoji:'🚣', active:true },
-  { key:'sup',           labelEN:'SUP',           labelIS:'SUP',          emoji:'🏄', active:true },
-  { key:'wingfoil',      labelEN:'Wingfoil',      labelIS:'Wingfoil',     emoji:'🪁', active:true },
-  { key:'other',         labelEN:'Other',         labelIS:'Annað',        emoji:'🚤', active:true },
-];
-let _allBoatCats = [];   // full list including inactive
-let boatCats     = [];   // active only
-let _bcEditingId = null;
-
-// ── Init ───────────────────────────────────────────────────────────────────────
-window.addEventListener('message', e => {
-  if (e.data && e.data.type === 'payroll-resize') {
-    const frame = document.getElementById('payrollFrame');
-    if (frame) frame.style.height = e.data.height + 'px';
-  }
-});
-
-document.addEventListener("DOMContentLoaded", () => {
-  buildHeader('admin');
-  injectBoatModalHtml();
-  injectRecurringSlotModal({ showBoat: true, showNote: true,
-    previewFn: 'previewRecurringSlots', saveFn: 'saveRecurringSlots', saveKey: 'slot.create' });
-  injectSingleSlotModal({ showBoatName: true, showNote: true, showBookedInfo: true,
-    saveFn: 'saveCurrentSlot', deleteFn: 'deleteCurrentSlot' });
-  applyStrings();
-  _adminWireStrings();
-  // Enable unsaved-changes guard on all editable admin modals. The guard
-  // snapshots input state when a modal opens and confirms before closing
-  // if any field changed (bypassed when closeModal is called with force=true).
-  [
-    'memberModal', 'boatCatModal', 'boatModal', 'locationModal',
-    'clModal', 'launchCLModal', 'actTypeModal', 'volEventModal',
-    'certCatModal', 'certDefModal', 'recurSlotModal', 'slotModal',
-    'passportSettingsModal', 'passportItemModal', 'passportCategoryModal',
-    'memberCertModal',
-  ].forEach(id => { if (typeof guardUnsavedChanges === 'function') guardUnsavedChanges(id); });
-  loadAll().then(() => {
-    const p = new URLSearchParams(window.location.search);
-    const top = p.get('top') || 'members';
-    showTopTab(top);
-    if (top === 'settings') showTab(p.get('tab') || 'boats');
-  });
-
-  document.getElementById("bOOS").addEventListener("change", e => {
-    document.getElementById("oosReasonField").classList.toggle("hidden", !e.target.checked);
-  });
-
-  // Auto-generate key from EN label in category modal
-  document.getElementById("bcLabelEN").addEventListener("input", e => {
-    if (!_bcEditingId) {
-      document.getElementById("bcKey").value = e.target.value.toLowerCase().trim().replace(/\s+/g, '-');
-    }
-  });
-
-  warmContainer();
-});
-
-async function loadAll() {
-  const statusEl = document.getElementById("membersCard");
-  let cfgRes = {};
-  try {
-    if (statusEl) statusEl.innerHTML = '<div class="spinner"></div>';
-    const [mRes, cfgRes_] = await Promise.all([
-      window._earlyMembers || apiGet("getMembers"),
-      window._earlyConfig || apiGet("getConfig"),
-    ]);
-    members  = mRes.members || [];
-    cfgRes   = cfgRes_;
-  } catch(e) {
-    console.error("loadAll failed:", e);
-    if (statusEl) statusEl.innerHTML = `<div class="empty-state">${s('admin.loadFailed')}: ${e.message}</div>`;
-    return;
-  }
-
-  // Load volunteer signups in the background so the volunteer tab can show
-  // who signed up for each role (with phone if the member opted in).
-  apiPost('getVolunteerSignups', {}).then(res => {
-    volunteerSignups = (res && res.signups) || [];
-    renderVolunteerEvents();
-  }).catch(e => { console.warn('getVolunteerSignups failed:', e.message); });
-
-  // ── Assign data ───────────────────────────────────────────────────────────
-  actTypes        = cfgRes.activityTypes || [];
-  volunteerEvents = cfgRes.volunteerEvents || [];
-  clItems        = [ ...(cfgRes.dailyChecklist?.opening || []),
-                     ...(cfgRes.dailyChecklist?.closing  || []) ];
-  certDefs       = certDefsFromConfig(cfgRes.certDefs || []);
-  certCategories = certCategoriesFromConfig(cfgRes.certCategories || []);
-  _allBoats      = cfgRes.boats      || [];
-  _allLocations  = cfgRes.locations  || [];
-  _allBoatCats   = cfgRes.boatCategories?.length ? cfgRes.boatCategories : JSON.parse(JSON.stringify(DEFAULT_BOAT_CATS));
-  boats          = _allBoats    .filter(b => b.active !== false && b.active !== 'false');
-  locations      = _allLocations.filter(l => l.active !== false && l.active !== 'false');
-  boatCats       = _allBoatCats .filter(c => c.active !== false && c.active !== 'false');
-  registerBoatCats(boatCats);
-
-  try { loadCharterCalendars(cfgRes.charterCalendars || {}); } catch(e) { console.warn("loadCharterCalendars:", e.message); }
-  try { loadClubCalendars(cfgRes.clubCalendars || []); } catch(e) { console.warn("loadClubCalendars:", e.message); }
-  try { loadAlertConfig(cfgRes.overdueAlerts); }   catch(e) { console.warn("loadAlertConfig:", e.message); }
-  try { loadLaunchChecklists(cfgRes.launchChecklists || {}); } catch(e) { console.warn("loadLaunchChecklists:", e.message); }
-  try { loadFlagConfigPanel(cfgRes.flagConfig); }  catch(e) { console.warn("loadFlagConfigPanel:", e.message); }
-
-  renderMembers(); renderBoats(); renderLocations();
-  renderChecklists(); renderActTypes(); renderVolunteerEvents();
-  renderCertDefs(); renderCertCategories();
-  populateCategorySelects();
-}
-
-function _adminWireStrings() {
-  const search = document.getElementById('memberSearch');
-  if (search) search.placeholder = s('admin.searchMembers');
-  const bOwnerSearch = document.getElementById('bOwnerSearch');
-  if (bOwnerSearch) bOwnerSearch.placeholder = s('admin.searchMember');
-  const mInitials = document.getElementById('mInitials');
-  if (mInitials) mInitials.placeholder = s('admin.initialsPlaceholder');
-}
-
-// ── Collapsible sections ───────────────────────────────────────────────────────
-function toggleSection(head) {
-  const body   = head.nextElementSibling;
-  const toggle = head.querySelector(".col-toggle");
-  const isOpen = !body.classList.contains("hidden");
-  body.classList.toggle("hidden",  isOpen);
-  head.classList.toggle("open",   !isOpen);
-  toggle.classList.toggle("open", !isOpen);
-}
-
-// ── Top-level tab switching ────────────────────────────────────────────────────
-function showTopTab(top) {
-  document.querySelectorAll('#topTabBar .tab-btn').forEach(b => {
-    b.classList.toggle('active', b.dataset.top === top);
-  });
-  document.getElementById('top-members').classList.toggle('hidden', top !== 'members');
-  document.getElementById('top-settings').classList.toggle('hidden', top !== 'settings');
-  document.getElementById('top-payroll').classList.toggle('hidden', top !== 'payroll');
-  if (top === 'settings') {
-    const active = document.querySelector('#settingsTabBar .tab-btn.active');
-    showTab(active ? active.dataset.tab : 'boats');
-  }
-  if (top === 'payroll') {
-    const frame = document.getElementById('payrollFrame');
-    if (frame.src === 'about:blank' || !frame.src.includes('payroll/')) {
-      frame.src = 'payroll/?embed=1';
-    }
-  }
-  const url = new URL(window.location.href);
-  url.searchParams.set('top', top);
-  if (top !== 'settings') url.searchParams.delete('tab');
-  history.replaceState(null, '', url);
-  window.scrollTo({ top: 0, behavior: 'smooth' });
-}
-
-// ── Settings sub-tab switching ─────────────────────────────────────────────────
-function showTab(tab) {
-  document.querySelectorAll('#top-settings > [id^="tab-"]').forEach(el => el.classList.add('hidden'));
-  document.querySelectorAll('#settingsTabBar .tab-btn').forEach(b => {
-    b.classList.toggle('active', b.dataset.tab === tab);
-  });
-  const sel = document.getElementById('settingsTabSelect');
-  if (sel) sel.value = tab;
-  const el = document.getElementById('tab-' + tab);
-  if (el) el.classList.remove('hidden');
-
-  if (tab === 'certs') renderCertDefs();
-  if (tab === 'slotCal') initSlotCalendar();
-  if (tab === 'volunteers') renderVolunteerEvents();
-  if (tab === 'passport') renderPassportAdmin();
-
-  const url = new URL(window.location.href);
-  url.searchParams.set('tab', tab);
-  history.replaceState(null, '', url);
-  window.scrollTo({ top: 0, behavior: 'smooth' });
-}
-
-// ── Member sub-navigation ──────────────────────────────────────────────────────
-function showMemberSub(sub) {
-  document.getElementById('memberSubList').classList.toggle('hidden', sub === 'import');
-  document.getElementById('memberSubImport').classList.toggle('hidden', sub !== 'import');
-}
-
-// ── Generic entity save ────────────────────────────────────────────────────────
-async function saveEntity({ apiAction, getArray, setArray, payload, modalId, renderFn, btn }) {
-  if (btn) btn.disabled = true;
-  try {
-    const res = await apiPost(apiAction, payload);
-    const arr = getArray();
-    if (!payload.id && res.id) {
-      setArray([...arr, { ...payload, id: res.id }]);
-    } else {
-      setArray(arr.map(x => x.id === payload.id ? { ...x, ...payload } : x));
-      if (!arr.find(x => x.id === payload.id)) setArray([...arr, payload]);
-    }
-    if (modalId) closeModal(modalId, true);
-    if (renderFn) renderFn();
-    toast(s("toast.saved"));
-  } catch(e) {
-    toast(s("toast.saveFailed") + ": " + e.message, "err");
-  } finally {
-    if (btn) btn.disabled = false;
-  }
-}
-
-// ── Populate selects driven by boatCats ───────────────────────────────────────
-function populateCategorySelects() {
-  const L      = getLang();
-  const locale = L === 'IS' ? 'is' : 'en';
-  const sorted = boatCats.slice().sort((a, b) => {
-    const la = (L === 'IS' && a.labelIS ? a.labelIS : a.labelEN) || '';
-    const lb = (L === 'IS' && b.labelIS ? b.labelIS : b.labelEN) || '';
-    return la.localeCompare(lb, locale, { sensitivity: 'base' });
-  });
-  const opts = sorted.map(c =>
-    `<option value="${esc(c.key)}">${esc(c.emoji || '')} ${esc(L === 'IS' && c.labelIS ? c.labelIS : c.labelEN)}</option>`
-  ).join('');
-
-  // Boat modal category select
-  const bCat = document.getElementById("bCategory");
-  if (bCat) bCat.innerHTML = opts;
-
-  // Launch CL category filter
-  const lcFilter = document.getElementById("launchCLCatFilter");
-  if (lcFilter) {
-    const prev = lcFilter.value;
-    lcFilter.innerHTML = opts;
-    if (boatCats.find(c => c.key === prev)) lcFilter.value = prev;
-  }
-
-  // Launch CL modal category select
-  const lcCat = document.getElementById("lcCat");
-  if (lcCat) lcCat.innerHTML = opts;
-}
-
-// ══ MEMBERS ══════════════════════════════════════════════════════════════════
-
-function filterMembers() {
-  const q = document.getElementById("memberSearch").value.toLowerCase();
-  const active = members.filter(m => bool(m.active) &&
-    (String(m.name||"").toLowerCase().includes(q) || String(m.kennitala||"").includes(q)));
-  renderMemberList(active);
-}
-
-function renderMembers() {
-  const active = members.filter(m => bool(m.active));
-  document.getElementById("memberCountLabel").textContent = `(${active.length})`;
-  renderMemberList(active);
-}
-
-var _memberListData = [];
-var _memberDupNames = null;
-var _memberRendered = 0;
-var _memberObserver = null;
-var _MEMBER_BATCH = 50;
-
-function renderMemberList(list) {
-  const card = document.getElementById("membersCard");
-  if (!list.length) { card.innerHTML = `<div class="empty-state">${s('admin.noMembers')}</div>`; return; }
-  _memberListData = list;
-  _memberDupNames = duplicateMemberNames(list);
-  _memberRendered = 0;
-  card.innerHTML = '';
-  _renderMemberBatch(card);
-  _setupMemberScrollObserver(card);
-}
-
-function _renderMemberBatch(card) {
-  var end = Math.min(_memberRendered + _MEMBER_BATCH, _memberListData.length);
-  var frag = document.createDocumentFragment();
-  for (var i = _memberRendered; i < end; i++) {
-    var m = _memberListData[i];
-    var row = document.createElement('div');
-    row.className = 'member-row';
-    row.innerHTML =
-      `<span class="member-name">${esc((_memberDupNames && _memberDupNames.has(m.name) && m.birthYear) ? (m.name + ' (' + m.birthYear + ')') : (m.name || "—"))}</span>` +
-      `<span class="member-kt">${esc(m.kennitala || "")}</span>` +
-      `<button class="row-edit" onclick="openMemberModal('${m.id}')">Edit</button>` +
-      `<button class="row-edit" onclick="openMemberCertModal('${m.id}')" style="font-size:10px">${s('admin.manageCreds')}</button>`;
-    frag.appendChild(row);
-  }
-  var oldSentinel = card.querySelector('.member-scroll-sentinel');
-  if (oldSentinel) oldSentinel.remove();
-  card.appendChild(frag);
-  _memberRendered = end;
-  if (_memberRendered < _memberListData.length) {
-    var sentinel = document.createElement('div');
-    sentinel.className = 'member-scroll-sentinel';
-    sentinel.style.height = '1px';
-    card.appendChild(sentinel);
-  }
-}
-
-function _setupMemberScrollObserver(card) {
-  if (_memberObserver) _memberObserver.disconnect();
-  if (!('IntersectionObserver' in window)) return;
-  _memberObserver = new IntersectionObserver(function(entries) {
-    if (entries[0].isIntersecting && _memberRendered < _memberListData.length) {
-      _renderMemberBatch(card);
-    }
-  }, { rootMargin: '200px' });
-  var sentinel = card.querySelector('.member-scroll-sentinel');
-  if (sentinel) _memberObserver.observe(sentinel);
-}
-
-function openMemberModal(id) {
-  editingId = id || null;
-  const m   = id ? members.find(x => x.id === id) : null;
-  document.getElementById("memberModalTitle").textContent = m ? s('admin.memberModal.edit') : s('admin.memberModal.add');
-  document.getElementById("mName").value           = m ? (m.name         || "") : "";
-  document.getElementById("mKennitala").value      = m ? (m.kennitala    || "") : "";
-  document.getElementById("mEmail").value          = m ? (m.email        || "") : "";
-  document.getElementById("mPhone").value          = m ? (m.phone        || "") : "";
-  document.getElementById("mInitials").value       = m ? (m.initials     || "") : "";
-  document.getElementById("mDob").value            = m ? (m.dob          || "") : "";
-  document.getElementById("mRole").value           = m ? (m.role         || "member") : "member";
-  document.getElementById("mGuardianName").value   = m ? (m.guardianName  || "") : "";
-  document.getElementById("mGuardianKt").value     = m ? (m.guardianKt   || "") : "";
-  document.getElementById("mGuardianPhone").value  = m ? (m.guardianPhone || "") : "";
-  document.getElementById("mActive").checked       = m ? bool(m.active)  : true;
-  document.getElementById("mDeleteBtn").classList.toggle("hidden", !m);
-  // Show a compact password status + reset button for existing members.
-  var pwBox = document.getElementById("mPwBox");
-  if (m) {
-    pwBox.classList.remove("hidden");
-    var status = document.getElementById("mPwStatus");
-    if (m.hasPassword) {
-      status.textContent = s('admin.hasCustomPassword');
-      status.style.color = 'var(--muted)';
-    } else {
-      status.textContent = s('admin.usingDefaultPassword');
-      status.style.color = 'var(--brass)';
-    }
-    document.getElementById("mResetPwBtn").disabled = !m.hasPassword;
-  } else {
-    pwBox.classList.add("hidden");
-  }
-  openModal("memberModal");
-}
-
-async function resetMemberPassword() {
-  if (!editingId) return;
-  var m = members.find(function(x) { return x.id === editingId; });
-  if (!m) return;
-  var name = m.name || m.kennitala;
-  if (!(await ymConfirm(s('admin.resetPasswordConfirm').replace('{name}', name)))) return;
-  var btn = document.getElementById('mResetPwBtn');
-  btn.disabled = true;
-  try {
-    var res = await apiPost('adminResetMemberPassword', { kennitala: m.kennitala });
-    m.hasPassword = false;
-    var status = document.getElementById('mPwStatus');
-    status.textContent = s('admin.usingDefaultPassword');
-    status.style.color = 'var(--brass)';
-    var n = (res && typeof res.sessionsRevoked === 'number') ? res.sessionsRevoked : 0;
-    toast(s('admin.resetPasswordDone').replace('{n}', n), 'ok');
-    if (res && res.tempPassword) {
-      showTempPasswordDialog([{ name: name, kennitala: m.kennitala, tempPassword: res.tempPassword }]);
-    }
-  } catch (e) {
-    toast(s('toast.error') + ': ' + e.message, 'err');
-    btn.disabled = false;
-  }
-}
-
-// Show a modal listing one or more admin-issued temp passwords with copy
-// buttons. Called after saveMember/adminResetMemberPassword/importMembers
-// whenever the backend returns plaintext temp credentials. The modal must
-// stay open long enough for the admin to record the value — the server
-// never retains it.
-function showTempPasswordDialog(items) {
-  if (!items || !items.length) return;
-  var overlay = document.createElement('div');
-  overlay.className = 'modal-overlay';
-  overlay.style.zIndex = '300';
-  var box = document.createElement('div');
-  box.className = 'modal';
-  box.style.maxWidth = '480px';
-  var heading = document.createElement('h3');
-  heading.style.margin = '0 0 8px';
-  heading.textContent = items.length === 1 ? s('admin.tempPasswordTitle') : s('admin.tempPasswordTitlePlural');
-  var warn = document.createElement('p');
-  warn.style.cssText = 'color:var(--muted);margin:0 0 14px;font-size:13px';
-  warn.textContent = s('admin.tempPasswordWarning');
-  box.appendChild(heading);
-  box.appendChild(warn);
-  items.forEach(function(it) {
-    var row = document.createElement('div');
-    row.style.cssText = 'margin-bottom:10px;padding:8px;border:1px solid var(--border);border-radius:6px';
-    var label = document.createElement('div');
-    label.style.cssText = 'font-size:12px;color:var(--muted)';
-    label.textContent = (it.name || '') + (it.kennitala ? ' · ' + it.kennitala : '');
-    var pwRow = document.createElement('div');
-    pwRow.style.cssText = 'display:flex;gap:8px;align-items:center;margin-top:4px';
-    var code = document.createElement('code');
-    code.style.cssText = 'flex:1;font-size:16px;font-family:monospace;padding:4px 8px;background:var(--faint);border-radius:4px;user-select:all';
-    code.textContent = it.tempPassword;
-    var btn = document.createElement('button');
-    btn.className = 'btn btn-ghost';
-    btn.textContent = s('admin.tempPasswordCopy');
-    btn.onclick = function() {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(it.tempPassword).then(function() {
-          toast(s('admin.tempPasswordCopied'), 'ok');
-        });
-      }
-    };
-    pwRow.appendChild(code);
-    pwRow.appendChild(btn);
-    row.appendChild(label);
-    row.appendChild(pwRow);
-    box.appendChild(row);
-  });
-  var btnRow = document.createElement('div');
-  btnRow.className = 'ym-dialog-btns';
-  btnRow.style.marginTop = '14px';
-  var closeBtn = document.createElement('button');
-  closeBtn.className = 'btn btn-primary';
-  closeBtn.textContent = s('btn.close');
-  closeBtn.onclick = function() { overlay.remove(); };
-  btnRow.appendChild(closeBtn);
-  box.appendChild(btnRow);
-  overlay.appendChild(box);
-  overlay.addEventListener('click', function(e) { if (e.target === overlay) overlay.remove(); });
-  document.body.appendChild(overlay);
-}
-
-async function saveMember() {
-  const name      = document.getElementById("mName").value.trim();
-  const kennitala = document.getElementById("mKennitala").value.trim();
-  if (!name || !kennitala) { toast(s("admin.nameKtRequired"), "err"); return; }
-
-  const id      = editingId || ("mbr_" + Date.now().toString(36));
-  const payload = {
-    id, name, kennitala,
-    email:          document.getElementById("mEmail").value.trim(),
-    phone:          document.getElementById("mPhone").value.trim(),
-    initials:       document.getElementById("mInitials").value.trim().toUpperCase(),
-    dob:            document.getElementById("mDob").value,
-    role:           document.getElementById("mRole").value,
-    guardianName:   document.getElementById("mGuardianName").value.trim(),
-    guardianKt:     document.getElementById("mGuardianKt").value.trim(),
-    guardianPhone:  document.getElementById("mGuardianPhone").value.trim(),
-    active:         document.getElementById("mActive").checked,
-  };
-
-  try {
-    const res = await apiPost("saveMember", payload);
-    const idx = members.findIndex(x => x.id === id);
-    if (idx >= 0) members[idx] = { ...members[idx], ...payload };
-    else          members.push(payload);
-    closeModal("memberModal", true);
-    renderMembers();
-    toast(s("toast.saved"));
-    const temps = [];
-    if (res && res.tempPassword) temps.push({ name: name, kennitala: kennitala, tempPassword: res.tempPassword });
-    if (res && res.guardianTempPassword) temps.push(res.guardianTempPassword);
-    if (temps.length) showTempPasswordDialog(temps);
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-async function deactivateMember(id) {
-  if (!await ymConfirm(s("admin.confirmDeactivateMember"))) return;
-  try {
-    await apiPost("deleteMember", { id });
-    members = members.filter(m => m.id !== id);
-    renderMembers();
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-async function deleteMember() { await deactivateMember(editingId); closeModal("memberModal", true); }
-
-// ══ BOAT CATEGORIES ══════════════════════════════════════════════════════════
-
-function renderBoatCats() {
-  const card   = document.getElementById("boatCatsCard");
-  const locale = getLang() === 'IS' ? 'is' : 'en';
-  const active = _allBoatCats
-    .filter(c => c.active !== false && c.active !== 'false')
-    .sort((a, b) => {
-      const la = (getLang() === 'IS' && a.labelIS ? a.labelIS : a.labelEN) || '';
-      const lb = (getLang() === 'IS' && b.labelIS ? b.labelIS : b.labelEN) || '';
-      return la.localeCompare(lb, locale, { sensitivity: 'base' });
-    });
-  if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noCategories')}</div>`; return; }
-   card.innerHTML = active.map(c => `
-    <div class="list-row">
-      <span style="font-size:18px;width:28px;flex-shrink:0">${esc(c.emoji || '⛵')}</span>
-      <span class="list-name">
-        <strong>${esc(c.labelEN)}</strong>
-        ${c.labelIS ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(c.labelIS)}</span>` : ''}
-        <span style="color:var(--border);font-size:10px;margin-left:8px">${esc(c.key)}</span>
-      </span>
-      <button class="row-edit" onclick="openBoatCatModal('${c.key}')">Edit</button>
-    </div>`).join("");
-}
-
-function openBoatCatModal(key) {
-  _bcEditingId = key || null;
-  const c = key ? _allBoatCats.find(x => x.key === key) : null;
-  document.getElementById("boatCatModalTitle").textContent = c ? s('admin.boatCatModal.edit') : s('admin.boatCatModal.add');
-  document.getElementById("bcLabelEN").value   = c ? (c.labelEN || "") : "";
-  document.getElementById("bcLabelIS").value   = c ? (c.labelIS || "") : "";
-  document.getElementById("bcEmoji").value     = c ? (c.emoji   || "") : "";
-  document.getElementById("bcKey").value       = c ? c.key : "";
-  document.getElementById("bcKey").readOnly    = !!c;  // key immutable after creation
-  document.getElementById("bcActive").checked  = c ? bool(c.active) : true;
-  document.getElementById("bcDeleteBtn").classList.toggle("hidden", !c);
-  openModal("boatCatModal");
-}
-
-async function saveBoatCat() {
-  const labelEN = document.getElementById("bcLabelEN").value.trim();
-  const key     = document.getElementById("bcKey").value.trim().toLowerCase().replace(/\s+/g,'-');
-  if (!labelEN || !key) { toast(s("admin.nameKeyRequired"), "err"); return; }
-
-  const payload = {
-    key,
-    labelEN,
-    labelIS:  document.getElementById("bcLabelIS").value.trim(),
-    emoji:    document.getElementById("bcEmoji").value.trim(),
-    active:   document.getElementById("bcActive").checked,
-  };
-
-  const idx = _allBoatCats.findIndex(x => x.key === key);
-  if (idx >= 0) _allBoatCats[idx] = { ..._allBoatCats[idx], ...payload };
-  else          _allBoatCats.push(payload);
-
-  try {
-    await apiPost("saveConfig", { boatCategories: _allBoatCats });
-    boatCats = _allBoatCats.filter(c => c.active !== false && c.active !== 'false');
-    registerBoatCats(boatCats);
-    closeModal("boatCatModal", true);
-    renderBoatCats();
-    renderBoats();
-    populateCategorySelects();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-async function deleteBoatCat() {
-  const key = _bcEditingId;
-  if (!key || !await ymConfirm(s("admin.confirmRemoveBoatCat"))) return;
-  _allBoatCats = _allBoatCats.map(c => c.key === key ? { ...c, active: false } : c);
-  try {
-    await apiPost("saveConfig", { boatCategories: _allBoatCats });
-    boatCats = _allBoatCats.filter(c => c.active !== false && c.active !== 'false');
-    registerBoatCats(boatCats);
-    closeModal("boatCatModal", true);
-    renderBoatCats();
-    renderBoats();
-    populateCategorySelects();
-    toast(s("toast.deleted"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-// ══ BOATS ═════════════════════════════════════════════════════════════════════
-
-function renderBoats() {
-  const el     = document.getElementById("boatSections");
-  const active = boats.filter(b => bool(b.active));
-  if (!active.length) { el.innerHTML = `<div class="empty-state">${s('admin.noBoats')}</div>`; return; }
-
-  const groups = {};
-  boatCats.forEach(c => { groups[c.key] = []; });
-  groups['other'] = groups['other'] || [];
-  active.forEach(b => {
-    const k = (b.category || 'other').toLowerCase();
-    if (groups[k]) groups[k].push(b); else groups['other'].push(b);
-  });
-
-  const L      = getLang();
-  const locale = L === 'IS' ? 'is' : 'en';
-  const sortedCats = boatCats.slice().sort((a, b) => {
-    const la = (L === 'IS' && a.labelIS ? a.labelIS : a.labelEN) || '';
-    const lb = (L === 'IS' && b.labelIS ? b.labelIS : b.labelEN) || '';
-    return la.localeCompare(lb, locale, { sensitivity: 'base' });
-  });
-  el.innerHTML = sortedCats
-    .map(cat => {
-      const label = (L === 'IS' && cat.labelIS) ? cat.labelIS : cat.labelEN;
-      const cards = (groups[cat.key] || []).map(b => `
-        <div class="boat-card${bool(b.oos) ? " oos" : ""}">
-          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:6px;margin-bottom:4px">
-            <div class="boat-card-name">${cat.emoji || boatEmoji(cat.key)} ${esc(b.name)}</div>
-            <div style="display:flex;gap:4px;flex-shrink:0">
-              ${b.accessMode === 'controlled' ? `<span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass-fg)">${esc(s('fleet.badgeControlled'))}</span>` : ""}
-              ${bool(b.oos) ? `<span class="oos-badge">OOS</span>` : ""}
-              ${boatCatBadge(cat.key)}
-            </div>
-          </div>
-          ${b.oosReason ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${esc(b.oosReason)}</div>` : ""}
-          ${(b.registrationNo || b.typeModel) ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
-          <div class="boat-card-actions">
-            <button class="row-edit" style="flex:1" onclick="openBoatModal('${b.id}')">Edit</button>
-            <button class="row-edit" onclick="showBoatQR('${b.id}')" title="Show QR code">🔳</button>
-            <button class="row-del"  onclick="deleteBoat('${b.id}')" title="Delete">×</button>
-          </div>
-        </div>`).join("");
-
-      return `<div class="col-section">
-        <div class="col-head" onclick="toggleSection(this)">
-          <div class="col-title">${cat.emoji || boatEmoji(cat.key)} ${boatCatBadge(cat.key)}</div>
-          <div style="display:flex;align-items:center;gap:6px" onclick="event.stopPropagation()">
-            <button class="row-edit" onclick="openBoatModalForCat('${cat.key}')">+ Add boat</button>
-            <button class="row-edit" onclick="openBoatCatModal('${cat.key}')">Edit</button>
-            <span class="col-toggle">▼</span>
-          </div>
-        </div>
-        <div class="col-body hidden">
-          <div class="boat-grid">${cards}</div>
-        </div>
-      </div>`;
-    }).join("");
-}
-  
-function openBoatModalForCat(catKey) {
-  openBoatModal();
-  const sel = document.getElementById('bCategory');
-  if (sel) sel.value = catKey;
-}
-  
-function populateDefaultPortSelect(selectedId) {
-  const sel = document.getElementById("bDefaultPortId");
-  if (!sel) return;
-  const ports = _allLocations.filter(l => l.type === 'port' && (l.active !== false && l.active !== 'false'));
-  sel.innerHTML = `<option value="">${s('admin.optionNone')}</option>` +
-    ports.map(p => `<option value="${esc(p.id)}"${p.id === selectedId ? ' selected' : ''}>${esc(p.name)}</option>`).join('');
-}
-
-function updateBoatModalFields() {
-  const cat = document.getElementById("bCategory").value;
-  const isKeelboat = cat === 'keelboat';
-  const lbl = document.getElementById("bRegNoLabel");
-  const inp = document.getElementById("bRegNo");
-  lbl.setAttribute("data-s", isKeelboat ? "boat.registrationNo" : "boat.sailNo");
-  lbl.textContent = s(isKeelboat ? 'boat.registrationNo' : 'boat.sailNo');
-  inp.placeholder = isKeelboat ? "e.g. ÍS-342" : "e.g. 1234";
-}
-
-function openBoatModal(id) {
-  editingId = id || null;
-  const b   = id ? _allBoats.find(x => x.id === id) : null;
-  document.getElementById("boatModalTitle").textContent = b ? s('admin.boatModal.edit') : s('admin.boatModal.add');
-  populateCategorySelects();  // ensure select is fresh
-  document.getElementById("bName").value      = b ? b.name                     : "";
-  document.getElementById("bCategory").value  = b ? (b.category || boatCats[0]?.key || "dinghy") : (boatCats[0]?.key || "dinghy");
-  document.getElementById("bOOS").checked     = b ? bool(b.oos)                : false;
-  document.getElementById("bOOSReason").value = b ? (b.oosReason || "")       : "";
-  document.getElementById("oosReasonField").classList.toggle("hidden", !b || !bool(b.oos));
-  document.getElementById("bActive").checked  = b ? bool(b.active)            : true;
-  document.getElementById("bDeleteBtn").classList.toggle("hidden", !b);
-  // Keelboat-only fields
-  document.getElementById("bRegNo").value      = b ? (b.registrationNo || "") : "";
-  document.getElementById("bLoa").value        = b ? (b.loa || "")            : "";
-  document.getElementById("bTypeModel").value  = b ? (b.typeModel || "")      : "";
-  populateDefaultPortSelect(b ? (b.defaultPortId || "") : "");
-  // Ownership
-  document.getElementById("bOwnership").value = b && b.ownership === 'private' ? 'private' : 'club';
-  document.getElementById("bOwnerId").value   = b ? (b.ownerId || '') : '';
-  document.getElementById("bOwnerSearch").value = '';
-  document.getElementById("bOwnerName").textContent = b && b.ownerName ? b.ownerName : '';
-  document.getElementById("bOwnerSuggestions").innerHTML = '';
-  // Access mode
-  document.getElementById("bAccessMode").value = b && b.accessMode === 'controlled' ? 'controlled' : 'free';
-  populateGateCertSelect(_currentGateFor(b));
-  _editAllowlist = b && Array.isArray(b.accessAllowlist) ? b.accessAllowlist.slice() : [];
-  renderAllowlistChips();
-  updateAccessFields();
-  // Slot scheduling
-  document.getElementById("bSlotScheduling").checked = b && boolVal(b.slotSchedulingEnabled);
-  document.getElementById("bAvailOutside").checked = b ? (b.availableOutsideSlots === undefined || b.availableOutsideSlots === null || boolVal(b.availableOutsideSlots)) : true;
-  updateSlotFields();
-  // Reservations
-  document.getElementById("bReservationForm").classList.add("hidden");
-  document.getElementById("bResMemberKt").value = '';
-  document.getElementById("bResMemberSearch").value = '';
-  document.getElementById("bResMemberName").textContent = '';
-  document.getElementById("bResStart").value = '';
-  document.getElementById("bResEnd").value = '';
-  document.getElementById("bResNote").value = '';
-  renderReservationList(b);
-  updateOwnershipFields();
-  updateBoatModalFields();
-  applyStrings(document.getElementById("boatModal"));
-  openModal("boatModal");
-}
-
-// ── Ownership helpers ──────────────────────────────────────────────────────────
-function updateOwnershipFields() {
-  const isPrivate = document.getElementById("bOwnership").value === 'private';
-  document.getElementById("bOwnerField").classList.toggle("hidden", !isPrivate);
-}
-
-function searchBoatOwner(q) {
-  const drop = document.getElementById("bOwnerSuggestions");
-  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
-  const ql = q.toLowerCase();
-  const hits = members.filter(m => (m.name||'').toLowerCase().includes(ql)).slice(0, 8);
-  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
-  drop.innerHTML = hits.map(m => `<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"
-    onclick="selectBoatOwner('${esc(m.kennitala)}','${esc(memberDisplayName(m, members))}')">${esc(memberDisplayName(m, members))}</div>`).join('');
-  drop.style.display = 'block';
-}
-
-function selectBoatOwner(kt, name) {
-  document.getElementById("bOwnerId").value = kt;
-  document.getElementById("bOwnerSearch").value = '';
-  document.getElementById("bOwnerName").textContent = name;
-  document.getElementById("bOwnerSuggestions").innerHTML = '';
-  document.getElementById("bOwnerSuggestions").style.display = 'none';
-}
-
-// ── Access control helpers ────────────────────────────────────────────────────
-var _editAllowlist = [];
-
-function updateAccessFields() {
-  var isControlled = document.getElementById("bAccessMode").value === 'controlled';
-  document.getElementById("bAccessControlledSection").classList.toggle("hidden", !isControlled);
-  document.getElementById("bSlotSchedulingSection").classList.toggle("hidden", !isControlled);
-}
-
-function updateSlotFields() {
-  var enabled = document.getElementById("bSlotScheduling").checked;
-  document.getElementById("bSlotOptions").classList.toggle("hidden", !enabled);
-}
-
-// Encode a gate descriptor as a stable option value. Empty fields are omitted
-// and the result is a compact JSON string. Decoded by _decodeGateValue().
-function _encodeGateValue(gate) {
-  if (!gate || !gate.certId) return '';
-  var out = { certId: gate.certId };
-  if (gate.sub) out.sub = gate.sub;
-  if (gate.minRank) out.minRank = Number(gate.minRank);
-  return JSON.stringify(out);
-}
-function _decodeGateValue(v) {
-  if (!v) return null;
-  try { var o = JSON.parse(v); return (o && o.certId) ? o : null; } catch (e) { return null; }
-}
-// Return the stored gate for a boat as a {certId, sub, minRank} object, or
-// null. Uses normalizeAccessGate (from shared/boats.js) so legacy boats with
-// just accessGateCert still resolve to the correct {certId, sub} pair.
-function _currentGateFor(boat) {
-  if (!boat) return null;
-  if (typeof normalizeAccessGate === 'function') {
-    return normalizeAccessGate(boat, certDefs);
-  }
-  // Defensive fallback — should not trigger in practice.
-  if (boat.accessGate && boat.accessGate.certId) return boat.accessGate;
-  return null;
-}
-
-function populateGateCertSelect(currentGate) {
-  var sel = document.getElementById("bGateCert");
-  sel.innerHTML = '<option value="">' + esc(s('boat.gateCertNone')) + '</option>';
-  var selectedVal = _encodeGateValue(currentGate);
-  // Build options: one entry per credential "grade".
-  //   Flat defs (no subcats) → a single def-level entry.
-  //   Defs with subcats → a def-level "(any level)" entry, one exact-match
-  //     entry per subcat, plus a "… or higher" entry for each ranked subcat.
-  var anyLbl   = s('boat.gateCertAny');
-  var orHigher = s('boat.gateCertOrHigher');
-  (certDefs || []).forEach(function(def) {
-    if (!def || !def.id) return;
-    var defName = certDefName(def);
-    var subs    = Array.isArray(def.subcats) ? def.subcats : [];
-    if (!subs.length) {
-      var v0 = _encodeGateValue({ certId: def.id });
-      sel.innerHTML += '<option value="' + esc(v0) + '"' + (v0 === selectedVal ? ' selected' : '') + '>'
-        + esc(defName) + '</option>';
-      return;
-    }
-    // def-level "(any level)" option
-    var vAny = _encodeGateValue({ certId: def.id });
-    sel.innerHTML += '<option value="' + esc(vAny) + '"' + (vAny === selectedVal ? ' selected' : '') + '>'
-      + esc(defName + ' — ' + anyLbl) + '</option>';
-    // exact-match subcat options
-    subs.forEach(function(sc) {
-      if (!sc || !sc.key) return;
-      var vExact = _encodeGateValue({ certId: def.id, sub: sc.key });
-      sel.innerHTML += '<option value="' + esc(vExact) + '"' + (vExact === selectedVal ? ' selected' : '') + '>'
-        + esc(defName + ' — ' + certSubcatLabel(sc)) + '</option>';
-    });
-    // rank-or-higher options (only for subcats with a numeric rank)
-    subs.forEach(function(sc) {
-      if (!sc || !sc.key || !sc.rank) return;
-      var vRank = _encodeGateValue({ certId: def.id, minRank: Number(sc.rank) });
-      sel.innerHTML += '<option value="' + esc(vRank) + '"' + (vRank === selectedVal ? ' selected' : '') + '>'
-        + esc(defName + ' — ' + certSubcatLabel(sc) + ' ' + orHigher) + '</option>';
-    });
-  });
-}
-
-function renderAllowlistChips() {
-  var el = document.getElementById("bAllowlistChips");
-  if (!_editAllowlist.length) { el.innerHTML = ''; return; }
-  el.innerHTML = _editAllowlist.map(function(kt) {
-    var m = members.find(function(x) { return x.kennitala === kt; });
-    var name = m ? memberDisplayName(m, members) : kt;
-    return '<span style="font-size:10px;padding:3px 8px;border-radius:12px;background:var(--surface);border:1px solid var(--border);color:var(--text);display:inline-flex;align-items:center;gap:4px">'
-      + esc(name)
-      + '<span style="cursor:pointer;color:var(--red);font-size:12px" onclick="removeFromAllowlist(\'' + esc(kt) + '\')">&times;</span>'
-      + '</span>';
-  }).join('');
-}
-
-function searchAllowlistMember(q) {
-  var drop = document.getElementById("bAllowlistSuggestions");
-  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
-  var ql = q.toLowerCase();
-  var hits = members.filter(function(m) { return (m.name||'').toLowerCase().includes(ql) && _editAllowlist.indexOf(m.kennitala) === -1; }).slice(0, 8);
-  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
-  drop.innerHTML = hits.map(function(m) {
-    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-      + 'onclick="addToAllowlist(\'' + esc(m.kennitala) + '\')">' + esc(memberDisplayName(m, members)) + '</div>';
-  }).join('');
-  drop.style.display = 'block';
-}
-
-function addToAllowlist(kt) {
-  if (_editAllowlist.indexOf(kt) === -1) _editAllowlist.push(kt);
-  document.getElementById("bAllowlistSearch").value = '';
-  document.getElementById("bAllowlistSuggestions").innerHTML = '';
-  document.getElementById("bAllowlistSuggestions").style.display = 'none';
-  renderAllowlistChips();
-}
-
-function removeFromAllowlist(kt) {
-  _editAllowlist = _editAllowlist.filter(function(k) { return k !== kt; });
-  renderAllowlistChips();
-}
-
-// ── Reservation helpers ───────────────────────────────────────────────────────
-function renderReservationList(boat) {
-  var el = document.getElementById("bReservationList");
-  var actEl = document.getElementById("bReservationActions");
-  if (!boat || !boat.reservations || !boat.reservations.length) {
-    el.innerHTML = '';
-    actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" onclick="showResForm()">' + esc(s('boat.addReservation')) + '</button>';
-    return;
-  }
-  el.innerHTML = boat.reservations.map(function(r) {
-    return '<div style="font-size:11px;padding:6px 8px;background:var(--surface);border:1px solid var(--border);border-radius:6px;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center">'
-      + '<div><strong>' + esc(r.memberName) + '</strong> · ' + esc(r.startDate) + ' → ' + esc(r.endDate)
-      + (r.note ? ' · <span style="color:var(--muted)">' + esc(r.note) + '</span>' : '') + '</div>'
-      + '<button style="font-size:10px;background:none;border:none;color:var(--red);cursor:pointer" onclick="removeResFromModal(\'' + esc(r.id) + '\')">&times;</button>'
-      + '</div>';
-  }).join('');
-  actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" onclick="showResForm()">' + esc(s('boat.addReservation')) + '</button>';
-}
-
-function showResForm() {
-  document.getElementById("bReservationForm").classList.remove("hidden");
-}
-
-function cancelResForm() {
-  document.getElementById("bReservationForm").classList.add("hidden");
-}
-
-function searchResMember(q) {
-  var drop = document.getElementById("bResMemberSuggestions");
-  if (!q || q.length < 2) { drop.innerHTML=''; drop.style.display='none'; return; }
-  var ql = q.toLowerCase();
-  var hits = members.filter(function(m) { return (m.name||'').toLowerCase().includes(ql); }).slice(0, 8);
-  if (!hits.length) { drop.innerHTML=''; drop.style.display='none'; return; }
-  drop.innerHTML = hits.map(function(m) {
-    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)" '
-      + 'onclick="selectResMember(\'' + esc(m.kennitala) + '\',\'' + esc(memberDisplayName(m, members)) + '\')">' + esc(memberDisplayName(m, members)) + '</div>';
-  }).join('');
-  drop.style.display = 'block';
-}
-
-function selectResMember(kt, name) {
-  document.getElementById("bResMemberKt").value = kt;
-  document.getElementById("bResMemberSearch").value = '';
-  document.getElementById("bResMemberName").textContent = name;
-  document.getElementById("bResMemberSuggestions").innerHTML = '';
-  document.getElementById("bResMemberSuggestions").style.display = 'none';
-}
-
-async function saveResFromModal() {
-  var boatId = editingId;
-  if (!boatId) return;
-  var kt   = document.getElementById("bResMemberKt").value;
-  var name = document.getElementById("bResMemberName").textContent;
-  var start = document.getElementById("bResStart").value;
-  var end   = document.getElementById("bResEnd").value;
-  var note  = document.getElementById("bResNote").value.trim();
-  if (!kt || !name || !start || !end) { toast(s("admin.memberDatesRequired"), "err"); return; }
-  try {
-    var res = await apiPost('saveReservation', { boatId: boatId, memberKennitala: kt, memberName: name, startDate: start, endDate: end, note: note });
-    var b = _allBoats.find(function(x) { return x.id === boatId; });
-    if (b && res.boat) { b.reservations = res.boat.reservations; }
-    // Clear sub-form fields so the boat modal's dirty check doesn't flag
-    // the stale reservation inputs after a successful save.
-    document.getElementById("bResMemberKt").value = '';
-    document.getElementById("bResMemberSearch").value = '';
-    document.getElementById("bResMemberName").textContent = '';
-    document.getElementById("bResStart").value = '';
-    document.getElementById("bResEnd").value = '';
-    document.getElementById("bResNote").value = '';
-    cancelResForm();
-    renderReservationList(b);
-    if (typeof resnapshotModal === 'function') resnapshotModal('boatModal');
-    toast(s('boat.reservationSaved'));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function removeResFromModal(resId) {
-  var boatId = editingId;
-  if (!boatId) return;
-  if (!(await ymConfirm(s('boat.removeReservation') + '?'))) return;
-  try {
-    var res = await apiPost('removeReservation', { boatId: boatId, reservationId: resId });
-    var b = _allBoats.find(function(x) { return x.id === boatId; });
-    if (b && res.boat) { b.reservations = res.boat.reservations; }
-    renderReservationList(b);
-    toast(s('boat.reservationRemoved'));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function saveBoat() {
-  const name = document.getElementById("bName").value.trim();
-  if (!name) { toast(s("admin.nameRequired"), "err"); return; }
-
-  const id  = editingId || ("boat_" + Date.now().toString(36));
-  const cat = document.getElementById("bCategory").value;
-  const ownershipVal = document.getElementById("bOwnership").value;
-  const accessModeVal = document.getElementById("bAccessMode").value;
-  const payload = {
-    id, name,
-    category:      cat,
-    defaultPortId: document.getElementById("bDefaultPortId").value || "",
-    oos:           document.getElementById("bOOS").checked,
-    oosReason:     document.getElementById("bOOSReason").value.trim(),
-    active:        document.getElementById("bActive").checked,
-    registrationNo: document.getElementById("bRegNo").value.trim(),
-    // all boats
-    typeModel:      document.getElementById("bTypeModel").value.trim(),
-    loa:            parseFloat(document.getElementById("bLoa").value) || '',
-    // ownership
-    ownership:      ownershipVal,
-    ownerId:        ownershipVal === 'private' ? (document.getElementById("bOwnerId").value || '') : '',
-    ownerName:      ownershipVal === 'private' ? (document.getElementById("bOwnerName").textContent || '') : '',
-    // access control — new structured gate, plus legacy mirror for older readers
-    accessMode:     accessModeVal,
-    accessGate:     accessModeVal === 'controlled' ? _decodeGateValue(document.getElementById("bGateCert").value) : null,
-    accessGateCert: accessModeVal === 'controlled' ? (function() {
-      var _g = _decodeGateValue(document.getElementById("bGateCert").value);
-      return _g ? (_g.sub || _g.certId) : '';
-    })() : '',
-    accessAllowlist: accessModeVal === 'controlled' ? _editAllowlist.slice() : [],
-    // slot scheduling
-    slotSchedulingEnabled: accessModeVal === 'controlled' && document.getElementById("bSlotScheduling").checked,
-    availableOutsideSlots: accessModeVal === 'controlled' && document.getElementById("bSlotScheduling").checked ? document.getElementById("bAvailOutside").checked : true,
-  };
-
-  const idx = _allBoats.findIndex(x => x.id === id);
-  if (idx >= 0) {
-    // Preserve reservations (managed via separate endpoints)
-    payload.reservations = _allBoats[idx].reservations || [];
-    _allBoats[idx] = { ..._allBoats[idx], ...payload };
-  } else {
-    payload.reservations = [];
-    _allBoats.push(payload);
-  }
-
-  try {
-    await apiPost("saveConfig", { boats: _allBoats });
-    boats = _allBoats.filter(b => b.active !== false && b.active !== 'false');
-    closeModal("boatModal", true);
-    renderBoats();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-async function deleteBoat(id) {
-  const _id = id || editingId;
-  if (!await ymConfirm(s("admin.confirmDeleteBoat"))) return;
-  _allBoats = _allBoats.map(b => b.id === _id ? { ...b, active: false } : b);
-  try {
-    await apiPost("saveConfig", { boats: _allBoats });
-    boats = _allBoats.filter(b => b.active !== false && b.active !== 'false');
-    renderBoats();
-    closeModal("boatModal", true);
-    toast(s("toast.deleted"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-function showBoatQR(id) {
-  const b = boats.find(x => x.id === id);
-  if (!b) return;
-  const url = `${BASE_URL}/member/?boat=${id}`;
-  document.getElementById("qrBoatName").textContent = b.name;
-  document.getElementById("qrCategory").textContent = b.category || "";
-  document.getElementById("qrUrl").textContent = url;
-  document.getElementById("qrBoatId").textContent = id;
-  document.getElementById("qrImg").src = `https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(url)}`;
-  openModal("qrModal");
-}
-
-function printQR() {
-  const img = document.getElementById("qrImg").src;
-  const name = document.getElementById("qrBoatName").textContent;
-  const w = window.open("", "_blank");
-  w.document.write(`<html><body style="text-align:center;font-family:monospace;padding:20px">
-    <h2>${name}</h2><img src="${img}" style="width:200px"><br>
-    <small>${document.getElementById("qrUrl").textContent}</small>
-    <script>window.print();window.close();<\/script></body></html>`);
-}
-
-// ══ LOCATIONS ════════════════════════════════════════════════════════════════
-
-function renderLocations() {
-  const card   = document.getElementById("locationsCard");
-  const locale = getLang() === 'IS' ? 'is' : 'en';
-  const active = locations
-    .filter(l => bool(l.active))
-    .sort((a, b) => (a.name || '').localeCompare(b.name || '', locale, { sensitivity: 'base' }));
-  if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noLocations')}</div>`; return; }
-  card.innerHTML = active.map(l => `
-    <div class="list-row">
-      <span class="list-name">${esc(l.name)}${l.type==='port' ? ' <span style="font-size:9px;color:var(--brass-fg);border:1px solid var(--brass)44;border-radius:4px;padding:1px 5px;margin-left:4px">⚓️ PORT</span>' : ' <span style="font-size:9px;color:var(--ice);border:1px solid var(--ice)44;border-radius:4px;padding:1px 5px;margin-left:4px">⛵ SAILING AREA</span>'}</span>
-      <button class="row-edit" onclick="openLocationModal('${l.id}')">Edit</button>
-      <button class="row-del"  onclick="deleteLocation('${l.id}')">×</button>
-    </div>`).join("");
-}
-
-function openLocationModal(id) {
-  editingId = id || null;
-  const l   = id ? _allLocations.find(x => x.id === id) : null;
-  document.getElementById("locationModalTitle").textContent = l ? s('admin.locModal.edit') : s('admin.locModal.add');
-  document.getElementById("lName").value     = l ? l.name              : "";
-  document.getElementById("lType").value     = l ? (l.type || 'location') : 'location';
-  var coords = (l && l.coordinates) ? l.coordinates.split(",") : [null, null];
-  document.getElementById("lLat").value      = coords[0] || "";
-  document.getElementById("lLng").value      = coords[1] || "";
-  document.getElementById("lActive").checked = l ? bool(l.active)      : true;
-  document.getElementById("lDeleteBtn").classList.toggle("hidden", !l);
-  applyStrings(document.getElementById("locationModal"));
-  openModal("locationModal");
-}
-
-async function saveLocation() {
-  const name = document.getElementById("lName").value.trim();
-  if (!name) { toast(s("admin.nameRequired"), "err"); return; }
-
-  const id      = editingId || ("loc_" + Date.now().toString(36));
-  var latVal = document.getElementById("lLat").value.trim();
-  var lngVal = document.getElementById("lLng").value.trim();
-  var coordinates = (latVal && lngVal) ? latVal + "," + lngVal : "";
-  const payload = { id, name, type: document.getElementById("lType").value || 'location', active: document.getElementById("lActive").checked, coordinates: coordinates };
-
-  const idx = _allLocations.findIndex(x => x.id === id);
-  if (idx >= 0) _allLocations[idx] = { ..._allLocations[idx], ...payload };
-  else          _allLocations.push(payload);
-
-  try {
-    await apiPost("saveConfig", { locations: _allLocations });
-    locations = _allLocations.filter(l => l.active !== false && l.active !== 'false');
-    closeModal("locationModal", true);
-    renderLocations();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-async function deleteLocation(id) {
-  const _id = id || editingId;
-  if (!await ymConfirm(s("admin.confirmDeleteLocation"))) return;
-  _allLocations = _allLocations.map(l => l.id === _id ? { ...l, active: false } : l);
-  try {
-    await apiPost("saveConfig", { locations: _allLocations });
-    locations = _allLocations.filter(l => l.active !== false && l.active !== 'false');
-    renderLocations();
-    closeModal("locationModal", true);
-    toast(s("toast.deleted"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-// ══ OPENING / CLOSING CHECKLISTS ═════════════════════════════════════════════
-// Items stored in dailyChecklist.opening[] and dailyChecklist.closing[] in config.
-// Phase field on each item is "opening" or "closing".
-
-function renderChecklists() {
-  renderCLPhase("openingCLCard", "opening");
-  renderCLPhase("closingCLCard", "closing");
-}
-
-function renderCLPhase(cardId, phase) {
-  const card  = document.getElementById(cardId);
-  const items = clItems
-    .filter(i => String(i.phase).toLowerCase() === phase && bool(i.active))
-    .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
-  if (!items.length) { card.innerHTML = `<div class="empty-state">${s('admin.noItems')}</div>`; return; }
-  const btnId = 'clUpdateOrder_' + phase;
-  card.innerHTML = items.map(i => `
-    <div class="cl-row">
-      <input type="number" class="cl-sort-input" data-cl-id="${i.id}" data-cl-phase="${phase}"
-        value="${i.sortOrder || 99}" min="0" onchange="document.getElementById('${btnId}').classList.remove('hidden')">
-      <span style="flex:1;color:var(--text)">${esc(i.textEN || "")}${i.textIS
-        ? `<span style="color:var(--muted);font-size:11px;margin-left:6px">${esc(i.textIS)}</span>` : ""}</span>
-      <button class="row-edit" onclick="openCLModal('${i.id}')">Edit</button>
-      <button class="row-del"  onclick="deleteCLItem('${i.id}')">×</button>
-    </div>`).join("") +
-    `<button id="${btnId}" class="btn btn-primary cl-update-order hidden" onclick="updateCLOrder('${phase}')">Update Order</button>`;
-}
-
-function openCLModal(id) {
-  editingId    = id || null;
-  const item   = id ? clItems.find(x => x.id === id) : null;
-  document.getElementById("clModalTitle").textContent = item ? s('admin.clModal.edit') : s('admin.clModal.add');
-  document.getElementById("clPhase").value    = item ? (item.phase || 'opening') : "opening";
-  document.getElementById("clTextEN").value   = item ? (item.textEN  || "") : "";
-  document.getElementById("clTextIS").value   = item ? (item.textIS  || "") : "";
-  document.getElementById("clSort").value     = item ? (item.sortOrder || 99) : 99;
-  document.getElementById("clActive").checked = item ? bool(item.active) : true;
-  document.getElementById("clDeleteBtn").classList.toggle("hidden", !item);
-  openModal("clModal");
-}
-
-async function saveCLItem() {
-  const textEN = document.getElementById("clTextEN").value.trim();
-  if (!textEN) { toast(s("admin.textENRequired"), "err"); return; }
-  const payload = {
-    id:        editingId,
-    phase:     document.getElementById("clPhase").value,   // "opening" or "closing"
-    textEN,
-    textIS:    document.getElementById("clTextIS").value.trim(),
-    sortOrder: parseInt(document.getElementById("clSort").value) || 99,
-    active:    document.getElementById("clActive").checked,
-  };
-  await saveEntity({
-    apiAction: "saveChecklistItem",
-    getArray:  () => clItems,
-    setArray:  arr => { clItems = arr; },
-    payload, modalId: "clModal",
-    renderFn:  renderChecklists,
-  });
-}
-
-async function deleteCLItem(id) {
-  const _id = id || editingId;
-  if (!await ymConfirm(s("admin.confirmDeleteItem"))) return;
-  try {
-    await apiPost("deleteChecklistItem", { id: _id });
-    clItems = clItems.filter(i => i.id !== _id);
-    renderChecklists();
-    closeModal("clModal", true);
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function updateCLOrder(phase) {
-  const inputs = document.querySelectorAll(`input.cl-sort-input[data-cl-phase="${phase}"]`);
-  const updates = [];
-  inputs.forEach(inp => {
-    const id = inp.dataset.clId;
-    const val = parseInt(inp.value) || 99;
-    const item = clItems.find(x => x.id === id);
-    if (item && item.sortOrder !== val) { item.sortOrder = val; updates.push(item); }
-  });
-  if (!updates.length) { document.getElementById('clUpdateOrder_' + phase)?.classList.add('hidden'); return; }
-  try {
-    for (const item of updates) {
-      await apiPost("saveChecklistItem", { id: item.id, phase: item.phase, textEN: item.textEN, textIS: item.textIS || "", sortOrder: item.sortOrder, active: item.active });
-    }
-    renderChecklists();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-// ══ LAUNCH / LANDING CHECKLISTS ══════════════════════════════════════════════
-// Stored in config as: launchChecklists = {
-//   dinghy: { launch:[{id,text,textIS,sort}], landing:[...] }, ...
-// }
-let _launchCLs   = {};
-let _lcEditingId = null;
-
-function loadLaunchChecklists(cfgLaunchChecklists) {
-  _launchCLs = cfgLaunchChecklists || {};
-  populateCategorySelects();   // filter may not be populated yet on first load
-  renderLaunchCLSections();
-}
-
-function renderLaunchCLSections() {
-  const cat     = document.getElementById("launchCLCatFilter")?.value || boatCats[0]?.key || "dinghy";
-  const catData = _launchCLs[cat] || { launch:[], landing:[] };
-  ["launch", "landing"].forEach(phase => {
-    const el    = document.getElementById(phase === "launch" ? "launchCLLaunchList" : "launchCLLandingList");
-    if (!el) return;
-    const items = (catData[phase] || []).slice().sort((a, b) => (a.sort || 99) - (b.sort || 99));
-    if (!items.length) { el.innerHTML = '<div class="empty-state">' + s('admin.noItems') + '</div>'; return; }
-    const btnId = 'lcUpdateOrder_' + cat + '_' + phase;
-    el.innerHTML = items.map(i => `
-      <div class="cl-row">
-        <input type="number" class="cl-sort-input" data-lc-cat="${esc(cat)}" data-lc-phase="${phase}" data-lc-id="${esc(i.id)}"
-          value="${i.sort || 99}" min="0" onchange="document.getElementById('${btnId}').classList.remove('hidden')">
-        <span style="flex:1;color:var(--text)">${esc(i.text || "")}${i.textIS
-          ? `<span style="color:var(--muted);font-size:11px;margin-left:6px">${esc(i.textIS)}</span>` : ""}</span>
-        <button class="row-edit" onclick="openLaunchCLModal('${esc(cat)}','${phase}','${esc(i.id)}')">Edit</button>
-        <button class="row-del"  onclick="deleteLaunchCLItem('${esc(cat)}','${phase}','${esc(i.id)}')">×</button>
-      </div>`).join("") +
-      `<button id="${btnId}" class="btn btn-primary cl-update-order hidden" onclick="updateLaunchCLOrder('${esc(cat)}','${phase}')">Update Order</button>`;
-  });
-}
-
-function openLaunchCLModal(cat, phase, id) {
-  _lcEditingId  = id || null;
-  const curCat  = cat   || document.getElementById("launchCLCatFilter")?.value || boatCats[0]?.key || "dinghy";
-  const curPhase = phase || "launch";
-  let item = null;
-  if (id && _launchCLs[curCat]?.[curPhase]) {
-    item = _launchCLs[curCat][curPhase].find(x => x.id === id);
-  }
-  populateCategorySelects();
-  document.getElementById("launchCLModalTitle").textContent = item ? s('admin.lcModal.edit') : s('admin.lcModal.add');
-  document.getElementById("lcCat").value    = curCat;
-  document.getElementById("lcPhase").value  = curPhase;
-  document.getElementById("lcText").value   = item ? (item.text   || "") : "";
-  document.getElementById("lcTextIS").value = item ? (item.textIS || "") : "";
-  document.getElementById("lcSort").value   = item ? (item.sort   || 99) : 99;
-  document.getElementById("lcDeleteBtn").classList.toggle("hidden", !item);
-  openModal("launchCLModal");
-}
-
-async function saveLaunchCLItem() {
-  const cat    = document.getElementById("lcCat").value;
-  const phase  = document.getElementById("lcPhase").value;
-  const text   = document.getElementById("lcText").value.trim();
-  const textIS = document.getElementById("lcTextIS").value.trim();
-  const sort   = parseInt(document.getElementById("lcSort").value) || 99;
-  if (!text) { toast(s("admin.textENRequired"), "err"); return; }
-  if (!_launchCLs[cat])        _launchCLs[cat] = { launch:[], landing:[] };
-  if (!_launchCLs[cat][phase]) _launchCLs[cat][phase] = [];
-
-  const id   = _lcEditingId || ("lc_" + Date.now().toString(36));
-  const list = _launchCLs[cat][phase];
-  const idx  = list.findIndex(x => x.id === id);
-  const item = { id, text, textIS, sort };
-  if (idx >= 0) list[idx] = item; else list.push(item);
-
-  try {
-    await apiPost("saveConfig", { launchChecklists: _launchCLs });
-    closeModal("launchCLModal", true);
-    renderLaunchCLSections();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-async function updateLaunchCLOrder(cat, phase) {
-  const inputs = document.querySelectorAll(`input.cl-sort-input[data-lc-cat="${cat}"][data-lc-phase="${phase}"]`);
-  let changed = false;
-  inputs.forEach(inp => {
-    const id = inp.dataset.lcId;
-    const val = parseInt(inp.value) || 99;
-    const list = _launchCLs[cat]?.[phase] || [];
-    const item = list.find(x => x.id === id);
-    if (item && item.sort !== val) { item.sort = val; changed = true; }
-  });
-  if (!changed) { document.getElementById('lcUpdateOrder_' + cat + '_' + phase)?.classList.add('hidden'); return; }
-  try {
-    await apiPost("saveConfig", { launchChecklists: _launchCLs });
-    renderLaunchCLSections();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-async function deleteLaunchCLItem(cat, phase, id) {
-  // Can be called directly from row button (args supplied) or from modal delete btn
-  if (!cat) {
-    cat   = document.getElementById("lcCat").value;
-    phase = document.getElementById("lcPhase").value;
-    id    = _lcEditingId;
-  }
-  if (!await ymConfirm(s("admin.confirmDeleteItem"))) return;
-  if (_launchCLs[cat]?.[phase]) {
-    _launchCLs[cat][phase] = _launchCLs[cat][phase].filter(x => x.id !== id);
-  }
-  try {
-    await apiPost("saveConfig", { launchChecklists: _launchCLs });
-    closeModal("launchCLModal", true);
-    renderLaunchCLSections();
-    toast(s("toast.deleted"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-// ══ ACTIVITY TYPES ════════════════════════════════════════════════════════════
-
-function renderActTypes() {
-  const card   = document.getElementById("actTypesCard");
-  const locale = getLang() === 'IS' ? 'is' : 'en';
-  const active = actTypes
-    .filter(a => bool(a.active))
-    .sort((a, b) => {
-      const la = (getLang() === 'IS' && a.nameIS ? a.nameIS : a.name) || '';
-      const lb = (getLang() === 'IS' && b.nameIS ? b.nameIS : b.name) || '';
-      return la.localeCompare(lb, locale, { sensitivity: 'base' });
-    });
-  if (!active.length) { card.innerHTML = `<div class="empty-state">${s('admin.noActTypes')}</div>`; return; }
-  card.innerHTML = active.map(a => {
-    const subs = Array.isArray(a.subtypes) ? a.subtypes : tryParse_(a.subtypes, []);
-    const roles = Array.isArray(a.roles) ? a.roles : tryParse_(a.roles, []);
-    const isVol = bool(a.volunteer);
-    return `<div class="list-row" style="flex-direction:column;align-items:stretch;gap:2px">
-      <div style="display:flex;align-items:center;gap:10px">
-        <span class="list-name">${esc(a.name)}${a.nameIS
-          ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(a.nameIS)}</span>` : ""}${isVol
-          ? `<span style="color:var(--brass-fg);font-size:9px;margin-left:8px;letter-spacing:.5px">${s('admin.volunteerType').toUpperCase()}</span>` : ""}</span>
-        <button class="row-edit" onclick="openActTypeModal('${a.id}')">Edit</button>
-        <button class="row-del"  onclick="deleteActType('${a.id}')">×</button>
-      </div>
-      ${subs.map(st=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">→ ${esc(st.name)}${st.defaultStart?' · '+esc(st.defaultStart)+(st.defaultEnd?'–'+esc(st.defaultEnd):''):''}</div>`).join('')}
-      ${isVol && roles.length ? roles.map(r=>`<div style="font-size:10px;color:var(--muted);padding:1px 0 1px 12px">⚑ ${esc(r.name||'')}${r.slots?' ('+r.slots+')':''}${r.requiredEndorsement?` <span style="color:var(--brass-fg)">[${esc(certDefName((certDefs||[]).find(d=>d.id===r.requiredEndorsement))||r.requiredEndorsement)}]</span>`:''}</div>`).join('') : ''}
-    </div>`;
-  }).join("");
-}
-
-function openActTypeModal(id) {
-  editingId = id || null;
-  const a   = id ? actTypes.find(x => x.id === id) : null;
-  document.getElementById("actTypeModalTitle").textContent = a ? s('admin.actTypeModal.edit') : s('admin.actTypeModal.add');
-  document.getElementById("atName").value     = a ? a.name            : "";
-  document.getElementById("atNameIS").value   = a ? (a.nameIS || "")  : "";
-  document.getElementById("atActive").checked = a ? bool(a.active)    : true;
-  document.getElementById("atVolunteer").checked = a ? bool(a.volunteer) : false;
-  document.getElementById("atCalendarId").value = a ? (a.calendarId || "") : "";
-  document.getElementById("atCalendarSyncActive").checked = a ? bool(a.calendarSyncActive) : false;
-  document.getElementById("atDeleteBtn").classList.toggle("hidden", !a);
-  window._atSubtypes = a && a.subtypes ? JSON.parse(JSON.stringify(
-    Array.isArray(a.subtypes) ? a.subtypes : tryParse_(a.subtypes, [])
-  )) : [];
-  // Migrate any legacy top-level bulkSchedule onto the first subtype on open
-  var legacyBs = (a && (typeof a.bulkSchedule === 'string' ? tryParse_(a.bulkSchedule, null) : a.bulkSchedule)) || null;
-  if (legacyBs && window._atSubtypes.length && !window._atSubtypes[0].bulkSchedule) {
-    window._atSubtypes[0].bulkSchedule = legacyBs;
-  }
-  // Load volunteer roles
-  window._atRoles = a && a.roles ? JSON.parse(JSON.stringify(
-    Array.isArray(a.roles) ? a.roles : tryParse_(a.roles, [])
-  )) : [];
-  toggleAtVolunteerSection();
-  renderAtRoles();
-  renderAtSubtypes();
-  openModal("actTypeModal");
-}
-
-async function saveActType() {
-  const name = document.getElementById("atName").value.trim();
-  if (!name) { toast(s("admin.nameRequired"), "err"); return; }
-  const isVol = document.getElementById("atVolunteer").checked;
-  const payload = {
-    id: editingId, name,
-    nameIS:   document.getElementById("atNameIS").value.trim(),
-    active:   document.getElementById("atActive").checked,
-    volunteer: isVol,
-    calendarId: document.getElementById("atCalendarId").value.trim(),
-    calendarSyncActive: document.getElementById("atCalendarSyncActive").checked,
-    subtypes: JSON.stringify(window._atSubtypes || []),
-    roles: isVol ? JSON.stringify(window._atRoles || []) : JSON.stringify([]),
-    bulkSchedule: null,
-  };
-  await saveEntity({
-    apiAction: "saveActivityType",
-    getArray:  () => actTypes,
-    setArray:  arr => { actTypes = arr; },
-    payload, modalId: "actTypeModal",
-    renderFn:  renderActTypes,
-  });
-  // Volunteer event materialization is deferred to syncVolunteerEvents.
-  // Trigger it in the background after a successful save so new events
-  // appear on the Volunteer tab without a manual refresh.
-  if (isVol) {
-    _volSyncDone = false;
-    apiPost('syncVolunteerEvents', {}).then(function(res) {
-      if (res && res.added > 0) {
-        apiGet('getConfig', { _fresh: true }).then(function(cfg) {
-          volunteerEvents = cfg.volunteerEvents || [];
-          renderVolunteerEvents();
-        }).catch(function() {});
-      }
-    }).catch(function() {});
-  }
-}
-
-async function deleteActType(id) {
-  const _id = id || editingId;
-  if (!await ymConfirm(s("admin.confirmDeleteActType"))) return;
-  // Count linked volunteer events and signups so we can warn the admin
-  // before cascading through real signup data.
-  var linkedEventIds = (volunteerEvents || [])
-    .filter(function(e) {
-      if (!e) return false;
-      return (e.sourceActivityTypeId && String(e.sourceActivityTypeId) === String(_id))
-          || (e.activityTypeId       && String(e.activityTypeId)       === String(_id));
-    })
-    .map(function(e) { return e.id; });
-  var linkedSignups = (volunteerSignups || [])
-    .filter(function(su) { return su && linkedEventIds.indexOf(su.eventId) !== -1; }).length;
-  if (linkedSignups > 0) {
-    var warn = s("admin.confirmDeleteActTypeCascade")
-      .replace("{n}", linkedEventIds.length)
-      .replace("{m}", linkedSignups);
-    if (!await ymConfirm(warn)) return;
-  }
-  try {
-    const res = await apiPost("deleteActivityType", { id: _id });
-    actTypes = actTypes.filter(a => a.id !== _id);
-    var removedE = (res && res.removedEvents) || 0;
-    var removedS = (res && res.removedSignups) || 0;
-    if (removedE > 0) {
-      // Drop cascaded events + signups from the in-memory arrays so the
-      // volunteer tab reflects the backend state without a full reload.
-      var droppedIds = {};
-      (volunteerEvents || []).forEach(function(e) {
-        if (!e) return;
-        var belongs = (e.sourceActivityTypeId && String(e.sourceActivityTypeId) === String(_id))
-                   || (e.activityTypeId       && String(e.activityTypeId)       === String(_id));
-        if (belongs) droppedIds[e.id] = true;
-      });
-      volunteerEvents = (volunteerEvents || []).filter(function(e) { return !(e && droppedIds[e.id]); });
-      volunteerSignups = (volunteerSignups || []).filter(function(su) { return !(su && droppedIds[su.eventId]); });
-      if (typeof renderVolunteerEvents === 'function') {
-        try { renderVolunteerEvents(); } catch(e) {}
-      }
-      toast(
-        s("admin.actTypeDeletedCascade")
-          .replace("{n}", removedE)
-          .replace("{m}", removedS),
-        "ok"
-      );
-    } else {
-      toast(s("toast.deleted"), "ok");
-    }
-    renderActTypes();
-    closeModal("actTypeModal", true);
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-function tryParse_(v, fallback) { try { return JSON.parse(v); } catch(e) { return fallback; } }
-
-function renderAtSubtypes() {
-  const list = document.getElementById("atSubtypesList");
-  if (!list) return;
-  if (!window._atSubtypes.length) {
-    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin-bottom:6px">' + s('admin.noSubtypes') + '</div>';
-    return;
-  }
-  const dayLabels = [
-    { v:'1', k:'day.mon', d:'Mon' }, { v:'2', k:'day.tue', d:'Tue' },
-    { v:'3', k:'day.wed', d:'Wed' }, { v:'4', k:'day.thu', d:'Thu' },
-    { v:'5', k:'day.fri', d:'Fri' }, { v:'6', k:'day.sat', d:'Sat' },
-    { v:'0', k:'day.sun', d:'Sun' },
-  ];
-  list.innerHTML = window._atSubtypes.map((st, i) => {
-    const bs = st.bulkSchedule || {};
-    const bsDays = Array.isArray(bs.daysOfWeek) ? bs.daysOfWeek.map(String) : [];
-    const daysHtml = dayLabels.map(d =>
-      `<label style="font-size:11px"><input type="checkbox" value="${d.v}" ${bsDays.indexOf(d.v)!==-1?'checked':''}
-        onchange="toggleAtStBsDay(${i}, ${d.v}, this.checked)"> <span data-s="${d.k}">${d.d}</span></label>`
-    ).join('');
-    return `
-    <div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:6px">
-        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">NAME (EN)</label>
-          <input type="text" value="${esc(st.name||"")}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
-            onchange="window._atSubtypes[${i}].name=this.value"></div>
-        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">NAME (IS)</label>
-          <input type="text" value="${esc(st.nameIS||"")}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
-            onchange="window._atSubtypes[${i}].nameIS=this.value"></div>
-      </div>
-      <div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">
-        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">DEFAULT START</label>
-          <input type="text" value="${esc(st.defaultStart||"")}" placeholder="HH:MM" maxlength="5" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
-            oninput="var v=this.value.replace(/[^0-9]/g,'');if(v.length>=3)v=v.slice(0,2)+':'+v.slice(2);this.value=v;window._atSubtypes[${i}].defaultStart=this.value"></div>
-        <div><label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">DEFAULT END</label>
-          <input type="text" value="${esc(st.defaultEnd||"")}" placeholder="HH:MM" maxlength="5" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px"
-            oninput="var v=this.value.replace(/[^0-9]/g,'');if(v.length>=3)v=v.slice(0,2)+':'+v.slice(2);this.value=v;window._atSubtypes[${i}].defaultEnd=this.value"></div>
-        <button onclick="window._atSubtypes.splice(${i},1);renderAtSubtypes()" title="Remove" style="background:none;border:none;color:var(--red);font-size:16px;cursor:pointer;padding:0 4px;line-height:1">✕</button>
-      </div>
-      <div style="margin-top:8px;padding-top:8px;border-top:1px dashed var(--border)">
-        <label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:4px" data-s="admin.bulkSchedule">BULK SCHEDULE</label>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:6px">
-          <div><label style="font-size:9px;color:var(--muted)" data-s="slot.fromDate">From date</label>
-            <input type="date" value="${esc(bs.fromDate||'')}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:11px;padding:5px 7px"
-              onchange="ensureAtStBs(${i}).fromDate=this.value"></div>
-          <div><label style="font-size:9px;color:var(--muted)" data-s="slot.toDate">To date</label>
-            <input type="date" value="${esc(bs.toDate||'')}" style="width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:11px;padding:5px 7px"
-              onchange="ensureAtStBs(${i}).toDate=this.value"></div>
-        </div>
-        <div style="display:flex;gap:6px;flex-wrap:wrap">${daysHtml}</div>
-        ${(st.defaultStart || st.defaultEnd) ? '<div style="font-size:10px;color:var(--muted);margin-top:4px">' + s('admin.bulkUsesDefaultTimes') + ': ' + esc(st.defaultStart || '?') + '–' + esc(st.defaultEnd || '?') + '</div>' : '<div style="font-size:10px;color:var(--muted);margin-top:4px;font-style:italic">' + s('admin.bulkSetDefaultTimes') + '</div>'}
-      </div>
-    </div>`;
-  }).join("");
-}
-
-function ensureAtStBs(i) {
-  if (!window._atSubtypes[i].bulkSchedule) {
-    window._atSubtypes[i].bulkSchedule = { fromDate:'', toDate:'', daysOfWeek:[], startTime:'', endTime:'' };
-  }
-  return window._atSubtypes[i].bulkSchedule;
-}
-
-function toggleAtStBsDay(i, day, checked) {
-  var bs = ensureAtStBs(i);
-  if (!Array.isArray(bs.daysOfWeek)) bs.daysOfWeek = [];
-  var idx = bs.daysOfWeek.indexOf(day);
-  if (checked && idx === -1) bs.daysOfWeek.push(day);
-  else if (!checked && idx !== -1) bs.daysOfWeek.splice(idx, 1);
-}
-
-function addAtSubtypeRow() {
-  if (!window._atSubtypes) window._atSubtypes = [];
-  window._atSubtypes.push({ id: "st-"+Date.now(), name: "", nameIS: "", defaultStart: "", defaultEnd: "" });
-  renderAtSubtypes();
-}
-
-// ── Activity type: volunteer roles ────────────────────────────────────────────
-
-function toggleAtVolunteerSection() {
-  var show = document.getElementById("atVolunteer").checked;
-  document.getElementById("atRolesSection").classList.toggle("hidden", !show);
-}
-
-function renderAtRoles() {
-  var list = document.getElementById("atRolesList");
-  if (!list) return;
-  populateRolePresetPicker("atRolePresetPicker");
-  if (!window._atRoles || !window._atRoles.length) {
-    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin-bottom:6px">' + s('admin.noRoles') + '</div>';
-    return;
-  }
-  var endorsements = (certDefs || []).filter(function(d) { return !!d.clubEndorsement; });
-  var inputStyle = 'width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px';
-  var labelStyle = 'font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px';
-  list.innerHTML = window._atRoles.map(function(r, i) {
-    var endorseOpts = '<option value="">' + s('admin.roleNoRestriction') + '</option>'
-      + endorsements.map(function(e) {
-        return '<option value="' + esc(e.id) + '"' + (r.requiredEndorsement === e.id ? ' selected' : '') + '>' + esc(certDefName(e)) + '</option>';
-      }).join('');
-    return '<div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">'
-      + '<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleName') + '</label>'
-      + '<input type="text" value="' + esc(r.name || '') + '" style="' + inputStyle + '" onchange="window._atRoles[' + i + '].name=this.value"></div>'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleNameIS') + '</label>'
-      + '<input type="text" value="' + esc(r.nameIS || '') + '" style="' + inputStyle + '" onchange="window._atRoles[' + i + '].nameIS=this.value"></div>'
-      + '<button onclick="window._atRoles.splice(' + i + ',1);renderAtRoles()" title="Remove" style="background:none;border:none;color:var(--red);font-size:16px;cursor:pointer;padding:0 4px;line-height:1">✕</button>'
-      + '</div>'
-      + '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:6px">'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescEN') + '</label>'
-      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" onchange="window._atRoles[' + i + '].description=this.value">' + esc(r.description || '') + '</textarea></div>'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescIS') + '</label>'
-      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" onchange="window._atRoles[' + i + '].descriptionIS=this.value">' + esc(r.descriptionIS || '') + '</textarea></div>'
-      + '</div>'
-      + '<div style="display:grid;grid-template-columns:80px 1fr;gap:8px;margin-top:6px;align-items:end">'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volSlots') + '</label>'
-      + '<input type="number" min="1" value="' + (r.slots || '') + '" style="' + inputStyle + '" onchange="window._atRoles[' + i + '].slots=parseInt(this.value)||0"></div>'
-      + '<div><label style="' + labelStyle + '">' + s('admin.roleEndorsement') + '</label>'
-      + '<select style="' + inputStyle + '" onchange="window._atRoles[' + i + '].requiredEndorsement=this.value">' + endorseOpts + '</select></div>'
-      + '</div>'
-      + '</div>';
-  }).join('');
-}
-
-function addAtRoleRow() {
-  if (!window._atRoles) window._atRoles = [];
-  window._atRoles.push({ id: "r-" + Date.now(), name: "", nameIS: "", description: "", descriptionIS: "", slots: 1, requiredEndorsement: "" });
-  renderAtRoles();
-}
-
-function addAtRoleFromPreset(presetId) {
-  var preset = (typeof getVolunteerRolePreset === 'function') ? getVolunteerRolePreset(presetId) : null;
-  if (!preset) return;
-  if (!window._atRoles) window._atRoles = [];
-  window._atRoles.push({
-    id: "r-" + Date.now(),
-    name: preset.name || '',
-    nameIS: preset.nameIS || '',
-    description: preset.description || '',
-    descriptionIS: preset.descriptionIS || '',
-    slots: preset.slots || 1,
-    requiredEndorsement: '',
-  });
-  renderAtRoles();
-}
-
-// Populates a <select> element with a list of standard volunteer role presets.
-// First option is a placeholder; the rest come from shared/volunteer-role-presets.js.
-// Safe to call repeatedly — idempotent when called with the same language.
-function populateRolePresetPicker(selectId) {
-  var sel = document.getElementById(selectId);
-  if (!sel) return;
-  if (typeof listVolunteerRolePresets !== 'function') return;
-  var L = getLang();
-  var presets = listVolunteerRolePresets(L);
-  var placeholder = '<option value="">' + s('admin.volRolePickPreset') + '</option>';
-  sel.innerHTML = placeholder + presets.map(function(p) {
-    var label = (L === 'IS' && p.nameIS ? p.nameIS : p.name) || p.name || p.id;
-    return '<option value="' + esc(p.id) + '">' + esc(label) + '</option>';
-  }).join('');
-}
-
-// ══ VOLUNTEER EVENTS ═════════════════════════════════════════════════════════
-
-let _veEditingId = null;
-
-let _volSyncDone = false;
-let _volShowPast = false;
-
-function renderVolunteerEvents() {
-  const card = document.getElementById("volEventsCard");
-  // One-time backfill: ensure any bulk-scheduled events defined on activity
-  // types are materialized into config.volunteer_events. This is a no-op
-  // once events have been materialized. Runs in the background and triggers
-  // a re-render when it finishes.
-  if (!_volSyncDone) {
-    _volSyncDone = true;
-    (async function() {
-      try {
-        const res = await apiPost('syncVolunteerEvents', {});
-        if (res && res.added > 0) {
-          // apiPost invalidates the getConfig cache; re-fetch to pick up
-          // newly materialized events.
-          try {
-            const cfg = await apiGet('getConfig');
-            volunteerEvents = cfg.volunteerEvents || [];
-            renderVolunteerEvents();
-          } catch(e) {}
-        }
-      } catch(e) { /* non-fatal — keep showing what we have */ }
-    })();
-  }
-  const L = getLang();
-  const today = new Date().toISOString().slice(0, 10);
-  // Defense-in-depth: hide materialized events whose source activity type is
-  // missing, inactive, or no longer volunteer-flagged. Manually-created events
-  // (no sourceActivityTypeId) are shown regardless.
-  const activeAtIds = new Set((actTypes || [])
-    .filter(a => bool(a.active) && bool(a.volunteer))
-    .map(a => a.id));
-  const saved = (volunteerEvents || []).filter(e => {
-    if (!e || e.active === false) return false;
-    if (e.sourceActivityTypeId) return activeAtIds.has(e.sourceActivityTypeId);
-    return true;
-  });
-  // Expand virtual events from activity type bulk schedules so they appear
-  // immediately after saving, before the background sync materializes them.
-  // Use 365-day horizon to match the volunteer page.
-  const rangeTo = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const virtual = (typeof expandVolunteerActivityTypes === 'function')
-    ? expandVolunteerActivityTypes(actTypes || [], today, rangeTo)
-    : [];
-  const all = (typeof mergeVolunteerEvents === 'function')
-    ? mergeVolunteerEvents(saved, virtual)
-    : saved.concat(virtual);
-  // Store merged events so openVolEventModal can find virtual events too.
-  window._volMergedEvents = all;
-  const sorted = all.slice().sort((a, b) => (a.date || '').localeCompare(b.date || '')
-    || (a.startTime || '').localeCompare(b.startTime || ''));
-  const upcoming = sorted.filter(e => (e.date || '') >= today);
-  const past     = sorted.filter(e => (e.date || '') <  today);
-  const shown    = _volShowPast ? sorted : upcoming;
-  if (!shown.length) {
-    card.innerHTML = '<div class="empty-state">' + s('admin.noVolEvents') + '</div>'
-      + (past.length ? _volPastToggleHtml(past.length) : '');
-    return;
-  }
-  const rowsHtml = shown.map(ev => _volRowHtml(ev, L)).join('');
-  card.innerHTML = rowsHtml + (past.length ? _volPastToggleHtml(past.length) : '');
-}
-
-function _volPastToggleHtml(count) {
-  const lbl = _volShowPast
-    ? s('admin.volHidePast')
-    : s('admin.volShowPast').replace('{n}', count);
-  return '<div style="text-align:center;padding:10px 0 2px">'
-    + '<button class="btn btn-secondary" style="font-size:10px" onclick="_volTogglePast()">' + esc(lbl) + '</button>'
-    + '</div>';
-}
-
-function _volTogglePast() {
-  _volShowPast = !_volShowPast;
-  renderVolunteerEvents();
-}
-
-// Localized "Wed, 15 Apr" / "Wed 15 Apr – Fri 17 Apr" for a volunteer event.
-function _volFormatDayLabel(ev) {
-  const startIso = ev && ev.date ? ev.date : '';
-  if (!startIso) return '';
-  const endIso = (ev && ev.endDate && ev.endDate !== startIso) ? ev.endDate : '';
-  const dows = ['day.sun','day.mon','day.tue','day.wed','day.thu','day.fri','day.sat'];
-  const months = ['month.jan','month.feb','month.mar','month.apr','month.may','month.jun',
-                  'month.jul','month.aug','month.sep','month.oct','month.nov','month.dec'];
-  const a = new Date(startIso + 'T00:00:00');
-  const left = s(dows[a.getDay()]) + ', ' + a.getDate() + ' ' + s(months[a.getMonth()]);
-  if (!endIso) return left;
-  const b = new Date(endIso + 'T00:00:00');
-  const right = s(dows[b.getDay()]) + ' ' + b.getDate() + ' ' + s(months[b.getMonth()]);
-  return left + ' – ' + right;
-}
-
-function _volFormatTimeRange(ev) {
-  const a = (ev && ev.startTime || '').slice(0, 5);
-  const b = (ev && ev.endTime   || '').slice(0, 5);
-  if (a && b) return a + '–' + b;
-  if (a) return a;
-  return '';
-}
-
-// Admin volunteer row — reuses the shared /volunteer/ card renderer so the
-// two views stay visually identical. Adds an Edit button that opens the
-// full volunteer-event modal and a Delete button for destructive removal.
-function _volRowHtml(ev, L) {
-  if (typeof renderVolunteerCard !== 'function') return '';
-  return renderVolunteerCard(ev, {
-    mode: 'admin',
-    lang: L || getLang(),
-    signups: volunteerSignups,
-    members: members,
-    certDefs: certDefs,
-    certDefName: (typeof certDefName === 'function') ? certDefName : function(d) { return d && (d.name || d.id) || ''; },
-    esc: esc,
-    s: s,
-    formatDay: _volFormatDayLabel,
-    formatTime: _volFormatTimeRange,
-    onCardClick:   "openVolEventModal",
-    onEditClick:   "openVolEventModal",
-    onDeleteClick: "deleteVolEvent",
-  });
-}
-
-function openVolEventModal(id) {
-  _veEditingId = id || null;
-  // Search saved events first, then the merged list (which includes virtual events).
-  const ev = id
-    ? (volunteerEvents.find(x => x.id === id) || (window._volMergedEvents || []).find(x => x.id === id))
-    : null;
-  document.getElementById("volEventModalTitle").textContent = ev ? s('admin.volEventModal.edit') : s('admin.volEventModal.add');
-  document.getElementById("veTitle").value = ev ? (ev.title || '') : '';
-  document.getElementById("veTitleIS").value = ev ? (ev.titleIS || '') : '';
-  document.getElementById("veDate").value = ev ? (ev.date || '') : '';
-  document.getElementById("veEndDate").value = ev ? (ev.endDate || '') : '';
-  document.getElementById("veStartTime").value = ev ? (ev.startTime || '') : '';
-  document.getElementById("veEndTime").value = ev ? (ev.endTime || '') : '';
-  // Leader member lookup
-  document.getElementById("veLeaderMemberId").value = ev ? (ev.leaderMemberId || '') : '';
-  document.getElementById("veLeaderPhone").value = ev ? (ev.leaderPhone || '') : '';
-  document.getElementById("veShowPhone").checked = ev ? (ev.showLeaderPhone === true || ev.showLeaderPhone === 'true') : false;
-  // Show leader chip or search
-  var leaderM = ev && ev.leaderMemberId ? members.find(function(m){ return m.id === ev.leaderMemberId || m.kennitala === ev.leaderMemberId; }) : null;
-  if (!leaderM && ev && ev.leaderName) {
-    leaderM = members.find(function(m){ return (m.name||'') === ev.leaderName; });
-  }
-  if (leaderM) {
-    showVolLeaderChip(leaderM);
-  } else {
-    clearVolLeaderChip();
-    document.getElementById("veLeaderSearch").value = ev ? (ev.leaderName || '') : '';
-  }
-  document.getElementById("veNotes").value = ev ? (ev.notes || '') : '';
-  document.getElementById("veNotesIS").value = ev ? (ev.notesIS || '') : '';
-  document.getElementById("veDeleteBtn").classList.toggle("hidden", !ev);
-  // Populate activity type select (only volunteer-flagged types)
-  const sel = document.getElementById("veActType");
-  const L = getLang();
-  sel.innerHTML = '<option value="">' + s('admin.volActTypeNone') + '</option>'
-    + actTypes.filter(a => bool(a.volunteer) && bool(a.active)).map(a => {
-      const label = (L === 'IS' && a.nameIS ? a.nameIS : a.name) || a.name;
-      return '<option value="' + a.id + '"' + (ev && ev.activityTypeId === a.id ? ' selected' : '') + '>' + esc(label) + '</option>';
-    }).join('');
-  // Roles — inherit from activity type for new events, use saved roles for existing
-  if (ev && ev.roles && (Array.isArray(ev.roles) ? ev.roles.length : true)) {
-    window._volRoles = JSON.parse(JSON.stringify(Array.isArray(ev.roles) ? ev.roles : []));
-  } else {
-    window._volRoles = loadRolesFromActType(sel.value);
-  }
-  renderVolRoles();
-  openModal("volEventModal");
-}
-
-async function saveVolEvent() {
-  const title = document.getElementById("veTitle").value.trim();
-  if (!title) { toast(s("admin.nameRequired"), "err"); return; }
-  var memberId = document.getElementById("veLeaderMemberId").value.trim();
-  var leaderM = memberId ? members.find(function(m){ return m.id === memberId || m.kennitala === memberId; }) : null;
-  const payload = {
-    id: _veEditingId,
-    title,
-    titleIS: document.getElementById("veTitleIS").value.trim(),
-    activityTypeId: document.getElementById("veActType").value,
-    date: document.getElementById("veDate").value,
-    endDate: document.getElementById("veEndDate").value,
-    startTime: document.getElementById("veStartTime").value,
-    endTime: document.getElementById("veEndTime").value,
-    leaderMemberId: memberId,
-    leaderName: leaderM ? leaderM.name : document.getElementById("veLeaderSearch").value.trim(),
-    leaderPhone: document.getElementById("veLeaderPhone").value.trim(),
-    showLeaderPhone: document.getElementById("veShowPhone").checked,
-    notes: document.getElementById("veNotes").value.trim(),
-    notesIS: document.getElementById("veNotesIS").value.trim(),
-    roles: JSON.stringify(window._volRoles || []),
-    active: true,
-  };
-  await saveEntity({
-    apiAction: "saveVolunteerEvent",
-    getArray:  () => volunteerEvents,
-    setArray:  arr => { volunteerEvents = arr; },
-    payload, modalId: "volEventModal",
-    renderFn:  renderVolunteerEvents,
-  });
-}
-
-async function deleteVolEvent(id) {
-  const _id = id || _veEditingId;
-  if (!await ymConfirm(s("admin.confirmDeleteVolEvent"))) return;
-  try {
-    await apiPost("deleteVolunteerEvent", { id: _id });
-    volunteerEvents = volunteerEvents.filter(a => a.id !== _id);
-    renderVolunteerEvents();
-    closeModal("volEventModal", true);
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-function renderVolRoles() {
-  const list = document.getElementById("volRolesList");
-  if (!list) return;
-  populateRolePresetPicker("veRolePresetPicker");
-  if (!window._volRoles || !window._volRoles.length) {
-    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin-bottom:6px">' + s('admin.noRoles') + '</div>';
-    return;
-  }
-  var inputStyle = 'width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px';
-  var labelStyle = 'font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px';
-  list.innerHTML = window._volRoles.map(function(r, i) {
-    var endorseLabel = '';
-    if (r.requiredEndorsement) {
-      var eDef = (certDefs || []).find(function(d){ return d.id === r.requiredEndorsement; });
-      endorseLabel = '<div style="font-size:10px;color:var(--brass-fg);margin-top:4px">' + s('admin.roleEndorsement') + ': ' + esc(eDef ? certDefName(eDef) : r.requiredEndorsement) + '</div>';
-    }
-    return '<div style="background:var(--card);border:1px solid var(--border);border-radius:6px;padding:8px 10px;margin-bottom:6px">'
-      + '<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleName') + '</label>'
-      + '<input type="text" value="' + esc(r.name || '') + '" style="' + inputStyle + '" onchange="window._volRoles[' + i + '].name=this.value"></div>'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleNameIS') + '</label>'
-      + '<input type="text" value="' + esc(r.nameIS || '') + '" style="' + inputStyle + '" onchange="window._volRoles[' + i + '].nameIS=this.value"></div>'
-      + '<button onclick="window._volRoles.splice(' + i + ',1);renderVolRoles()" title="Remove" style="background:none;border:none;color:var(--red);font-size:16px;cursor:pointer;padding:0 4px;line-height:1">✕</button>'
-      + '</div>'
-      + '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:6px">'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescEN') + '</label>'
-      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" onchange="window._volRoles[' + i + '].description=this.value">' + esc(r.description || '') + '</textarea></div>'
-      + '<div><label style="' + labelStyle + '">' + s('admin.volRoleDescIS') + '</label>'
-      + '<textarea rows="2" style="' + inputStyle + ';resize:vertical" onchange="window._volRoles[' + i + '].descriptionIS=this.value">' + esc(r.descriptionIS || '') + '</textarea></div>'
-      + '</div>'
-      + '<div style="margin-top:6px"><label style="' + labelStyle + '">' + s('admin.volSlots') + '</label>'
-      + '<input type="number" min="1" value="' + (r.slots || '') + '" style="width:80px;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text);font-family:inherit;font-size:11px;padding:5px 7px" onchange="window._volRoles[' + i + '].slots=parseInt(this.value)||0"></div>'
-      + endorseLabel
-      + '</div>';
-  }).join('');
-}
-
-function addVolRoleRow() {
-  if (!window._volRoles) window._volRoles = [];
-  window._volRoles.push({ id: "r-" + Date.now(), name: "", nameIS: "", description: "", descriptionIS: "", slots: 1, requiredEndorsement: "" });
-  renderVolRoles();
-}
-
-function addVolRoleFromPreset(presetId) {
-  var preset = (typeof getVolunteerRolePreset === 'function') ? getVolunteerRolePreset(presetId) : null;
-  if (!preset) return;
-  if (!window._volRoles) window._volRoles = [];
-  window._volRoles.push({
-    id: "r-" + Date.now(),
-    name: preset.name || '',
-    nameIS: preset.nameIS || '',
-    description: preset.description || '',
-    descriptionIS: preset.descriptionIS || '',
-    slots: preset.slots || 1,
-    requiredEndorsement: '',
-  });
-  renderVolRoles();
-}
-
-// ── Volunteer event: leader member autocomplete ──────────────────────────────
-
-function searchVolLeader(q) {
-  var drop = document.getElementById("veLeaderSuggestions");
-  if (!q || q.length < 2) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
-  var ql = q.toLowerCase();
-  var hits = members.filter(function(m) { return bool(m.active) && (m.name || '').toLowerCase().includes(ql); }).slice(0, 8);
-  if (!hits.length) { drop.innerHTML = ''; drop.style.display = 'none'; return; }
-  drop.innerHTML = hits.map(function(m) {
-    return '<div class="suggest-item" style="padding:6px 8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--border)"'
-      + ' onclick="selectVolLeader(\'' + esc(m.id || m.kennitala) + '\')">' + esc(memberDisplayName(m, members))
-      + (m.phone ? '<span style="color:var(--muted);margin-left:8px;font-size:10px">' + esc(m.phone) + '</span>' : '') + '</div>';
-  }).join('');
-  drop.style.display = 'block';
-}
-
-function selectVolLeader(id) {
-  var m = members.find(function(x) { return x.id === id || x.kennitala === id; });
-  if (!m) return;
-  document.getElementById("veLeaderMemberId").value = m.id || m.kennitala;
-  document.getElementById("veLeaderPhone").value = m.phone || '';
-  document.getElementById("veLeaderSuggestions").innerHTML = '';
-  document.getElementById("veLeaderSuggestions").style.display = 'none';
-  showVolLeaderChip(m);
-}
-
-function showVolLeaderChip(m) {
-  var chip = document.getElementById("veLeaderChip");
-  var search = document.getElementById("veLeaderSearch");
-  chip.innerHTML = '<span style="font-size:11px;padding:4px 10px;border-radius:12px;background:var(--surface);border:1px solid var(--border);color:var(--text);display:inline-flex;align-items:center;gap:6px">'
-    + esc(memberDisplayName(m, members))
-    + '<span style="cursor:pointer;color:var(--red);font-size:13px" onclick="clearVolLeaderChip()">&times;</span></span>';
-  chip.style.display = 'block';
-  search.style.display = 'none';
-}
-
-function clearVolLeaderChip() {
-  document.getElementById("veLeaderChip").style.display = 'none';
-  document.getElementById("veLeaderChip").innerHTML = '';
-  document.getElementById("veLeaderMemberId").value = '';
-  document.getElementById("veLeaderPhone").value = '';
-  var search = document.getElementById("veLeaderSearch");
-  search.value = '';
-  search.style.display = '';
-}
-
-// ── Volunteer event: inherit roles from activity type ────────────────────────
-
-function loadRolesFromActType(atId) {
-  if (!atId) return [];
-  var at = actTypes.find(function(a) { return a.id === atId; });
-  if (!at || !at.roles) return [];
-  var roles = Array.isArray(at.roles) ? at.roles : tryParse_(at.roles, []);
-  return roles.map(function(r) {
-    return {
-      id: "r-" + Date.now() + '-' + Math.random().toString(36).slice(2,6),
-      name: r.name || '',
-      nameIS: r.nameIS || '',
-      description: r.description || '',
-      descriptionIS: r.descriptionIS || '',
-      slots: r.slots || 1,
-      requiredEndorsement: r.requiredEndorsement || '',
-    };
-  });
-}
-
-function onVeActTypeChange() {
-  var atId = document.getElementById("veActType").value;
-  var newRoles = loadRolesFromActType(atId);
-  if (newRoles.length) {
-    window._volRoles = newRoles;
-    renderVolRoles();
-  }
-}
-
-// ══ CERTIFICATIONS ════════════════════════════════════════════════════════════
-// Top-level cert def has `expires` (bool) and `expiryDate` (absolute date).
-// Subcats supercede the parent: the most specific expiry shown/used is the subcat's.
-
-let certDefs     = [];
-let certEditId   = null;
-// Credential modal — uses shared/mcm.js
-window.mcmGetMembers        = function() { return members; };
-window.mcmGetCertDefs       = function() { return certDefs; };
-window.mcmGetCertCategories = function() { return certCategories; };
-
-// ── Credential categories ─────────────────────────────────────────────────────
-let _ccEditingKey = null;
-
-function renderCertCategories() {
-  const el = document.getElementById("certCatsCard");
-  const addWrap = document.getElementById("certCatsAddWrap");
-  if (!el) return;
-  if (!certCategories.length) {
-    el.innerHTML = `<div class="empty-state">${s('admin.noCertCategories')}</div>`;
-  } else {
-    el.innerHTML = certCategories.map((c) => {
-      const key     = certCategoryKey(c);
-      const labelEN = (c && c.labelEN) || key;
-      const labelIS = (c && c.labelIS) || '';
-      const safeKey = String(key).replace(/'/g, "\\'");
-      return `<div class="list-row">
-        <div style="flex:1;font-size:12px">
-          <strong>${esc(labelEN)}</strong>
-          ${labelIS ? `<span style="color:var(--muted);font-size:11px;margin-left:8px">${esc(labelIS)}</span>` : ''}
-        </div>
-        <button class="row-edit" onclick="openCertCatModal('${safeKey}')">Edit</button>
-        <button class="row-del" onclick="removeCertCategory('${safeKey}')" title="Remove">×</button>
-      </div>`;
-    }).join('');
-  }
-  if (addWrap) addWrap.classList.remove("hidden");
-}
-
-async function addCertCategory() {
-  const inEN = document.getElementById("newCatInputEN");
-  const inIS = document.getElementById("newCatInputIS");
-  const labelEN = inEN.value.trim();
-  const labelIS = inIS ? inIS.value.trim() : '';
-  if (!labelEN) return;
-  // Stable key = labelEN unchanged, to keep legacy member-cert category
-  // references working. Dedupe by key.
-  const key = labelEN;
-  if (certCategories.some(c => certCategoryKey(c) === key)) {
-    toast(s("admin.categoryExists"), "err"); return;
-  }
-  certCategories.push({ key, labelEN, labelIS });
-  inEN.value = "";
-  if (inIS) inIS.value = "";
-  try {
-    await apiPost("saveCertCategories", { categories: certCategories });
-    renderCertCategories();
-    toast(s("admin.categoryAdded"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-function openCertCatModal(key) {
-  _ccEditingKey = key;
-  const cat = certCategoryByKey(certCategories, key) || { key, labelEN: key, labelIS: '' };
-  document.getElementById("certCatModalTitle").textContent = s('admin.certCatModal.edit');
-  document.getElementById("ccLabelEN").value = cat.labelEN || key;
-  document.getElementById("ccLabelIS").value = cat.labelIS || '';
-  document.getElementById("ccKey").value     = cat.key || key;
-  openModal("certCatModal");
-}
-
-async function saveCertCat() {
-  const key     = _ccEditingKey;
-  const labelEN = document.getElementById("ccLabelEN").value.trim();
-  const labelIS = document.getElementById("ccLabelIS").value.trim();
-  if (!key || !labelEN) { toast(s("admin.nameRequired"), "err"); return; }
-  const idx = certCategories.findIndex(c => certCategoryKey(c) === key);
-  if (idx < 0) { toast(s("toast.error"), "err"); return; }
-  // Update labels but keep key stable — member-cert records reference `key`.
-  const existing = certCategories[idx];
-  certCategories[idx] = Object.assign({}, (typeof existing === 'string' ? { key: existing } : existing), {
-    key, labelEN, labelIS,
-  });
-  try {
-    await apiPost("saveCertCategories", { categories: certCategories });
-    closeModal("certCatModal", true);
-    renderCertCategories();
-    renderCertDefs();
-    toast(s("toast.saved"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function removeCertCategory(key) {
-  if (!await ymConfirm(s("admin.confirmRemoveCategory"))) return;
-  const next = certCategories.filter(c => certCategoryKey(c) !== key);
-  if (next.length === certCategories.length) return;
-  certCategories = next;
-  try {
-    await apiPost("saveCertCategories", { categories: certCategories });
-    renderCertCategories();
-    toast(s("admin.categoryRemoved"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-function renderCertDefs() {
-  const el = document.getElementById("certDefsCard");
-  if (!el) return;
-  if (!certDefs.length) {
-    el.innerHTML = `<div class="empty-state">${s('admin.noCertDefs')}</div>`;
-    return;
-  }
-  const locale = getLang() === 'IS' ? 'is' : 'en';
-  const sortedCertDefs = certDefs.slice().sort((a, b) =>
-    certDefName(a).localeCompare(certDefName(b), locale, { sensitivity: 'base' })
-  );
-  const certifications = sortedCertDefs.filter(d => !d.clubEndorsement);
-  const endorsements   = sortedCertDefs.filter(d => !!d.clubEndorsement);
-
-  function certDefRow(d) {
-    const authority = d.issuingAuthority
-      ? `<span style="color:var(--muted)"> · ${esc(d.issuingAuthority)}</span>` : "";
-    const catObj = d.category ? certCategoryByKey(certCategories, d.category) : null;
-    const catLabel = catObj ? certCategoryLabel(catObj) : d.category;
-    const catStr = d.category
-      ? `<span style="color:var(--brass-fg);font-size:10px">[${esc(catLabel)}]</span> ` : "";
-    const expiryStr = d.expires
-      ? `<span style="color:var(--muted)"> · expires</span>` : "";
-    const nameEN = d.nameEN || d.name || '';
-    const nameIS = d.nameIS || '';
-    const name   = certDefName(d);
-    const altName = (getLang() === 'IS' && nameEN && nameEN !== name) ? nameEN
-                    : (getLang() === 'EN' && nameIS && nameIS !== name) ? nameIS
-                    : '';
-    const altHtml = altName
-      ? `<span style="color:var(--muted);font-size:11px;margin-left:6px">${esc(altName)}</span>` : '';
-    const subcatStr = d.subcats?.length
-      ? d.subcats.map(sc => {
-          const parts = [certSubcatLabel(sc)];
-          if (sc.rank != null) parts.push(`rank ${sc.rank}`);
-          if (sc.issuingAuthority) parts.push(sc.issuingAuthority);
-          return parts.join(" · ");
-        }).join(", ")
-      : s('admin.noSubcategories');
-    const descStr = certDefDescription(d);
-    return `<div class="list-row">
-      <div style="flex:1">
-        <div class="list-name">${catStr}${esc(name)}${altHtml}${authority}${expiryStr}</div>
-        <div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(subcatStr)}</div>
-        ${descStr ? `<div style="font-size:11px;color:var(--muted);margin-top:2px;font-style:italic">${esc(descStr)}</div>` : ""}
-      </div>
-      <button class="row-edit" onclick="openCertDefModal('${d.id}')">Edit</button>
-      <button class="row-del"  onclick="deleteCertDefById('${d.id}')" title="Delete">×</button>
-    </div>`;
-  }
-
-  let html = '';
-  if (certifications.length) {
-    html += `<div style="font-size:9px;color:var(--muted);letter-spacing:1.2px;margin:8px 0 6px">${s('admin.certTypes')}</div>`;
-    html += certifications.map(certDefRow).join('');
-  }
-  if (endorsements.length) {
-    html += `<div style="font-size:9px;color:var(--muted);letter-spacing:1.2px;margin:${certifications.length ? '16' : '8'}px 0 6px">${s('cert.clubEndorsements')}</div>`;
-    html += endorsements.map(certDefRow).join('');
-  }
-  el.innerHTML = html;
-}
-
-function openCertDefModal(id) {
-  certEditId = id || null;
-  const d    = id ? certDefs.find(x => x.id === id) : null;
-  document.getElementById("certDefModalTitle").textContent = d ? s('admin.certEditModal') : s('admin.certAddModal');
-  // Prefer new bilingual fields, fall back to legacy single-string fields.
-  document.getElementById("cdNameEN").value            = d ? (d.nameEN || d.name || "") : "";
-  document.getElementById("cdNameIS").value            = d ? (d.nameIS || "") : "";
-  document.getElementById("cdDescEN").value            = d ? (d.descriptionEN || d.description || "") : "";
-  document.getElementById("cdDescIS").value            = d ? (d.descriptionIS || "") : "";
-  document.getElementById("cdIssuingAuthority").value = d ? (d.issuingAuthority || "") : "";
-  document.getElementById("cdClubEndorsement").checked = d ? !!d.clubEndorsement : false;
-  document.getElementById("cdColor").value            = d?.color || "#b5890a";
-  document.getElementById("cdHasIdNumber").checked     = d ? !!d.hasIdNumber : false;
-  document.getElementById("cdExpires").checked        = d ? !!d.expires : false;
-  document.getElementById("certDefDeleteBtn").classList.toggle("hidden", !d);
-  // Category dropdown
-  populateCdCategorySelect(d?.category || '');
-  toggleCdEndorsement();
-  document.getElementById("subcatRows").innerHTML = "";
-  (d?.subcats || []).forEach(sc => addSubcatRow(sc));
-  openModal("certDefModal");
-}
-
-function populateCdCategorySelect(selected) {
-  const sel = document.getElementById("cdCategory");
-  sel.innerHTML = '<option value="">' + s('admin.certCategoryNone') + '</option>';
-  certCategories.forEach(c => {
-    const key   = certCategoryKey(c);
-    const label = certCategoryLabel(c);
-    if (!key) return;
-    const o = document.createElement("option");
-    o.value = key; o.textContent = label;
-    if (key === selected) o.selected = true;
-    sel.appendChild(o);
-  });
-}
-
-function toggleCdEndorsement() {
-  const isEndorsement = document.getElementById("cdClubEndorsement").checked;
-  document.getElementById("cdCategoryField").style.display = isEndorsement ? "none" : "";
-}
-
-async function saveCertDef() {
-  const btn    = document.getElementById("saveCertDefBtn");
-  const nameEN = document.getElementById("cdNameEN").value.trim();
-  const nameIS = document.getElementById("cdNameIS").value.trim();
-  if (!nameEN) { toast(s("admin.nameRequired"), "err"); return; }
-
-  const newId   = certEditId || ("cert_" + Date.now().toString(36));
-  const expires = document.getElementById("cdExpires").checked;
-  const isEndorsement = document.getElementById("cdClubEndorsement").checked;
-  const descEN  = document.getElementById("cdDescEN").value.trim();
-  const descIS  = document.getElementById("cdDescIS").value.trim();
-  const payload = {
-    id:               newId,
-    // New bilingual fields:
-    nameEN,
-    nameIS,
-    descriptionEN:    descEN,
-    descriptionIS:    descIS,
-    // Legacy mirrors for any half-upgraded consumer:
-    name:             nameEN,
-    description:      descEN,
-    category:         isEndorsement ? '' : document.getElementById("cdCategory").value.trim(),
-    issuingAuthority: document.getElementById("cdIssuingAuthority").value.trim(),
-    subcats:          gatherSubcats(),
-    clubEndorsement:  isEndorsement,
-    color:            document.getElementById("cdColor").value,
-    hasIdNumber:      document.getElementById("cdHasIdNumber").checked,
-    expires,
-  };
-
-  btn.disabled = true;
-  try {
-    const res     = await apiPost("saveCertDef", payload);
-    const savedId = res?.id || newId;
-    const saved   = { ...payload, id: savedId };
-    if (certEditId) {
-      certDefs = certDefs.map(d => d.id === certEditId ? saved : d);
-    } else {
-      certDefs = [...certDefs, saved];
-    }
-    certEditId = savedId;
-    renderCertDefs();
-
-    closeModal("certDefModal", true);
-    toast(s("admin.certDefSaved"));
-  } catch(e) {
-    toast(s("toast.saveFailed") + ": " + e.message, "err");
-  } finally {
-    btn.disabled = false;
-  }
-}
-
-async function deleteCertDef() {
-  if (!certEditId || !await ymConfirm(s("admin.confirmDeleteCertDef"))) return;
-  try {
-    await apiPost("deleteCertDef", { id: certEditId });
-    certDefs = certDefs.filter(d => d.id !== certEditId);
-    renderCertDefs();
-
-    closeModal("certDefModal", true);
-    toast(s("toast.deleted"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function deleteCertDefById(id) {
-  if (!await ymConfirm(s("admin.confirmDeleteCertDef"))) return;
-  try {
-    await apiPost("deleteCertDef", { id });
-    certDefs = certDefs.filter(d => d.id !== id);
-    renderCertDefs();
-
-    toast(s("toast.deleted"));
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-// Subcat row — bilingual label & description inputs. Key is still derived
-// from labelEN so existing data keeps matching.
-let _subcatCounter = 0;
-function addSubcatRow(sc) {
-  const i   = _subcatCounter++;
-  const row = document.createElement("div");
-  row.className = "list-row";
-  row.id = `scrow_${i}`;
-  row.style.cssText = "flex-direction:column;align-items:stretch;gap:6px;padding:10px 0;border-bottom:1px solid var(--border)44";
-  const labelEN = sc?.labelEN ?? sc?.label ?? "";
-  const labelIS = sc?.labelIS ?? "";
-  const descEN  = sc?.descriptionEN ?? sc?.description ?? "";
-  const descIS  = sc?.descriptionIS ?? "";
-  row.innerHTML = `
-    <div style="display:grid;grid-template-columns:1fr 1fr 60px auto;gap:8px;align-items:center">
-      <input type="text"   placeholder="${esc(s('admin.subcatLabelEN') || 'Label (EN)')}" value="${esc(labelEN)}"
-        style="font-size:12px" data-field="labelEN">
-      <input type="text"   placeholder="${esc(s('admin.subcatLabelIS') || 'Label (IS)')}" value="${esc(labelIS)}"
-        style="font-size:12px" data-field="labelIS">
-      <input type="number" placeholder="Rank" min="1" max="99" value="${sc?.rank ?? ""}"
-        style="font-size:12px" data-field="rank" title="Rank (higher replaces lower on assign)">
-      <button class="row-del" onclick="document.getElementById('scrow_${i}').remove()" title="Remove" style="font-size:16px;padding:2px 6px">×</button>
-    </div>
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
-      <input type="text" placeholder="${esc(s('admin.subcatDescEN') || 'Description (EN)')}" value="${esc(descEN)}"
-        style="font-size:12px" data-field="descEN">
-      <input type="text" placeholder="${esc(s('admin.subcatDescIS') || 'Description (IS)')}" value="${esc(descIS)}"
-        style="font-size:12px" data-field="descIS">
-    </div>
-    <div>
-      <label style="font-size:9px;color:var(--muted);letter-spacing:.6px;display:block;margin-bottom:2px">ISSUING AUTHORITY</label>
-      <input type="text" placeholder="e.g. World Sailing" value="${esc(sc?.issuingAuthority || "")}"
-        style="width:100%;box-sizing:border-box;font-size:12px" data-field="issuingAuthority">
-    </div>`;
-  document.getElementById("subcatRows").appendChild(row);
-}
-
-function gatherSubcats() {
-  return [...document.querySelectorAll("#subcatRows .list-row")].map(row => {
-    const labelEN = row.querySelector('[data-field="labelEN"]').value.trim();
-    const labelIS = row.querySelector('[data-field="labelIS"]').value.trim();
-    const descEN  = row.querySelector('[data-field="descEN"]').value.trim();
-    const descIS  = row.querySelector('[data-field="descIS"]').value.trim();
-    return {
-      key:              labelEN.toLowerCase().replace(/\s+/g, "_"),
-      // New bilingual fields:
-      labelEN,
-      labelIS,
-      descriptionEN:    descEN,
-      descriptionIS:    descIS,
-      // Legacy mirrors:
-      label:            labelEN,
-      description:      descEN,
-      rank:             parseInt(row.querySelector('[data-field="rank"]').value) || null,
-      issuingAuthority: row.querySelector('[data-field="issuingAuthority"]').value.trim(),
-    };
-  }).filter(sc => sc.labelEN);
-}
-
-// ══ ALERT SETTINGS ════════════════════════════════════════════════════════════
-
-function loadAlertConfig(cfg) {
-  if (!cfg) return;
-  document.getElementById("alertFirstMins").value  = cfg.firstAlertMins  || 30;
-  document.getElementById("alertRepeatMins").value = cfg.repeatMins       || 15;
-  document.getElementById("alertSnoozeMins").value = cfg.snoozeMins       || 10;
-  document.getElementById("alertEnabled").checked  = cfg.enabled !== false;
-  var ch=cfg.channels||{};
-  if(document.getElementById("chanWeb"))   document.getElementById("chanWeb").checked   = ch.web!==false;
-  if(document.getElementById("chanEmail")) document.getElementById("chanEmail").checked = !!ch.email;
-  if(document.getElementById("chanSms"))   document.getElementById("chanSms").checked   = !!ch.sms;
-  var emails=Array.isArray(cfg.staffEmailList)?cfg.staffEmailList.join(", "):(cfg.staffEmailList||"");
-  var sms=Array.isArray(cfg.staffSmsList)?cfg.staffSmsList.join(", "):(cfg.staffSmsList||"");
-  if(document.getElementById("alertEmailList")) document.getElementById("alertEmailList").value=emails;
-  if(document.getElementById("alertSmsList"))   document.getElementById("alertSmsList").value=sms;
-}
-
-async function saveAlertConfig() {
-  var emailRaw=(document.getElementById("alertEmailList")||{value:""}).value;
-  var smsRaw=(document.getElementById("alertSmsList")||{value:""}).value;
-  const cfg = {
-    firstAlertMins: parseInt(document.getElementById("alertFirstMins").value) || 30,
-    repeatMins:     parseInt(document.getElementById("alertRepeatMins").value) || 15,
-    snoozeMins:     parseInt(document.getElementById("alertSnoozeMins").value) || 10,
-    enabled:        document.getElementById("alertEnabled").checked,
-    channels: {
-      web:   document.getElementById("chanWeb")   ? document.getElementById("chanWeb").checked   : true,
-      email: document.getElementById("chanEmail") ? document.getElementById("chanEmail").checked : false,
-      sms:   document.getElementById("chanSms")   ? document.getElementById("chanSms").checked   : false,
-    },
-    staffEmailList: emailRaw.split(",").map(function(e){return e.trim();}).filter(function(e){return e.includes("@");}),
-    staffSmsList:   smsRaw.split(",").map(function(e){return e.trim();}).filter(function(e){return e.length>4;}),
-  };
-  try {
-    await apiPost("saveAlertConfig", cfg);
-    const msg = document.getElementById("alertSaveMsg");
-    msg.textContent = "✓ " + s("toast.saved");
-    setTimeout(() => { msg.textContent = ""; }, 2500);
-  } catch(e) { toast(s("toast.saveFailed") + ": " + e.message, "err"); }
-}
-
-// ══ FLAG CONFIG ═══════════════════════════════════════════════════════════════
-
-function _fcBandRow(cId,idx,fields,removeFn){
-  return '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px">'+fields.map(function(f){return '<div class="field" style="flex:1;min-width:80px;margin-bottom:0"><label style="font-size:10px">'+esc(f.label)+'</label><input type="number" id="'+cId+'_'+f.key+'_'+idx+'" value="'+f.val+'" step="'+(f.step||1)+'" min="'+(f.min!=null?f.min:-99)+'" style="width:100%" oninput="updateFlagPreview()"></div>';}).join('')+'<button onclick="'+removeFn+'('+idx+')" style="background:none;border:none;color:var(--muted);font-size:18px;cursor:pointer;padding:0 4px;margin-top:14px">×</button></div>';
-}
-function _fcReadBands(cId,keys){var rows=[],idx=0;while(document.getElementById(cId+'_'+keys[0]+'_'+idx)!==null){var row={};keys.forEach(function(k){var el=document.getElementById(cId+'_'+k+'_'+idx);row[k]=el?parseFloat(el.value):0;});rows.push(row);idx++;}return rows;}
-var _fcWindBands=[],_fcWaveBands=[],_fcSstBands=[],_fcFeelsBands=[];
-function fcRenderWindBands(){var el=document.getElementById('fcWindBands');if(!el)return;el.innerHTML=_fcWindBands.map(function(b,i){return _fcBandRow('fcWind',i,[{key:'maxBft',label:'Max Force',val:b.maxBft,min:0},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveWindBand');}).join('');}
-function fcRenderWaveBands(){var el=document.getElementById('fcWaveBands');if(!el)return;el.innerHTML=_fcWaveBands.map(function(b,i){return _fcBandRow('fcWave',i,[{key:'maxM',label:'Max m',val:b.maxM,min:0,step:0.1},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveWaveBand');}).join('');}
-function fcRenderSstBands(){var el=document.getElementById('fcSstBands');if(!el)return;el.innerHTML=_fcSstBands.map(function(b,i){return _fcBandRow('fcSst',i,[{key:'minC',label:'Min °C',val:b.minC},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveSstBand');}).join('');}
-function fcRenderFeelsBands(){var el=document.getElementById('fcFeelsBands');if(!el)return;el.innerHTML=_fcFeelsBands.map(function(b,i){return _fcBandRow('fcFeels',i,[{key:'minC',label:'Min °C',val:b.minC},{key:'pts',label:'Points',val:b.pts,min:0}],'fcRemoveFeelsBand');}).join('');}
-function fcAddWindBand(){_fcWindBands=fcReadWindBands();_fcWindBands.push({maxBft:12,pts:0});fcRenderWindBands();updateFlagPreview();}
-function fcRemoveWindBand(i){_fcWindBands=fcReadWindBands();_fcWindBands.splice(i,1);fcRenderWindBands();updateFlagPreview();}
-function fcReadWindBands(){return _fcReadBands('fcWind',['maxBft','pts']).map(function(r){return{maxBft:r.maxBft,pts:r.pts};});}
-function fcAddWaveBand(){_fcWaveBands=fcReadWaveBands();_fcWaveBands.push({maxM:99,pts:0});fcRenderWaveBands();updateFlagPreview();}
-function fcRemoveWaveBand(i){_fcWaveBands=fcReadWaveBands();_fcWaveBands.splice(i,1);fcRenderWaveBands();updateFlagPreview();}
-function fcReadWaveBands(){return _fcReadBands('fcWave',['maxM','pts']).map(function(r){return{maxM:r.maxM,pts:r.pts};});}
-function fcAddSstBand(){_fcSstBands=fcReadSstBands();_fcSstBands.push({minC:-99,pts:0});fcRenderSstBands();updateFlagPreview();}
-function fcRemoveSstBand(i){_fcSstBands=fcReadSstBands();_fcSstBands.splice(i,1);fcRenderSstBands();updateFlagPreview();}
-function fcReadSstBands(){return _fcReadBands('fcSst',['minC','pts']).map(function(r){return{minC:r.minC,pts:r.pts};});}
-function fcAddFeelsBand(){_fcFeelsBands=fcReadFeelsBands();_fcFeelsBands.push({minC:-99,pts:0});fcRenderFeelsBands();updateFlagPreview();}
-function fcRemoveFeelsBand(i){_fcFeelsBands=fcReadFeelsBands();_fcFeelsBands.splice(i,1);fcRenderFeelsBands();updateFlagPreview();}
-function fcReadFeelsBands(){return _fcReadBands('fcFeels',['minC','pts']).map(function(r){return{minC:r.minC,pts:r.pts};});}
-function loadFlagConfigPanel(c){
-  c=c||{};var sc=SCORE_CONFIG;var t=c.thresholds||sc.thresholds;
-  document.getElementById('fcThreshY').value=t.yellow!=null?t.yellow:25;
-  document.getElementById('fcThreshO').value=t.orange!=null?t.orange:45;
-  document.getElementById('fcThreshR').value=t.red!=null?t.red:65;
-  document.getElementById('fcThreshB').value=t.black!=null?t.black:80;
-  _fcWindBands=(c.wind||sc.wind).map(function(b){return{maxBft:b.maxBft,pts:b.pts};});
-  _fcWaveBands=(c.waves||sc.waves).map(function(b){return{maxM:b.maxM,pts:b.pts};});
-  _fcSstBands=(c.sst||sc.sst).map(function(b){return{minC:b.minC,pts:b.pts};});
-  _fcFeelsBands=(c.feelsLike||sc.feelsLike).map(function(b){return{minC:b.minC,pts:b.pts};});
-  fcRenderWindBands();fcRenderWaveBands();fcRenderSstBands();fcRenderFeelsBands();
-  var wdm=c.windDirModifier||sc.windDirModifier||{dirs:[],pts:0};
-  document.getElementById('fcWindDirPts').value=wdm.pts!=null?wdm.pts:0;
-  document.getElementById('fcGust1Pts').value=(c.gustModifier1Pts??sc.gustModifier1Pts)??0;
-  document.getElementById('fcGust2Pts').value=(c.gustModifier2Pts??sc.gustModifier2Pts)??0;
-  document.getElementById('fcWindDirDirs').value=(wdm.dirs||[]).join(',');
-  var vis=c.visibility||sc.visibility;
-  document.getElementById('fcVisGood').value=vis.good!=null?vis.good:0;
-  document.getElementById('fcVisReduced').value=vis.reduced!=null?vis.reduced:0;
-  document.getElementById('fcVisPoor').value=vis.poor!=null?vis.poor:0;
-  var advEl=document.getElementById('fcFlagAdvice');
-  if(advEl){advEl.innerHTML=['green','yellow','orange','red','black'].map(function(key){var fc=SCORE_CONFIG.flags[key],saved=(c.flags&&c.flags[key])||{};return '<div style="background:'+fc.bg+';border:1px solid '+fc.border+';border-radius:8px;padding:10px 12px;margin-bottom:4px">'+'<div style="font-size:12px;color:'+fc.color+';font-weight:500;margin-bottom:8px">'+fc.icon+' '+key+'</div>'+'<div class="field" style="margin-bottom:6px"><label style="font-size:10px">Short advice (EN)</label><input type="text" id="fcAdvice_'+key+'" value="'+esc(saved.advice||fc.advice||'')+'" style="font-size:11px"></div>'+'<div class="field" style="margin-bottom:6px"><label style="font-size:10px">Stutt ráðlegging (IS)</label><input type="text" id="fcAdviceIS_'+key+'" value="'+esc(saved.adviceIS||fc.adviceIS||'')+'" style="font-size:11px"></div>'+'<div class="field" style="margin-bottom:6px"><label style="font-size:10px">Full description (EN)</label><textarea id="fcDesc_'+key+'" rows="2" style="font-size:11px;width:100%;box-sizing:border-box;resize:vertical;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:5px 7px;font-family:inherit">'+esc(saved.description||fc.description||'')+'</textarea></div>'+'<div class="field" style="margin-bottom:0"><label style="font-size:10px">Full lýsingartexti (IS)</label><textarea id="fcDescIS_'+key+'" rows="2" style="font-size:11px;width:100%;box-sizing:border-box;resize:vertical;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:5px 7px;font-family:inherit">'+esc(saved.descriptionIS||fc.descriptionIS||'')+'</textarea></div>'+'</div>';}).join('');}
-  updateFlagPreview();
-}
-function getFlagFormValues(){
-  var t={yellow:parseInt(document.getElementById('fcThreshY').value)||25,orange:parseInt(document.getElementById('fcThreshO').value)||45,red:parseInt(document.getElementById('fcThreshR').value)||65,black:parseInt(document.getElementById('fcThreshB').value)||80};
-  var windDirDirs=(document.getElementById('fcWindDirDirs').value||'').split(',').map(function(s){return s.trim().toUpperCase();}).filter(Boolean);
-  var windDirModifier={dirs:windDirDirs,pts:parseInt(document.getElementById('fcWindDirPts').value)||0};
-  var cfg={thresholds:t,wind:fcReadWindBands(),waves:fcReadWaveBands(),sst:fcReadSstBands(),feelsLike:fcReadFeelsBands(),windDirModifier:windDirModifier,gustModifier1Pts:parseInt(document.getElementById('fcGust1Pts').value)||0,
-      gustModifier2Pts:parseInt(document.getElementById('fcGust2Pts').value)||0,visibility:{good:parseInt(document.getElementById('fcVisGood').value)||0,reduced:parseInt(document.getElementById('fcVisReduced').value)||0,poor:parseInt(document.getElementById('fcVisPoor').value)||0},flags:{}};
-  ['green','yellow','orange','red','black'].forEach(function(key){var en=document.getElementById('fcAdvice_'+key),is=document.getElementById('fcAdviceIS_'+key);var de=document.getElementById('fcDesc_'+key),dis=document.getElementById('fcDescIS_'+key);cfg.flags[key]={advice:en?en.value.trim():'',adviceIS:is?is.value.trim():'',description:de?de.value.trim():'',descriptionIS:dis?dis.value.trim():''};});
-  return cfg;
-}
-function validateFlagConfig(cfg){var errs=[],t=cfg.thresholds;if(t.yellow>=t.orange)errs.push('Yellow must be < orange.');if(t.orange>=t.red)errs.push('Orange must be < red.');if(t.red>=t.black)errs.push('Red must be < closed.');if(!cfg.wind.length)errs.push('At least one wind band required.');return errs;}
-function updateFlagPreview(){
-  var preview=document.getElementById('fcFlagPreview');if(!preview)return;
-  if(typeof wxScoreFlag!=='function'||typeof wxLoadFlagConfig!=='function'){
-    preview.innerHTML='<div style="font-size:11px;color:var(--muted)">Preview requires weather.js — check script imports.</div>';return;
-  }
-  var examples=[{label:'Force 2, calm',ws:1.6,wDir:'SW',waveH:0,airT:12,sst:10,wg:2},{label:'Force 4, 0.6m, 8°C',ws:5.5,wDir:'SW',waveH:0.6,airT:8,sst:7,wg:7},{label:'Force 5 NE, 1m, 4°C',ws:8.0,wDir:'NE',waveH:1.0,airT:4,sst:5,wg:11},{label:'Force 7 E, 1.8m, -2°C',ws:13.9,wDir:'E',waveH:1.8,airT:-2,sst:3,wg:17},{label:'Force 8, 2.2m, -5°C',ws:17.2,wDir:'NW',waveH:2.2,airT:-5,sst:2,wg:21}];
-  // Deep-clone SCORE_CONFIG, apply form values, render, then restore
-  var snap=JSON.parse(JSON.stringify(SCORE_CONFIG));
-  try{
-    var cfg=getFlagFormValues();
-    // Apply temporarily without persisting
-    Object.assign(SCORE_CONFIG.thresholds,cfg.thresholds);
-    SCORE_CONFIG.wind=cfg.wind;SCORE_CONFIG.waves=cfg.waves;
-    SCORE_CONFIG.sst=cfg.sst;SCORE_CONFIG.feelsLike=cfg.feelsLike;
-    Object.assign(SCORE_CONFIG.visibility,cfg.visibility);
-    SCORE_CONFIG.windDirModifier=cfg.windDirModifier;
-    SCORE_CONFIG.gustModifier1Pts=cfg.gustModifier1Pts;
-    SCORE_CONFIG.gustModifier2Pts=cfg.gustModifier2Pts;
-  }catch(e){}
-  preview.innerHTML=examples.map(function(ex){
-    var r=wxScoreFlag(ex.ws,ex.wDir,ex.waveH,ex.airT,ex.sst,ex.wg,'good');
-    var fk=r.flagKey,fl=SCORE_CONFIG.flags[fk];
-    return '<div style="flex:1;min-width:150px;background:'+fl.bg+';border:1px solid '+fl.border+';border-radius:8px;padding:8px 10px;color:'+fl.color+'">'
-      +'<div style="font-size:12px;font-weight:500">'+fl.icon+' · <b>'+r.score+'</b> pts</div>'
-      +'<div style="font-size:10px;opacity:.8;margin-top:3px">'+esc(ex.label)+'</div></div>';
-  }).join('');
-  // Restore
-  Object.assign(SCORE_CONFIG.thresholds,snap.thresholds);
-  SCORE_CONFIG.wind=snap.wind;SCORE_CONFIG.waves=snap.waves;
-  SCORE_CONFIG.sst=snap.sst;SCORE_CONFIG.feelsLike=snap.feelsLike;
-  Object.assign(SCORE_CONFIG.visibility,snap.visibility);
-  SCORE_CONFIG.windDirModifier=snap.windDirModifier;
-  SCORE_CONFIG.gustModifier1Pts=snap.gustModifier1Pts;
-  SCORE_CONFIG.gustModifier2Pts=snap.gustModifier2Pts;
-}
-async function saveFlagConfig(){
-  var errEl=document.getElementById('fcValidationError'),msgEl=document.getElementById('fcSaveMsg');errEl.style.display='none';msgEl.textContent='';
-  var cfg=getFlagFormValues(),errs=validateFlagConfig(cfg);if(errs.length){errEl.textContent=errs.join(' ');errEl.style.display='block';return;}
-  try{await apiPost('saveConfig',{flagConfig:cfg});if(typeof wxLoadFlagConfig==='function')wxLoadFlagConfig(cfg);updateFlagPreview();msgEl.style.color='var(--green)';msgEl.textContent='✓ '+s('toast.saved');setTimeout(function(){msgEl.textContent='';},3000);}catch(e){msgEl.style.color='var(--red)';msgEl.textContent=s('toast.saveFailed')+': '+e.message;}
-}
-async function resetFlagConfig(){if(!await ymConfirm(s('admin.confirmResetFlags')))return;loadFlagConfigPanel(null);}
-
-// ══ CSV IMPORT ════════════════════════════════════════════════════════════════
-
-function showImportStep(n) {
-  [1,2,3].forEach(i => {
-    document.getElementById("importStep" + i).classList.toggle("hidden", i !== n);
-  });
-}
-
-function handleCSVUpload(input) {
-  const file = input.files[0];
-  if (!file) return;
-  const reader = new FileReader();
-  reader.onload = e => {
-    try {
-      importResult = parseAblerCSV(e.target.result, members);
-      renderImportPreview(importResult);
-    } catch(err) {
-      document.getElementById("importError").textContent = s("admin.parseError") + ": " + err.message;
-      document.getElementById("importError").style.display = "block";
-    }
-  };
-  reader.readAsText(file, "UTF-8");
-}
-
-function parseAblerCSV(text, existing) {
-  const lines  = text.split(/\r?\n/).filter(l => l.trim());
-  const header = lines[0].split(/[,;]/).map(h => h.trim().toLowerCase().replace(/\s+/g,'_'));
-  const col    = k => header.indexOf(k);
-  const rows   = lines.slice(1).map(l => {
-    const vals = l.split(/[,;]/);
-    const get  = k => (vals[col(k)] || "").trim().replace(/^"|"$/g,'');
-    return {
-      kennitala:      get('kennitala'),
-      name:           get('name') || get('full_name') || get('nafn'),
-      email:          get('email') || get('netfang'),
-      phone:          get('phone') || get('simi'),
-      dob:            get('dob') || get('date_of_birth'),
-    };
-  }).filter(r => r.kennitala && r.name);
-
-  const added   = [], updated = [], unchanged = [], flagged = [], ambiguous = [];
-  const existKt = new Map(existing.map(m => [m.kennitala, m]));
-  const existNames = new Map();
-  existing.forEach(m => {
-    const norm = (m.name||'').trim().toLowerCase();
-    if (norm) { if (!existNames.has(norm)) existNames.set(norm, []); existNames.get(norm).push(m); }
-  });
-
-  // Helper: count differing characters between two strings of same length
-  function ktDistance(a, b) {
-    if (!a || !b || a.length !== b.length) return Infinity;
-    let d = 0;
-    for (let i = 0; i < a.length; i++) { if (a[i] !== b[i]) d++; }
-    return d;
-  }
-
-  rows.forEach(r => {
-    const ex = existKt.get(r.kennitala);
-    if (ex) {
-      if (ex.name !== r.name || ex.email !== r.email) {
-        updated.push({ ...r, id: ex.id, _prev: ex });
-      } else { unchanged.push(r); }
-    } else {
-      // Check for possible duplicate: same name OR very similar kennitala
-      const norm = r.name.trim().toLowerCase();
-      const nameMatch = (existNames.get(norm) || []).find(m => m.kennitala !== r.kennitala);
-      // Also check for kennitala off by 1-2 digits (typo detection)
-      let ktMatch = null;
-      if (!nameMatch && r.kennitala.length >= 6) {
-        for (const m of existing) {
-          if (m.kennitala === r.kennitala) continue;
-          if (ktDistance(r.kennitala, m.kennitala) <= 2) { ktMatch = m; break; }
-        }
-      }
-      const match = nameMatch || ktMatch;
-      if (match) {
-        const reason = nameMatch ? 'Same name, different kennitala' : 'Similar kennitala (possible typo)';
-        ambiguous.push({ csvRow: r, existing: match, reason });
-      } else {
-        added.push(r);
-      }
-    }
-  });
-  const activeOnly = existing.filter(m => boolVal(m.active) !== false && m.active !== 'FALSE');
-  activeOnly.forEach(m => {
-    if (['admin','staff','guest','guardian'].includes(m.role)) return;
-    if (!rows.find(r => r.kennitala === m.kennitala)) flagged.push(m);
-  });
-  return { added, updated, unchanged, flagged, ambiguous };
-}
-
-function renderImportPreview(res) {
-  const chips = [
-    { label: `${res.added.length} new`,         cls: 'chip-green'  },
-    { label: `${res.updated.length} updated`,   cls: 'chip-brass'  },
-    { label: `${res.unchanged.length} unchanged`,cls: 'chip-muted' },
-    { label: `${res.flagged.length} not in import`, cls: 'chip-orange' },
-  ];
-  if (res.ambiguous.length) chips.push({ label: `${res.ambiguous.length} needs review`, cls: 'chip-red' });
-  document.getElementById("importSummary").innerHTML = chips.map(c =>
-    `<span class="import-chip ${c.cls}">${c.label}</span>`).join("");
-
-  let html = "";
-  // Ambiguous matches — admin must review before anything happens
-  if (res.ambiguous.length) {
-    html += `<div style="font-size:11px;color:#9b59b6;margin:10px 0 4px;font-weight:500">NEEDS REVIEW — possible duplicates (${res.ambiguous.length})</div>
-      <div style="font-size:10px;color:var(--muted);margin-bottom:6px">These rows are skipped by default. Only change if you are sure.</div>`;
-    res.ambiguous.forEach((a, idx) => {
-      html += `<div class="import-ambig" data-ambig-idx="${idx}">
-        <div style="flex:1">
-          <div><strong>CSV:</strong> ${esc(a.csvRow.name)} <span style="color:var(--muted)">(${esc(a.csvRow.kennitala)})</span></div>
-          <div><strong>Existing:</strong> ${esc(a.existing.name)} <span style="color:var(--muted)">(${esc(a.existing.kennitala)})</span></div>
-          <div style="color:#9b59b6;font-size:10px;margin-top:2px">${esc(a.reason || 'Possible match')}</div>
-        </div>
-        <div class="import-ambig-btns">
-          <button onclick="resolveAmbig(${idx},'same')" title="Same person — update existing record with CSV kennitala &amp; data">Update existing</button>
-          <button onclick="resolveAmbig(${idx},'new')" title="Different person — add CSV row as a separate new member">Add as new</button>
-          <button onclick="resolveAmbig(${idx},'skip')" class="selected" title="Do nothing with this row">Skip</button>
-        </div>
-      </div>`;
-    });
-  }
-  if (res.added.length) {
-    html += `<div style="font-size:11px;color:var(--green);margin:10px 0 4px;font-weight:500">NEW (${res.added.length})</div>
-      <div class="import-list">${res.added.map(m => `
-        <div class="import-row">
-          <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
-          <span style="flex:1">${esc(m.name)}</span>
-          ${m.dob && (new Date().getFullYear() - parseInt(sstr(m.dob).slice(0,4))) < 18
-            ? `<span class="minor-badge">minor</span>` : ""}
-        </div>`).join("")}</div>`;
-  }
-  if (res.updated.length) {
-    html += `<div style="font-size:11px;color:var(--brass-fg);margin:10px 0 4px;font-weight:500">UPDATED (${res.updated.length})</div>
-      <div class="import-list">${res.updated.map(m => `
-        <div class="import-row">
-          <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
-          <span style="flex:1">${esc(m.name)}</span>
-          <span style="color:var(--muted);font-size:11px">was: ${esc(m._prev.name)}</span>
-        </div>`).join("")}</div>`;
-  }
-  if (res.flagged.length) {
-    html += `<div style="font-size:11px;color:var(--orange);margin:10px 0 4px;font-weight:500">NOT IN THIS IMPORT (${res.flagged.length})
-      <span style="font-weight:400;opacity:.7"> — check to deactivate</span></div>
-      <div style="margin-bottom:4px">
-        <label style="font-size:10px;color:var(--muted);cursor:pointer;display:inline-flex;align-items:center;gap:4px">
-          <input type="checkbox" id="flagSelectAll" onchange="toggleFlagAll(this.checked)"> Select all
-        </label>
-      </div>
-      <div class="import-list">${res.flagged.map(m => `
-        <div class="import-row">
-          <label>
-            <input type="checkbox" class="flag-cb" value="${esc(m.id)}" data-kt="${esc(m.kennitala)}">
-            <span style="color:var(--muted);width:80px">${esc(m.kennitala)}</span>
-            <span style="flex:1">${esc(m.name)}</span>
-            <span style="color:var(--muted);font-size:10px">${esc(m.role||'member')}</span>
-          </label>
-        </div>`).join("")}</div>`;
-  }
-
-  document.getElementById("importLists").innerHTML = html;
-  document.getElementById("importError").style.display = "none";
-  showImportStep(2);
-}
-
-function toggleFlagAll(checked) {
-  document.querySelectorAll('.flag-cb').forEach(cb => { cb.checked = checked; });
-}
-
-// Ambiguous resolution: track decisions per index
-let _ambigDecisions = {};
-function resolveAmbig(idx, decision) {
-  _ambigDecisions[idx] = decision;
-  const row = document.querySelector(`[data-ambig-idx="${idx}"]`);
-  if (!row) return;
-  row.querySelectorAll('.import-ambig-btns button').forEach(btn => btn.classList.remove('selected'));
-  const labels = { same: 'Update existing', new: 'Add as new', skip: 'Skip' };
-  row.querySelectorAll('.import-ambig-btns button').forEach(btn => {
-    if (btn.textContent === labels[decision]) btn.classList.add('selected');
-  });
-}
-
-async function confirmImport() {
-  if (!importResult) return;
-  const btn = document.getElementById("confirmImportBtn");
-  btn.disabled = true; btn.textContent = s("admin.importing");
-  try {
-    // Resolve ambiguous entries based on admin decisions
-    const extraAdded = [], extraUpdated = [];
-    (importResult.ambiguous || []).forEach((a, idx) => {
-      const decision = _ambigDecisions[idx] || 'skip';
-      if (decision === 'new') { extraAdded.push(a.csvRow); }
-      else if (decision === 'same') { extraUpdated.push({ ...a.csvRow, id: a.existing.id, kennitala: a.existing.kennitala, _prev: a.existing }); }
-    });
-
-    const toSend = [...importResult.added, ...extraAdded, ...importResult.updated, ...extraUpdated].map(m => {
-      const c = { ...m }; delete c._s; delete c._prev; return c;
-    });
-    const importTemps = [];
-    if (toSend.length) {
-      const results = await Promise.all(chunk(toSend, 10).map(rows => apiPost("importMembers", { rows })));
-      results.forEach(r => {
-        if (r && Array.isArray(r.tempPasswords)) importTemps.push(...r.tempPasswords);
-      });
-    }
-
-    // Deactivate checked flagged members
-    const deactivateIds = Array.from(document.querySelectorAll('.flag-cb:checked')).map(cb => cb.value).filter(Boolean);
-    let deactivated = 0;
-    if (deactivateIds.length) {
-      const res = await apiPost("deactivateMembers", { ids: deactivateIds });
-      deactivated = res.deactivated || 0;
-      deactivateIds.forEach(id => {
-        const m = members.find(x => x.id === id);
-        if (m) m.active = false;
-      });
-    }
-
-    importResult.updated.forEach(u => {
-      members = members.map(m => m.kennitala === u.kennitala ? { ...m, ...u } : m);
-    });
-    extraUpdated.forEach(u => {
-      members = members.map(m => m.id === u.id ? { ...m, ...u } : m);
-    });
-    importResult.added.forEach(a => {
-      const c = { ...a }; delete c._s; members.push(c);
-    });
-    extraAdded.forEach(a => {
-      const c = { ...a }; delete c._s; members.push(c);
-    });
-
-    const totalAdded = importResult.added.length + extraAdded.length;
-    const totalUpdated = importResult.updated.length + extraUpdated.length;
-    let msg = s('admin.importComplete', { added: totalAdded, updated: totalUpdated });
-    if (deactivated) msg += ' ' + s('admin.importDeactivated', { count: deactivated });
-    document.getElementById("importDoneMsg").textContent = msg;
-    showImportStep(3);
-    if (importTemps.length) showTempPasswordDialog(importTemps);
-  } catch(e) {
-    document.getElementById("importError").textContent = s("admin.importFailed") + ": " + e.message;
-    document.getElementById("importError").style.display = "block";
-    btn.disabled = false; btn.textContent = s("admin.confirmImport");
-  }
-}
-
-function resetImport() {
-  importResult = null;
-  _ambigDecisions = {};
-  document.getElementById("csvFile").value = "";
-  showImportStep(1);
-}
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// RESERVATION SLOT CALENDAR
-// ═══════════════════════════════════════════════════════════════════════════════
-
-var _slotWeekStart = null; // Monday of current week
-var _slotData = [];        // loaded slots for current view
-var _editingSlot = null;   // slot being edited in modal
-
-function loadCharterCalendars(cc) {
-  document.getElementById("charterRowingCalId").value = cc.rowingCalendarId || "";
-  document.getElementById("charterRowingCalActive").checked = !!cc.rowingCalendarSyncActive;
-  document.getElementById("charterKeelboatCalId").value = cc.keelboatCalendarId || "";
-  document.getElementById("charterKeelboatCalActive").checked = !!cc.keelboatCalendarSyncActive;
-}
-
-async function saveCharterCalendars() {
-  const msg = document.getElementById("charterCalSaveMsg");
-  msg.textContent = "";
-  try {
-    await apiPost("saveCharterCalendars", {
-      rowingCalendarId: document.getElementById("charterRowingCalId").value.trim(),
-      rowingCalendarSyncActive: document.getElementById("charterRowingCalActive").checked,
-      keelboatCalendarId: document.getElementById("charterKeelboatCalId").value.trim(),
-      keelboatCalendarSyncActive: document.getElementById("charterKeelboatCalActive").checked,
-    });
-    msg.textContent = s("toast.saved") || "Saved";
-    msg.style.color = "var(--green)";
-  } catch (e) {
-    msg.textContent = (s("toast.error") || "Error") + ": " + e.message;
-    msg.style.color = "var(--red)";
-  }
-}
-
-// ── Club Calendars ────────────────────────────────────────────────────────────
-function loadClubCalendars(cals) {
-  var list = document.getElementById("clubCalList");
-  list.innerHTML = "";
-  if (!cals.length) {
-    list.innerHTML = '<div style="font-size:11px;color:var(--muted);margin:8px 0" data-s="admin.calEmpty"></div>';
-    applyStrings(list);
-    return;
-  }
-  cals.forEach(function(c) { addClubCalRow(c.name, c.calendarId); });
-}
-
-function addClubCalRow(name, calId) {
-  var list = document.getElementById("clubCalList");
-  // Remove empty-state message if present
-  var empty = list.querySelector("[data-s='admin.calEmpty']");
-  if (empty) empty.remove();
-  var row = document.createElement("div");
-  row.className = "grid2";
-  row.style.cssText = "margin-bottom:8px;align-items:end";
-  row.innerHTML =
-    '<div class="field"><label data-s="admin.calName"></label><input type="text" class="ccName" value="' + esc(name) + '"></div>' +
-    '<div style="display:flex;gap:6px;align-items:end"><div class="field" style="flex:1"><label data-s="admin.calId"></label><input type="text" class="ccId" value="' + esc(calId) + '" placeholder="' + (s("admin.calPlaceholder") || "") + '"></div>' +
-    '<button class="btn btn-ghost btn-danger" style="margin-bottom:4px;font-size:10px" onclick="removeClubCalRow(this)" data-s="admin.calRemove"></button></div>';
-  list.appendChild(row);
-  applyStrings(row);
-}
-
-function removeClubCalRow(btn) {
-  btn.closest(".grid2").remove();
-}
-
-async function saveClubCalendars() {
-  var msg = document.getElementById("clubCalSaveMsg");
-  msg.textContent = "";
-  var rows = document.querySelectorAll("#clubCalList .grid2");
-  var cals = [];
-  rows.forEach(function(r) {
-    var name = r.querySelector(".ccName").value.trim();
-    var calId = r.querySelector(".ccId").value.trim();
-    if (name && calId) cals.push({ name: name, calendarId: calId });
-  });
-  try {
-    await apiPost("saveClubCalendars", { calendars: cals });
-    msg.textContent = s("toast.saved") || "Saved";
-    msg.style.color = "var(--green)";
-  } catch (e) {
-    msg.textContent = (s("toast.error") || "Error") + ": " + e.message;
-    msg.style.color = "var(--red)";
-  }
-}
-
-function initSlotCalendar() {
-  // Set week start to this Monday
-  var d = new Date();
-  d.setDate(d.getDate() - ((d.getDay() + 6) % 7)); // Monday
-  d.setHours(0,0,0,0);
-  _slotWeekStart = d;
-  // Populate category filter
-  var sel = document.getElementById("slotCatFilter");
-  sel.innerHTML = '';
-  var cats = (boatCats || []).filter(function(c) {
-    return (_allBoats || []).some(function(b) { return b.category === c.key && b.accessMode === 'controlled' && boolVal(b.slotSchedulingEnabled); });
-  });
-  if (!cats.length) {
-    sel.innerHTML = '<option value="">(' + s('slot.noSlotBoats') + ')</option>';
-    return;
-  }
-  cats.forEach(function(c) {
-    sel.innerHTML += '<option value="' + esc(c.key) + '">' + esc(c.label || c.key) + '</option>';
-  });
-  loadSlotCalendar();
-}
-
-async function loadSlotCalendar() {
-  var cat = document.getElementById("slotCatFilter").value;
-  if (!cat) { document.getElementById("slotCalGrid").innerHTML = ''; return; }
-  var fromDate = _slotWeekStart.toISOString().slice(0, 10);
-  var toD = new Date(_slotWeekStart); toD.setDate(toD.getDate() + 6);
-  var toDate = toD.toISOString().slice(0, 10);
-  try {
-    var res = await apiGet("getSlots", { category: cat, fromDate: fromDate, toDate: toDate });
-    _slotData = res.slots || [];
-  } catch(e) { _slotData = []; }
-  // Populate boat filter
-  var boatSel = document.getElementById("slotBoatFilter");
-  var catBoats = (_allBoats || []).filter(function(b) { return b.category === cat && boolVal(b.slotSchedulingEnabled); });
-  boatSel.innerHTML = '<option value="">' + s('slot.allBoats') + '</option>';
-  catBoats.forEach(function(b) { boatSel.innerHTML += '<option value="' + esc(b.id) + '">' + esc(b.name) + '</option>'; });
-  renderSlotCalendar();
-}
-
-var _adminCalendars = {};
-
-function _resolveSlotColor(sl) {
-  if (!sl || !sl.bookedByKennitala) return null;
-  if (sl.bookingColor) return sl.bookingColor;
-  if (sl.bookedByCrewId && Array.isArray(window._allCrews)) {
-    var crew = window._allCrews.find(function(c) { return c.id === sl.bookedByCrewId; });
-    if (crew && crew.color) return crew.color;
-  }
-  return null;
-}
-
-function renderSlotCalendar() {
-  var cat = document.getElementById("slotCatFilter").value;
-  var boatFilter = document.getElementById("slotBoatFilter").value;
-  var catBoats = (_allBoats || []).filter(function(b) {
-    return b.category === cat && boolVal(b.slotSchedulingEnabled) && (!boatFilter || b.id === boatFilter);
-  });
-  var container = document.getElementById("slotCalGrid");
-  if (!catBoats.length) {
-    container.innerHTML = '<div style="font-size:11px;color:var(--muted)">' + s('slot.noSlotBoats') + '</div>';
-    _adminCalendars = {};
-    return;
-  }
-  // Update week label
-  var d0 = new Date(_slotWeekStart);
-  var d6 = new Date(_slotWeekStart); d6.setDate(d6.getDate() + 6);
-  document.getElementById("slotWeekLabel").textContent = fmtWeekRange(d0.toISOString(), d6.toISOString());
-
-  // One SlotCalendar per boat (to match captain/rowing calendar styling)
-  container.innerHTML = '';
-  var newCals = {};
-  catBoats.forEach(function(boat) {
-    var boatSlots = _slotData.filter(function(sl) { return sl.boatId === boat.id; });
-    // Enrich with crew name so the calendar identifies bookings by crew.
-    if (Array.isArray(window._allCrews)) {
-      boatSlots.forEach(function(sl) {
-        if (sl.bookedByCrewId && !sl.bookedByCrewName) {
-          var crew = window._allCrews.find(function(c) { return c.id === sl.bookedByCrewId; });
-          if (crew) sl.bookedByCrewName = crew.name;
-        }
-      });
-    }
-    var wrap = document.createElement('div');
-    wrap.style.marginBottom = '16px';
-    var hdr = document.createElement('div');
-    hdr.style.cssText = 'font-size:11px;font-weight:500;letter-spacing:.5px;margin-bottom:6px;color:var(--text)';
-    hdr.textContent = boat.name;
-    wrap.appendChild(hdr);
-    var gridEl = document.createElement('div');
-    wrap.appendChild(gridEl);
-    container.appendChild(wrap);
-
-    var cal = new SlotCalendar(gridEl, {
-      isMine: function() { return false; },
-      onBook: function(slotId) { openSlotModal(slotId); },
-      onUnbook: function(slotId) { openSlotModal(slotId); },
-      getSlotColor: _resolveSlotColor,
-    });
-    cal.setWeekStart(_slotWeekStart);
-    cal.setSlots(boatSlots);
-    newCals[boat.id] = cal;
-  });
-  _adminCalendars = newCals;
-}
-
-function shiftSlotWeek(dir) {
-  _slotWeekStart.setDate(_slotWeekStart.getDate() + dir * 7);
-  loadSlotCalendar();
-}
-
-function slotWeekToday() {
-  var d = new Date();
-  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
-  d.setHours(0,0,0,0);
-  _slotWeekStart = d;
-  loadSlotCalendar();
-}
-
-// Open slot modal for a cell (create new)
-function openSlotCell(boatId, date) {
-  _editingSlot = null;
-  var boat = (_allBoats || []).find(function(b) { return b.id === boatId; });
-  document.getElementById("slotModalTitle").textContent = s('slot.newTitle');
-  document.getElementById("slotModalBoatName").textContent = boat ? boat.name : boatId;
-  document.getElementById("smDate").value = date;
-  document.getElementById("smStartTime").value = '18:00';
-  document.getElementById("smEndTime").value = '21:00';
-  document.getElementById("smNote").value = '';
-  document.getElementById("smDeleteBtn").classList.add("hidden");
-  document.getElementById("slotBookedInfo").classList.add("hidden");
-  _editingSlot = { boatId: boatId };
-  applyStrings(document.getElementById("slotModal"));
-  openModal("slotModal");
-}
-
-// Open slot modal for existing slot (edit)
-function openSlotModal(slotId) {
-  var sl = _slotData.find(function(s) { return s.id === slotId; });
-  if (!sl) return;
-  var boat = (_allBoats || []).find(function(b) { return b.id === sl.boatId; });
-  var title = document.getElementById("slotModalTitle");
-  title.setAttribute('data-s', 'slot.editTitle');
-  title.textContent = s('slot.editTitle');
-  document.getElementById("slotModalBoatName").textContent = boat ? boat.name : sl.boatId;
-  document.getElementById("smDate").value = sl.date;
-  document.getElementById("smStartTime").value = sl.startTime;
-  document.getElementById("smEndTime").value = sl.endTime;
-  document.getElementById("smNote").value = sl.note || '';
-  document.getElementById("smDeleteBtn").classList.remove("hidden");
-  if (sl.bookedByKennitala) {
-    document.getElementById("slotBookedInfo").classList.remove("hidden");
-    document.getElementById("slotBookedInfo").textContent = s('slot.bookedBy') + ': ' + (sl.bookedByName || sl.bookedByKennitala);
-  } else {
-    document.getElementById("slotBookedInfo").classList.add("hidden");
-  }
-  _editingSlot = { boatId: sl.boatId, slotId: sl.id };
-  applyStrings(document.getElementById("slotModal"));
-  openModal("slotModal");
-}
-
-async function saveCurrentSlot() {
-  if (!_editingSlot) return;
-  var date = document.getElementById("smDate").value;
-  var startTime = document.getElementById("smStartTime").value;
-  var endTime = document.getElementById("smEndTime").value;
-  if (!date || !startTime || !endTime) { toast(s('slot.missingFields'), 'err'); return; }
-  try {
-    await apiPost("saveSlot", {
-      boatId: _editingSlot.boatId,
-      slotId: _editingSlot.slotId || '',
-      date: date, startTime: startTime, endTime: endTime,
-      note: document.getElementById("smNote").value || '',
-    });
-    closeModal("slotModal", true);
-    toast(s('toast.saved'));
-    loadSlotCalendar();
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-async function deleteCurrentSlot() {
-  if (!_editingSlot || !_editingSlot.slotId) return;
-  if (!(await ymConfirm(s('slot.confirmDelete')))) return;
-  try {
-    await apiPost("deleteSlot", { slotId: _editingSlot.slotId });
-    closeModal("slotModal", true);
-    toast(s('toast.deleted'));
-    loadSlotCalendar();
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-// Open slot modal for NEW slot creation (requires a specific boat selected in filter)
-function openNewSlotModal() {
-  var boatId = document.getElementById("slotBoatFilter").value;
-  if (!boatId) { toast(s('slot.selectBoatFirst'), 'err'); return; }
-  var boat = (_allBoats || []).find(function(b) { return b.id === boatId; });
-  if (!boat) return;
-  var title = document.getElementById("slotModalTitle");
-  title.setAttribute('data-s', 'slot.newTitle');
-  title.textContent = s('slot.newTitle');
-  document.getElementById("slotModalBoatName").textContent = boat.name;
-  document.getElementById("smDate").value = new Date().toISOString().slice(0, 10);
-  document.getElementById("smStartTime").value = '18:00';
-  document.getElementById("smEndTime").value = '21:00';
-  document.getElementById("smNote").value = '';
-  document.getElementById("smDeleteBtn").classList.add("hidden");
-  document.getElementById("slotBookedInfo").classList.add("hidden");
-  _editingSlot = { boatId: boatId, slotId: '' };
-  applyStrings(document.getElementById("slotModal"));
-  openModal("slotModal");
-}
-
-// Recurring slot creation
-function openRecurringSlotModal() {
-  var cat = document.getElementById("slotCatFilter").value;
-  var catBoats = (_allBoats || []).filter(function(b) { return b.category === cat && boolVal(b.slotSchedulingEnabled); });
-  var sel = document.getElementById("rsBoat");
-  sel.innerHTML = '';
-  catBoats.forEach(function(b) { sel.innerHTML += '<option value="' + esc(b.id) + '">' + esc(b.name) + '</option>'; });
-  // Reset checkboxes
-  document.querySelectorAll('#rsDays input').forEach(function(cb) { cb.checked = false; });
-  document.getElementById("rsStartTime").value = '18:00';
-  document.getElementById("rsEndTime").value = '21:00';
-  var today = new Date().toISOString().slice(0, 10);
-  document.getElementById("rsFromDate").value = today;
-  var endD = new Date(); endD.setMonth(endD.getMonth() + 3);
-  document.getElementById("rsToDate").value = endD.toISOString().slice(0, 10);
-  document.getElementById("rsNote").value = '';
-  document.getElementById("rsPreview").textContent = '';
-  applyStrings(document.getElementById("recurSlotModal"));
-  openModal("recurSlotModal");
-}
-
-function previewRecurringSlots() {
-  var days = [];
-  document.querySelectorAll('#rsDays input:checked').forEach(function(cb) { days.push(parseInt(cb.value)); });
-  var from = document.getElementById("rsFromDate").value;
-  var to = document.getElementById("rsToDate").value;
-  if (!days.length || !from || !to) { document.getElementById("rsPreview").textContent = s('slot.selectDays'); return; }
-  var count = 0;
-  var d = new Date(from + 'T00:00:00');
-  var end = new Date(to + 'T00:00:00');
-  while (d <= end) {
-    if (days.indexOf(d.getDay()) !== -1) count++;
-    d.setDate(d.getDate() + 1);
-  }
-  document.getElementById("rsPreview").textContent = s('slot.previewCount', { count: count });
-}
-
-async function saveRecurringSlots() {
-  var boatId = document.getElementById("rsBoat").value;
-  var days = [];
-  document.querySelectorAll('#rsDays input:checked').forEach(function(cb) { days.push(parseInt(cb.value)); });
-  var startTime = document.getElementById("rsStartTime").value;
-  var endTime = document.getElementById("rsEndTime").value;
-  var fromDate = document.getElementById("rsFromDate").value;
-  var toDate = document.getElementById("rsToDate").value;
-  if (!boatId || !days.length || !startTime || !endTime || !fromDate || !toDate) {
-    toast(s('slot.missingFields'), 'err'); return;
-  }
-  try {
-    var res = await apiPost("saveRecurringSlots", {
-      boatId: boatId, daysOfWeek: days,
-      startTime: startTime, endTime: endTime,
-      fromDate: fromDate, toDate: toDate,
-      note: document.getElementById("rsNote").value || '',
-    });
-    closeModal("recurSlotModal", true);
-    toast(s('slot.created', { count: res.count || 0 }));
-    loadSlotCalendar();
-  } catch(e) { toast(s("toast.error") + ": " + e.message, "err"); }
-}
-
-// ── ROWING PASSPORT ADMIN ─────────────────────────────────────────────────────
-let _passportDef = null;
-let _passportDirty = false;
-// Sort mode: 'cat-mod' = Category → Module, 'mod-cat' = Module → Category
-let _passportSortMode = 'cat-mod';
-
-async function renderPassportAdmin() {
-  const card = document.getElementById('passportAdminPreview');
-  card.innerHTML = '<div class="loading-state"><span class="spinner"></span></div>';
-  try {
-    const res = await apiGet('getRowingPassport', {});
-    _passportDef = res.definition || { version: 1, passports: [] };
-    _passportDirty = false;
-    drawPassportEditor();
-  } catch(e) { card.innerHTML = '<div style="color:var(--red)">' + esc(e.message) + '</div>'; }
-}
-
-// In-memory edit targets for passport modals.
-let _ppEditing = { pi: null, ci: null, ii: null, mode: null };
-
-// Renders a single item row in the admin preview (used by both sort modes).
-// `pi, ci, ii` are the ORIGINAL indices into _passportDef so the edit/retire
-// handlers operate on the real underlying item regardless of display order.
-function _ppRenderItemRow(p, cat, it, pi, ci, ii) {
-  const retired = !!it.retired;
-  const assessment = it.assessment || 'practical';
-  const itemNameEN = it.name?.EN || it.id;
-  const itemNameIS = it.name?.IS || '';
-  const descEN = (it.desc && it.desc.EN) || '';
-  const descIS = (it.desc && it.desc.IS) || '';
-  const descPreview = descEN || descIS || '';
-  const assessmentLabel = assessment === 'theory' ? s('passport.theory') : s('passport.practical');
-  const assessmentColor = assessment === 'theory' ? 'var(--brass)' : 'var(--muted)';
-  const moduleNum = Number(it.module || 0);
-  const moduleBadge = moduleNum > 0
-    ? `<span style="font-size:9px;color:var(--brass-fg);border:1px solid var(--brass);border-radius:3px;padding:1px 4px;margin-left:4px;text-transform:uppercase;letter-spacing:.5px">${esc(s('passport.moduleShort'))} ${moduleNum}</span>`
-    : '';
-  return `<div style="border-top:1px solid var(--border);padding:8px 0;display:flex;align-items:flex-start;gap:8px;${retired ? 'opacity:.5' : ''}">
-    <div style="flex:1;min-width:0">
-      <div style="font-size:12px;font-weight:500">
-        ${esc(itemNameEN)}${itemNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(itemNameIS)}</span>` : ''}
-        <span style="font-size:9px;color:${assessmentColor};border:1px solid ${assessmentColor};border-radius:3px;padding:1px 4px;margin-left:6px;text-transform:uppercase;letter-spacing:.5px">${esc(assessmentLabel)}</span>
-        ${moduleBadge}
-        ${retired ? `<span style="font-size:9px;color:var(--red);border:1px solid var(--red);border-radius:3px;padding:1px 4px;margin-left:4px;text-transform:uppercase;letter-spacing:.5px">${esc(s('passport.retiredBadge'))}</span>` : ''}
-      </div>
-      <div style="font-size:10px;color:var(--muted);margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
-        ${descPreview ? esc(descPreview) : `<em>${esc(s('passport.noDescription'))}</em>`}
-      </div>
-      <div style="font-size:9px;color:var(--faint);margin-top:2px">${esc(it.id)}</div>
-    </div>
-    <div style="display:flex;flex-direction:column;gap:4px">
-      <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="openPassportItemModal(${pi},${ci},${ii})" data-s="passport.editItem">Edit</button>
-      <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="ppToggleRetire(${pi},${ci},${ii})">${retired ? esc(s('passport.unretire')) : esc(s('passport.retire'))}</button>
-    </div>
-  </div>`;
-}
-
-// Flatten all items of a passport, preserving original (ci, ii) coordinates.
-function _ppFlattenItems(p) {
-  const out = [];
-  (p.categories || []).forEach((cat, ci) => {
-    (cat.items || []).forEach((it, ii) => {
-      out.push({ cat, ci, it, ii });
-    });
-  });
-  return out;
-}
-
-function ppSetSortMode(mode) {
-  _passportSortMode = (mode === 'mod-cat') ? 'mod-cat' : 'cat-mod';
-  drawPassportEditor();
-}
-window.ppSetSortMode = ppSetSortMode;
-
-function drawPassportEditor() {
-  const card = document.getElementById('passportAdminPreview');
-  const def = _passportDef;
-  if (!def || !(def.passports || []).length) {
-    card.innerHTML = `<div style="color:var(--muted);padding:12px 0">No passports configured. Import a CSV to get started.</div>
-      <div style="margin-top:12px;display:flex;gap:8px;align-items:center">
-        <button class="btn btn-primary" style="font-size:11px" onclick="ppSaveDef()" data-s="passport.save">Save changes</button>
-        <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
-      </div>`;
-    applyStrings(card);
-    return;
-  }
-  const sortMode = _passportSortMode;
-  const isCatMod = sortMode !== 'mod-cat';
-  let html = '';
-
-  // Sort-mode toggle (shared across all passports in the editor)
-  html += `<div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
-    <span style="font-size:10px;color:var(--muted);letter-spacing:.5px;text-transform:uppercase" data-s="passport.sortBy">Sort by</span>
-    <button class="btn ${isCatMod ? 'btn-primary' : 'btn-secondary'}" style="font-size:10px;padding:3px 10px" onclick="ppSetSortMode('cat-mod')" data-s="passport.sortCatMod">Category → Module</button>
-    <button class="btn ${!isCatMod ? 'btn-primary' : 'btn-secondary'}" style="font-size:10px;padding:3px 10px" onclick="ppSetSortMode('mod-cat')" data-s="passport.sortModCat">Module → Category</button>
-  </div>`;
-
-  (def.passports || []).forEach((p, pi) => {
-    const totalItems   = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i => !i.retired).length, 0);
-    const retiredItems = (p.categories || []).reduce((sum, c) => sum + (c.items || []).filter(i =>  i.retired).length, 0);
-    const reqSigs   = Number(p.requiredSigs || 2);
-    const promoteId = p.promoteCertId || 'rowing_division';
-    const nameEN = p.name?.EN || p.id;
-    const nameIS = p.name?.IS || '';
-    html += `<div style="border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:14px;background:var(--card)">
-      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:10px">
-        <div style="flex:1;min-width:0">
-          <div style="font-weight:700;font-size:14px;color:var(--text)">${esc(nameEN)} <span style="color:var(--muted);font-weight:400;font-size:10px">(${esc(p.id)})</span></div>
-          ${nameIS ? `<div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(nameIS)}</div>` : ''}
-          <div style="font-size:10px;color:var(--muted);margin-top:6px">
-            v${def.version || 1} ·
-            ${totalItems} ${s('passport.activeCount')}${retiredItems ? ' · ' + retiredItems + ' ' + s('passport.retiredBadge') : ''} ·
-            ${s('passport.requiresSignatures', { n: reqSigs })} ·
-            ${s('passport.promotesTo', { cert: esc(promoteId) })} (${esc(p.fromSub || 'restricted')} → ${esc(p.toSub || 'released')})
-          </div>
-        </div>
-        <button class="btn btn-secondary" style="font-size:10px;padding:4px 10px;white-space:nowrap" onclick="openPassportSettingsModal(${pi})" data-s="passport.editSettings">Edit passport settings</button>
-      </div>`;
-
-    if (isCatMod) {
-      // Category → Module: preserve original category order; within each category
-      // sort items by (module asc, name asc). Adds/edits stay anchored per-category.
-      (p.categories || []).forEach((cat, ci) => {
-        const catNameEN = cat.name?.EN || cat.id;
-        const catNameIS = cat.name?.IS || '';
-        html += `<div style="margin-top:10px;border:1px solid var(--border);border-radius:6px;padding:10px;background:var(--surface)">
-          <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-            <div style="flex:1;min-width:0">
-              <div style="font-weight:600;font-size:12px">${esc(catNameEN)}${catNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(catNameIS)}</span>` : ''}</div>
-              <div style="font-size:9px;color:var(--muted)">${esc(cat.id)}</div>
-            </div>
-            <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="openPassportCategoryModal(${pi},${ci})" data-s="passport.editCategory">Edit category</button>
-          </div>`;
-
-        const items = (cat.items || []).map((it, ii) => ({ it, ii }));
-        if (!items.length) {
-          html += `<div style="font-size:10px;color:var(--muted);padding:6px 0">— no items —</div>`;
-        } else {
-          items.sort((a, b) => {
-            const ma = Number(a.it.module || 0);
-            const mb = Number(b.it.module || 0);
-            if (ma !== mb) return ma - mb;
-            return String(a.it.name?.EN || '').localeCompare(String(b.it.name?.EN || ''));
-          });
-          items.forEach(({ it, ii }) => {
-            html += _ppRenderItemRow(p, cat, it, pi, ci, ii);
-          });
-        }
-
-        html += `<div style="margin-top:8px">
-          <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="openPassportItemModal(${pi},${ci},null)" data-s="passport.addItem">+ Add item</button>
-        </div></div>`;
-      });
-    } else {
-      // Module → Category: bucket all items by module; within each module bucket
-      // group by their original category so edit handlers still line up. Module 0
-      // (unassigned) is shown last as a dedicated bucket.
-      const flat = _ppFlattenItems(p);
-      const modKeys = {};
-      flat.forEach(entry => {
-        const m = Number(entry.it.module || 0);
-        if (!modKeys[m]) modKeys[m] = [];
-        modKeys[m].push(entry);
-      });
-      const orderedMods = Object.keys(modKeys).map(Number).sort((a, b) => {
-        if (a === 0) return 1;  // unassigned last
-        if (b === 0) return -1;
-        return a - b;
-      });
-
-      if (!orderedMods.length) {
-        html += `<div style="font-size:10px;color:var(--muted);padding:8px 0">— no items —</div>`;
-      }
-
-      orderedMods.forEach(modNum => {
-        const bucket = modKeys[modNum];
-        const modLabel = modNum > 0
-          ? `${s('passport.moduleLabel')} ${modNum}`
-          : s('passport.unassignedModule');
-        html += `<div style="margin-top:10px;border:1px solid var(--border);border-radius:6px;padding:10px;background:var(--surface)">
-          <div style="font-weight:700;font-size:12px;color:var(--brass-fg);letter-spacing:.5px;text-transform:uppercase;margin-bottom:8px">${esc(modLabel)} <span style="color:var(--muted);font-weight:400;font-size:10px">· ${bucket.length}</span></div>`;
-
-        // Sub-group by category (preserving the passport's category order)
-        const byCat = {};
-        bucket.forEach(entry => {
-          if (!byCat[entry.ci]) byCat[entry.ci] = [];
-          byCat[entry.ci].push(entry);
-        });
-        const catOrder = Object.keys(byCat).map(Number).sort((a, b) => a - b);
-        catOrder.forEach(ci => {
-          const cat = p.categories[ci];
-          const catNameEN = cat.name?.EN || cat.id;
-          const catNameIS = cat.name?.IS || '';
-          html += `<div style="margin-top:8px;padding-left:8px;border-left:2px solid var(--border)">
-            <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
-              <div style="flex:1;min-width:0">
-                <div style="font-weight:600;font-size:11px">${esc(catNameEN)}${catNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(catNameIS)}</span>` : ''}</div>
-              </div>
-              <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="openPassportCategoryModal(${pi},${ci})" data-s="passport.editCategory">Edit category</button>
-            </div>`;
-          const entries = byCat[ci].slice().sort((a, b) =>
-            String(a.it.name?.EN || '').localeCompare(String(b.it.name?.EN || '')));
-          entries.forEach(({ it, ii }) => {
-            html += _ppRenderItemRow(p, cat, it, pi, ci, ii);
-          });
-          html += `</div>`;
-        });
-
-        html += `</div>`;
-      });
-
-      // In Module → Category mode, "+Add item" is shown per-category at the bottom
-      // so authors can still create items (they'll be assigned a module via the modal).
-      html += `<div style="margin-top:10px;border:1px dashed var(--border);border-radius:6px;padding:10px;background:var(--surface)">
-        <div style="font-size:10px;color:var(--muted);margin-bottom:6px" data-s="passport.addItemHint">Add a new item to a category:</div>
-        <div style="display:flex;gap:6px;flex-wrap:wrap">`;
-      (p.categories || []).forEach((cat, ci) => {
-        const catNameEN = cat.name?.EN || cat.id;
-        html += `<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" onclick="openPassportItemModal(${pi},${ci},null)">+ ${esc(catNameEN)}</button>`;
-      });
-      html += `</div></div>`;
-    }
-
-    html += `<div style="margin-top:12px">
-      <button class="btn btn-secondary" style="font-size:10px;padding:3px 10px" onclick="openPassportCategoryModal(${pi},null)" data-s="passport.addCategory">+ Add category</button>
-    </div>`;
-    html += '</div>';
-  });
-
-  html += `<div style="margin-top:14px;display:flex;gap:8px;align-items:center">
-    <button class="btn btn-primary" style="font-size:11px" onclick="ppSaveDef()" data-s="passport.save">Save changes</button>
-    <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
-  </div>`;
-  card.innerHTML = html;
-  applyStrings(card);
-}
-
-function _ppMarkDirty() { _passportDirty = true; const m = document.getElementById('ppDirtyMark'); if (m) m.textContent = '● unsaved'; }
-function _ppSlug(s) { return String(s || '').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') || ('item-' + Date.now().toString(36)); }
-
-// Existing items flagged with __new were added in this session and can be
-// spliced on delete; without the flag we soft-delete (retire) instead so
-// any backend sign-offs referencing the id remain valid.
-function _ppIsNewItem(it) { return !!(it && it.__new); }
-
-// ── Passport settings modal ────────────────────────────────────────────────
-function openPassportSettingsModal(pi) {
-  const p = _passportDef && _passportDef.passports[pi];
-  if (!p) return;
-  _ppEditing = { pi, ci: null, ii: null, mode: 'settings' };
-  document.getElementById('ppsId').value             = p.id || '';
-  document.getElementById('ppsNameEN').value         = (p.name && p.name.EN) || '';
-  document.getElementById('ppsNameIS').value         = (p.name && p.name.IS) || '';
-  document.getElementById('ppsRequiredSigs').value   = Number(p.requiredSigs || 2);
-  document.getElementById('ppsPromoteCertId').value  = p.promoteCertId || 'rowing_division';
-  document.getElementById('ppsFromSub').value        = p.fromSub || 'restricted';
-  document.getElementById('ppsToSub').value          = p.toSub || 'released';
-  openModal('passportSettingsModal');
-}
-
-function savePassportSettings() {
-  const pi = _ppEditing.pi;
-  const p  = _passportDef && _passportDef.passports[pi];
-  if (!p) return;
-  const nameEN = document.getElementById('ppsNameEN').value.trim();
-  if (!nameEN) { toast(s('passport.nameRequired'), 'err'); return; }
-  let req = parseInt(document.getElementById('ppsRequiredSigs').value, 10);
-  if (!(req >= 1)) req = 1;
-  p.name = p.name || {};
-  p.name.EN = nameEN;
-  p.name.IS = document.getElementById('ppsNameIS').value.trim();
-  p.requiredSigs  = req;
-  p.promoteCertId = document.getElementById('ppsPromoteCertId').value.trim() || 'rowing_division';
-  p.fromSub       = document.getElementById('ppsFromSub').value.trim() || 'restricted';
-  p.toSub         = document.getElementById('ppsToSub').value.trim() || 'released';
-  _ppMarkDirty();
-  closeModal('passportSettingsModal', true);
-  drawPassportEditor();
-}
-
-// ── Passport item modal (add + edit) ───────────────────────────────────────
-function openPassportItemModal(pi, ci, ii) {
-  const cat = _passportDef && _passportDef.passports[pi] && _passportDef.passports[pi].categories[ci];
-  if (!cat) return;
-  const adding = (ii === null || ii === undefined);
-  _ppEditing = { pi, ci, ii: adding ? null : ii, mode: adding ? 'item-add' : 'item-edit' };
-  const it = adding ? { id: '', name: { EN: '', IS: '' }, desc: { EN: '', IS: '' }, assessment: 'practical', module: 0, retired: false } : cat.items[ii];
-  document.getElementById('passportItemModalTitle').textContent =
-    adding ? s('passport.newItem') : s('passport.itemTitle');
-  document.getElementById('ppiId').value        = it.id || '';
-  document.getElementById('ppiNameEN').value    = (it.name && it.name.EN) || '';
-  document.getElementById('ppiNameIS').value    = (it.name && it.name.IS) || '';
-  document.getElementById('ppiDescEN').value    = (it.desc && it.desc.EN) || '';
-  document.getElementById('ppiDescIS').value    = (it.desc && it.desc.IS) || '';
-  document.getElementById('ppiAssessment').value = it.assessment || 'practical';
-  document.getElementById('ppiModule').value    = Number(it.module || 0) || '';
-  document.getElementById('ppiRetired').checked = !!it.retired;
-  document.getElementById('ppiDeleteBtn').classList.toggle('hidden', adding);
-  openModal('passportItemModal');
-}
-
-function savePassportItem() {
-  const { pi, ci, mode } = _ppEditing;
-  const cat = _passportDef && _passportDef.passports[pi] && _passportDef.passports[pi].categories[ci];
-  if (!cat) return;
-  const nameEN = document.getElementById('ppiNameEN').value.trim();
-  if (!nameEN) { toast(s('passport.nameRequired'), 'err'); return; }
-  let modNum = parseInt(document.getElementById('ppiModule').value, 10);
-  if (!(modNum >= 0)) modNum = 0;
-  const payload = {
-    name: {
-      EN: nameEN,
-      IS: document.getElementById('ppiNameIS').value.trim(),
-    },
-    desc: {
-      EN: document.getElementById('ppiDescEN').value.trim(),
-      IS: document.getElementById('ppiDescIS').value.trim(),
-    },
-    assessment: document.getElementById('ppiAssessment').value || 'practical',
-    module: modNum,
-    retired: document.getElementById('ppiRetired').checked,
-  };
-  if (mode === 'item-add') {
-    const id = _ppSlug(nameEN);
-    cat.items = cat.items || [];
-    cat.items.push({ id, __new: true, ...payload });
-  } else {
-    const it = cat.items[_ppEditing.ii];
-    if (!it) return;
-    it.name = payload.name;
-    it.desc = payload.desc;
-    it.assessment = payload.assessment;
-    it.module = payload.module;
-    it.retired = payload.retired;
-  }
-  _ppMarkDirty();
-  closeModal('passportItemModal', true);
-  drawPassportEditor();
-}
-
-async function deletePassportItem() {
-  const { pi, ci, ii } = _ppEditing;
-  const cat = _passportDef && _passportDef.passports[pi] && _passportDef.passports[pi].categories[ci];
-  if (!cat || ii === null || ii === undefined) return;
-  const it = cat.items[ii];
-  if (!it) return;
-  if (!await ymConfirm(s('passport.confirmDeleteItem'))) return;
-  if (_ppIsNewItem(it)) {
-    cat.items.splice(ii, 1);
-    toast(s('passport.itemDeleted'));
-  } else {
-    it.retired = true;
-    toast(s('passport.itemRetiredSoft'));
-  }
-  _ppMarkDirty();
-  closeModal('passportItemModal', true);
-  drawPassportEditor();
-}
-
-// ── Passport category modal (add + edit) ───────────────────────────────────
-function openPassportCategoryModal(pi, ci) {
-  const p = _passportDef && _passportDef.passports[pi];
-  if (!p) return;
-  const adding = (ci === null || ci === undefined);
-  _ppEditing = { pi, ci: adding ? null : ci, ii: null, mode: adding ? 'cat-add' : 'cat-edit' };
-  const cat = adding ? { id: '', name: { EN: '', IS: '' } } : p.categories[ci];
-  document.getElementById('passportCategoryModalTitle').textContent =
-    adding ? s('passport.newCategory') : s('passport.categoryTitle');
-  document.getElementById('ppcId').value     = cat.id || '';
-  document.getElementById('ppcNameEN').value = (cat.name && cat.name.EN) || '';
-  document.getElementById('ppcNameIS').value = (cat.name && cat.name.IS) || '';
-  document.getElementById('ppcDeleteBtn').classList.toggle('hidden', adding);
-  openModal('passportCategoryModal');
-}
-
-function savePassportCategory() {
-  const { pi, mode } = _ppEditing;
-  const p = _passportDef && _passportDef.passports[pi];
-  if (!p) return;
-  const nameEN = document.getElementById('ppcNameEN').value.trim();
-  if (!nameEN) { toast(s('passport.nameRequired'), 'err'); return; }
-  const nameIS = document.getElementById('ppcNameIS').value.trim();
-  if (mode === 'cat-add') {
-    const id = _ppSlug(nameEN);
-    p.categories = p.categories || [];
-    p.categories.push({ id, name: { EN: nameEN, IS: nameIS }, items: [] });
-  } else {
-    const cat = p.categories[_ppEditing.ci];
-    if (!cat) return;
-    cat.name = cat.name || {};
-    cat.name.EN = nameEN;
-    cat.name.IS = nameIS;
-  }
-  _ppMarkDirty();
-  closeModal('passportCategoryModal', true);
-  drawPassportEditor();
-}
-
-async function deletePassportCategory() {
-  const { pi, ci } = _ppEditing;
-  const p = _passportDef && _passportDef.passports[pi];
-  if (!p || ci === null || ci === undefined) return;
-  if (!await ymConfirm(s('passport.confirmDeleteCategory'))) return;
-  p.categories.splice(ci, 1);
-  _ppMarkDirty();
-  toast(s('passport.categoryDeleted'));
-  closeModal('passportCategoryModal', true);
-  drawPassportEditor();
-}
-
-function ppToggleRetire(pi, ci, ii) {
-  const it = _passportDef.passports[pi].categories[ci].items[ii];
-  it.retired = !it.retired;
-  _ppMarkDirty();
-  drawPassportEditor();
-}
-
-async function ppSaveDef() {
-  if (!_passportDef) return;
-  // Bump version on save
-  _passportDef.version = (_passportDef.version || 0) + 1;
-  // Strip transient __new flags before sending to backend
-  (_passportDef.passports || []).forEach(p => {
-    (p.categories || []).forEach(c => {
-      (c.items || []).forEach(it => { if (it.__new) delete it.__new; });
-    });
-  });
-  try {
-    await apiPost('saveRowingPassportDef', { definition: _passportDef });
-    _passportDirty = false;
-    toast(s('passport.saved'));
-    renderPassportAdmin();
-  } catch(e) { toast(e.message, 'err'); }
-}
-
-window.openPassportSettingsModal = openPassportSettingsModal;
-window.savePassportSettings      = savePassportSettings;
-window.openPassportItemModal     = openPassportItemModal;
-window.savePassportItem          = savePassportItem;
-window.deletePassportItem        = deletePassportItem;
-window.openPassportCategoryModal = openPassportCategoryModal;
-window.savePassportCategory      = savePassportCategory;
-window.deletePassportCategory    = deletePassportCategory;
-window.ppToggleRetire            = ppToggleRetire;
-window.ppSaveDef                 = ppSaveDef;
-
-async function passportImportCsv() {
-  const file = document.getElementById('passportCsvFile').files[0];
-  if (!file) { toast('Choose a CSV file first', 'err'); return; }
-  const text = await file.text();
-  if (!(await ymConfirm('Import this CSV? Items missing from the CSV will be marked retired (not deleted).'))) return;
-  try {
-    await apiPost('importRowingPassportCsv', { csv: text });
-    toast('Passport imported.');
-    renderPassportAdmin();
-  } catch(e) { toast(e.message, 'err'); }
-}
-
-async function passportExportCsv() {
-  try {
-    const res = await apiGet('getRowingPassport', {});
-    const def = res.definition || { passports: [] };
-    const lines = ['passport_id,category_id,category_label_en,category_label_is,item_id,assessment,module,item_label_en,item_label_is,description_en,description_is'];
-    const q = v => '"' + String(v || '').replace(/"/g,'""') + '"';
-    (def.passports || []).forEach(p => {
-      (p.categories || []).forEach(cat => {
-        (cat.items || []).forEach(it => {
-          if (it.retired) return;
-          const mod = Number(it.module || 0) || '';
-          lines.push([p.id, cat.id, cat.name?.EN || '', cat.name?.IS || '', it.id, it.assessment || 'practical', mod, it.name?.EN || '', it.name?.IS || '', it.desc?.EN || '', it.desc?.IS || ''].map(q).join(','));
-        });
-      });
-    });
-    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url; a.download = 'rowing-passport.csv';
-    document.body.appendChild(a); a.click(); document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  } catch(e) { toast(e.message, 'err'); }
-}
-
-// ── Utilities ──────────────────────────────────────────────────────────────────
-// bool, esc, parseJson, toast, chunk, openModal, closeModal, todayISO
-// all come from shared/api.js and shared/ui.js — no local redefinitions needed.
-</script>
+<script src="admin.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Biggest portal so far (4,680 lines, 230 inline handlers).

 - Extracts the 3,548-line inline script into admin/admin.js
 - Converts 154 static HTML handlers and 76 dynamic-template handlers to data-admin-* attributes (close / close-self / toggle-section / nobubble / click / click-el / change / change-val / change-check / change-el / input / input-val / preset-change / set-at-role / set-vol-role / set-at-subtype / set-at-stbs / toggle-atstbs-day / time-format-subtype / show-el / remove-el)
 - Introduces named helper wrappers for the inline state-mutation handlers that previously did things like window._atRoles[i].field=this.value or window._atRoles.splice(i,1);renderAtRoles(): _setAtRoleField / _setVolRoleField / _setAtSubtypeField / _setAtStBsField / _removeAtRole / _removeAtSubtype / _removeVolRole / _timeFormatSubtype (combined HH:MM format + field assignment) / _showElement / _removeElementById
 - Page-level delegated click / change / input listeners at the bottom of admin.js, guarded by document._adminListeners
 - Drops 'unsafe-inline' from script-src; removes unpkg, nominatim, calendar.google.com origins (admin doesn't embed external iframes — the payrollFrame loads same-origin /admin/payroll/?embed=1 and the calendar-ID inputs store strings without iframing them)

Scope note: ~30 unique handler patterns required bespoke regex rewrites; a few complex two-arg JS-concat patterns (selectResMember, selectBoatOwner, addToAllowlist variants) needed individual string replaces. Helper wrappers mean existing window.* global functions referenced from other pages are untouched.

https://claude.ai/code/session_01MiU5pjfVEtZbpf663FcSck