### PR TITLE
Fix admin add-boat button, boat-card badge overflow, maintenance phot…

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -34,9 +34,15 @@
 
     /* ── Boat cards ── */
     .boat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:10px; }
-    .boat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 14px; box-shadow:var(--shadow-sm); }
+    .boat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 14px; box-shadow:var(--shadow-sm); min-width:0; overflow:hidden; }
     .boat-card.oos { opacity:.55; }
-    .boat-card-name { font-size:13px; font-weight:500; color:var(--text); margin-bottom:6px; }
+    .boat-card-head { display:flex; align-items:flex-start; justify-content:space-between; gap:6px; margin-bottom:4px; flex-wrap:wrap; }
+    .boat-card-name { font-size:13px; font-weight:500; color:var(--text); margin-bottom:6px; min-width:0; flex:1 1 auto; word-break:break-word; overflow-wrap:anywhere; }
+    .boat-card-badges { display:flex; gap:4px; flex-wrap:wrap; justify-content:flex-end; max-width:100%; }
+    .boat-card-badges > * { max-width:100%; }
+    .boat-card-badge-controlled { font-size:8px; letter-spacing:.5px; padding:2px 6px; border-radius:10px;
+      border:1px solid color-mix(in srgb, var(--brass) 40%, transparent);
+      background:color-mix(in srgb, var(--brass) 10%, transparent); color:var(--brass-fg); }
     .boat-card-actions { display:flex; gap:6px; margin-top:10px; }
 
     /* ── Generic row ── */

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -595,10 +595,10 @@ function renderBoats() {
       const label = (L === 'IS' && cat.labelIS) ? cat.labelIS : cat.labelEN;
       const cards = (groups[cat.key] || []).map(b => `
         <div class="boat-card${bool(b.oos) ? " oos" : ""}">
-          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:6px;margin-bottom:4px">
+          <div class="boat-card-head">
             <div class="boat-card-name">${cat.emoji || boatEmoji(cat.key)} ${esc(b.name)}</div>
-            <div style="display:flex;gap:4px;flex-shrink:0">
-              ${b.accessMode === 'controlled' ? `<span style="font-size:8px;letter-spacing:.5px;padding:2px 6px;border-radius:10px;border:1px solid var(--brass)44;background:var(--brass)11;color:var(--brass-fg)">${esc(s('fleet.badgeControlled'))}</span>` : ""}
+            <div class="boat-card-badges">
+              ${b.accessMode === 'controlled' ? `<span class="boat-card-badge boat-card-badge-controlled">${esc(s('fleet.badgeControlled'))}</span>` : ""}
               ${bool(b.oos) ? `<span class="oos-badge">OOS</span>` : ""}
               ${boatCatBadge(cat.key)}
             </div>
@@ -3594,9 +3594,6 @@ function _removeElementById(id) { var e = document.getElementById(id); if (e) e.
   }
 
   document.addEventListener('click', function (e) {
-    // stopPropagation-only marker
-    if (e.target.closest('[data-admin-nobubble]')) { e.stopPropagation(); return; }
-
     // Modal close-self (click on the overlay element itself)
     var cs = e.target.closest('[data-admin-close-self]');
     if (cs && e.target === cs) { closeModal(cs.id); return; }
@@ -3605,9 +3602,17 @@ function _removeElementById(id) { var e = document.getElementById(id); if (e) e.
     var cl = e.target.closest('[data-admin-close]');
     if (cl) { closeModal(cl.dataset.adminClose); return; }
 
-    // Toggle section (expandable panels)
+    // Toggle section (expandable panels) — skip when the click originates from a
+    // nobubble region inside the section (buttons, inputs, etc.)
     var ts = e.target.closest('[data-admin-toggle-section]');
-    if (ts) { if (typeof toggleSection === 'function') toggleSection(ts); return; }
+    if (ts) {
+      var nb = e.target.closest('[data-admin-nobubble]');
+      if (!(nb && ts.contains(nb))) {
+        if (typeof toggleSection === 'function') toggleSection(ts);
+        return;
+      }
+      // fall through so data-admin-click on nested buttons still fires
+    }
 
     // Show element by id
     var se = e.target.closest('[data-admin-show-el]');

--- a/maintenance/maintenance.js
+++ b/maintenance/maintenance.js
@@ -325,7 +325,7 @@ function openEditRequest(r) {
   if (r.photoUrl) {
     photoDataUrl = r.photoUrl;
     const preview = document.getElementById("photoPreview");
-    preview.src = r.photoUrl;
+    preview.src = driveImageUrl(r.photoUrl);
     preview.className = "photo-preview show";
   }
 }

--- a/saumaklubbur/saumaklubbur.js
+++ b/saumaklubbur/saumaklubbur.js
@@ -169,7 +169,7 @@ function renderProjectCard(r) {
       </div>
     </div>
     ${r.description ? `<div class="req-desc">${esc(r.description)}</div>` : ''}
-    ${r.photoUrl ? `<img class="req-photo" src="${esc(r.photoUrl)}" data-sk-view-photo="${esc(r.photoUrl)}">` : ''}
+    ${r.photoUrl ? `<img class="req-photo" src="${esc(driveImageUrl(r.photoUrl))}" data-sk-view-photo="${esc(driveImageUrl(r.photoUrl))}">` : ''}
     <div class="flex-center gap-8 mt-8 text-sm text-muted">
       ${following ? '<span style="color:var(--brass-fg)" title="' + s('sauma.unfollow') + '">★</span>' : ''}
       <span>💬 ${commentCount}</span>
@@ -302,7 +302,7 @@ function openEditProject(r) {
   if (r.photoUrl) {
     suggestExistingPhotoUrl = r.photoUrl;
     const preview = document.getElementById("suggestPhotoPreview");
-    preview.src = r.photoUrl;
+    preview.src = driveImageUrl(r.photoUrl);
     preview.className = "photo-preview show";
   }
   const titleEl = document.querySelector('#suggestModal h3');

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -44,6 +44,19 @@ function maintTitleFallback_(r, max) {
   return (sp > 30 ? cut.slice(0, sp) : cut) + '…';
 }
 
+// ── Drive URL normalisation ───────────────────────────────────────────────────
+// Drive's file.getUrl() returns a "viewer" page URL (…/file/d/<ID>/view) which
+// cannot be loaded as an <img src>. Convert to the thumbnail endpoint so the
+// same URL works for inline previews and the lightbox overlay.
+function driveImageUrl(url) {
+  if (!url) return '';
+  const u = String(url);
+  const m = u.match(/\/d\/([a-zA-Z0-9_-]+)/) || u.match(/[?&]id=([a-zA-Z0-9_-]+)/);
+  if (m) return 'https://drive.google.com/thumbnail?id=' + m[1] + '&sz=w1600';
+  return u;
+}
+window.driveImageUrl = driveImageUrl;
+
 // ── Fallback viewPhoto — pages that include their own can override ────────────
 if (typeof window.viewPhoto === 'undefined') {
   window.viewPhoto = function (url) {
@@ -161,7 +174,7 @@ function maintOpenDetail(r, currentUser) {
       <div class="comment-item" style="position:relative;padding-right:24px">
         <div style="font-size:11px;margin-bottom:3px"><span style="color:var(--text);font-weight:500">${esc(c.by||'')}</span> <span style="color:var(--muted)">· ${sstr(c.at).slice(0,16).replace('T',' ')}</span></div>
         ${c.text ? `<div style="font-size:13px;margin-bottom:3px">${esc(c.text)}</div>` : ''}
-        ${c.photoUrl ? `<img src="${esc(c.photoUrl)}" style="max-width:200px;max-height:150px;border-radius:6px;border:1px solid var(--border);margin-bottom:4px;cursor:pointer" data-view-photo="${esc(c.photoUrl)}">` : ''}
+        ${c.photoUrl ? `<img src="${esc(driveImageUrl(c.photoUrl))}" style="max-width:200px;max-height:150px;border-radius:6px;border:1px solid var(--border);margin-bottom:4px;cursor:pointer" data-view-photo="${esc(driveImageUrl(c.photoUrl))}">` : ''}
         ${!resolved ? `<button data-cidx="${idx}" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;font-size:14px;color:var(--muted);padding:0 2px;line-height:1" title="${s('maint.deleteComment')}">&times;</button>` : ''}
       </div>`).join('');
 
@@ -205,7 +218,7 @@ function maintOpenDetail(r, currentUser) {
         ${r.createdAt  ? `<span>${sstr(r.createdAt).slice(0,10)}</span>`  : ''}
       </div>
       ${r.description ? `<p style="font-size:13px;margin:0 0 14px;line-height:1.5">${esc(r.description)}</p>` : ''}
-      ${r.photoUrl    ? `<img src="${esc(r.photoUrl)}" style="width:100%;border-radius:6px;margin-bottom:14px;cursor:pointer" data-view-photo="${esc(r.photoUrl)}">` : ''}
+      ${r.photoUrl    ? `<img src="${esc(driveImageUrl(r.photoUrl))}" style="width:100%;border-radius:6px;margin-bottom:14px;cursor:pointer" data-view-photo="${esc(driveImageUrl(r.photoUrl))}">` : ''}
       ${materialsHtml}
       ${commentHtml ? `<div class="comment-thread">${commentHtml}</div>` : ''}
       ${!resolved ? `
@@ -524,7 +537,7 @@ function maintRenderCard(r) {
     <div class="comment-item">
       <div style="font-size:11px;margin-bottom:2px"><span class="comment-by">${esc(c.by||'')}</span> <span style="color:var(--muted)">· ${sstr(c.at).slice(0,16).replace('T',' ')}</span></div>
       ${c.text ? `<div style="font-size:13px;margin-bottom:3px">${esc(c.text)}</div>` : ''}
-      ${c.photoUrl ? `<img src="${esc(c.photoUrl)}" style="width:60px;height:45px;object-fit:cover;border-radius:4px;border:1px solid var(--border);margin-bottom:3px;cursor:pointer" data-view-photo="${esc(c.photoUrl)}">` : ''}
+      ${c.photoUrl ? `<img src="${esc(driveImageUrl(c.photoUrl))}" style="width:60px;height:45px;object-fit:cover;border-radius:4px;border:1px solid var(--border);margin-bottom:3px;cursor:pointer" data-view-photo="${esc(driveImageUrl(c.photoUrl))}">` : ''}
     </div>`).join('');
 
   return `<div class="req-card ${sevClass}${resolved?' resolved':''}">
@@ -545,7 +558,7 @@ function maintRenderCard(r) {
       </div>
     </div>
     ${r.description ? `<div class="req-desc">${esc(r.description)}</div>` : ''}
-    ${r.photoUrl    ? `<img class="req-photo" src="${esc(r.photoUrl)}" style="cursor:pointer" data-view-photo="${esc(r.photoUrl)}">` : ''}
+    ${r.photoUrl    ? `<img class="req-photo" src="${esc(driveImageUrl(r.photoUrl))}" style="cursor:pointer" data-view-photo="${esc(driveImageUrl(r.photoUrl))}">` : ''}
     ${commentHtml   ? `<div class="comment-thread">${commentHtml}</div>` : ''}
     ${resolved ? `<div style="margin-top:8px;font-size:11px;color:var(--muted)">${s(isSauma ? 'maint.completedBy' : 'maint.resolvedBy', { date: sstr(r.resolvedAt).slice(0,10), by: esc(r.resolvedBy||'') })}</div>` : ''}
   </div>`;


### PR DESCRIPTION
…o links

- admin.js: the data-admin-nobubble click handler was early-returning before data-admin-click could fire, so buttons inside col-head ("+ Add boat", "Edit") were inert. Reworked the delegated click flow so nobubble only suppresses the section-toggle, while nested click handlers still run.
- admin.css/admin.js: boat card header is now a wrap-enabled flex row with min-width:0 on the card and name, so badges (controlled / OOS / category) flow onto a second line instead of spilling past the card edge on narrow mobile columns. Inline badge styles promoted to a .boat-card-badge-controlled class for consistency with other CSS variables.
- shared/maintenance.js: added driveImageUrl() that rewrites Drive viewer URLs (…/file/d/<ID>/view) to the thumbnail endpoint so they load as <img src>. Applied in shared/maintenance.js (card + detail + comment photos), saumaklubbur.js (card + edit preview) and member maintenance edit preview, which fixes the broken image after photo upload.