### PR TITLE
Adopt <ymir-header> across all 16 portals

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -14,6 +14,7 @@
   <script src="../shared/boats.js" defer></script>
   <script src="../shared/weather.js" defer></script>
   <script src="../shared/ui.js"></script>
+  <script src="../shared/layout.js"></script>
   <script src="../shared/certs.js" defer></script>
   <script src="../shared/volunteer.js" defer></script>
   <script src="../shared/volunteer-role-presets.js" defer></script>
@@ -25,10 +26,7 @@
 </head>
 <body>
 <div class="page">
-  <header id="ym-header">
-    <div class="header-left"></div>
-    <div class="header-right"></div>
-  </header>
+  <ymir-header></ymir-header>
 
   <main>
     <!-- Top-level tab bar -->

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -11,10 +11,11 @@
   <script src="../../shared/api.js"></script>
   <script src="../../shared/strings.js"></script>
   <script src="../../shared/ui.js"></script>
+  <script src="../../shared/layout.js"></script>
   </head>
 <body>
 <div class="page">
-  <header id="ym-header" class="pr-standalone-only"><div class="header-left"></div><div class="header-right"></div></header>
+  <ymir-header class="pr-standalone-only"></ymir-header>
   <main>
     <div class="pr-standalone-only d-flex items-baseline gap-12" style="margin-bottom:20px">
       <h2 style="margin:0;font-size:18px" data-s="admin.tabPayroll"></h2>

--- a/captain/index.html
+++ b/captain/index.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="../shared/tripcard.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/list-filter.js"></script>
 <script src="../shared/calendar.js" defer></script>
@@ -26,10 +27,7 @@
 <link rel="stylesheet" href="captain.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-content">
 

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/calendar.js" defer></script>
 <script src="../shared/boats.js" defer></script>
@@ -19,10 +20,7 @@
 <link rel="stylesheet" href="coxswain.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-content">
 

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/weather.js"></script>
 <script src="../shared/tides.js"></script>
@@ -19,10 +20,7 @@
 <link rel="stylesheet" href="dailylog.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div id="mainWrap" class="page-content">
 

--- a/guardian/index.html
+++ b/guardian/index.html
@@ -11,14 +11,12 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <link rel="stylesheet" href="guardian.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <main class="container">
   <div class="guardian-hero">

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -11,15 +11,13 @@
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js"></script>
   <script src="../shared/ui.js"></script>
+  <script src="../shared/layout.js"></script>
   <script src="../shared/strings.js"></script>
   <script src="../shared/qr.js" defer></script>
   <link rel="stylesheet" href="incidents.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page">
   <main>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -13,6 +13,7 @@
 <link rel="stylesheet" href="../shared/tripcard.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/trip-form.js"></script>
 <script src="../shared/list-filter.js"></script>
@@ -22,10 +23,7 @@
 <link rel="stylesheet" href="logbook.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 <div class="page">
 
   <!-- Stats -->

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js"></script>
   <script src="../shared/ui.js"></script>
+  <script src="../shared/layout.js"></script>
   <script src="../shared/strings.js"></script>
   <script src="../shared/list-filter.js"></script>
   <script src="../shared/maintenance.js" defer></script>
@@ -19,10 +20,7 @@
 <body>
 
 <!-- ══ HEADER ══ -->
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-wrap">
 

--- a/member/index.html
+++ b/member/index.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/weather.js" defer></script>
@@ -22,10 +23,7 @@
 <link rel="stylesheet" href="member.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-content">
 

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -11,16 +11,14 @@
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js"></script>
   <script src="../shared/ui.js"></script>
+  <script src="../shared/layout.js"></script>
   <script src="../shared/strings.js"></script>
   <script src="../shared/maintenance.js" defer></script>
   <link rel="stylesheet" href="saumaklubbur.css">
 </head>
 <body>
 
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-wrap">
 

--- a/settings/index.html
+++ b/settings/index.html
@@ -11,14 +11,12 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <link rel="stylesheet" href="settings.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="settings-overlay" id="settingsOverlay">
 <div class="settings-page">

--- a/shared/layout.js
+++ b/shared/layout.js
@@ -92,9 +92,9 @@
         // replacing self with the canonical <header>. Avoids Shadow DOM
         // so global styles (style.css) still apply.
         var host = this;
-        if (host.id) { /* id migrates to the replacement */ }
         var hdr = document.createElement('header');
         hdr.id = 'ym-header';
+        if (host.className) hdr.className = host.className;
         var page = host.getAttribute('data-page') || '';
         hdr.innerHTML = '<div class="header-left"></div><div class="header-right"></div>';
         host.replaceWith(hdr);

--- a/staff/index.html
+++ b/staff/index.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/weather.js" defer></script>
@@ -23,10 +24,7 @@
 </head>
 <body>
 <div id="overdue-banner"></div>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-content">
 

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -10,16 +10,14 @@
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js"></script>
   <script src="../shared/ui.js"></script>
+  <script src="../shared/layout.js"></script>
   <script src="../shared/boats.js"></script>
   <script src="../shared/strings.js"></script>
   <script src="../shared/certs.js" defer></script>
   <link rel="stylesheet" href="staff_logbook-review.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-content">
   <div class="mb-16">

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/dateutil.js"></script>
 <script src="../shared/certs.js" defer></script>
@@ -18,10 +19,7 @@
 <link rel="stylesheet" href="volunteer.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 
 <div class="page-content">
 

--- a/weather/index.html
+++ b/weather/index.html
@@ -12,15 +12,13 @@
 <script src="../shared/api.js"></script>
 <script src="../shared/strings.js"></script>
 <script src="../shared/ui.js"></script>
+<script src="../shared/layout.js"></script>
 <script src="../shared/weather.js"></script>
 <script src="../shared/tides.js"></script>
 <link rel="stylesheet" href="weather.css">
 </head>
 <body>
-<header id="ym-header">
-  <div class="header-left"></div>
-  <div class="header-right"></div>
-</header>
+<ymir-header></ymir-header>
 <div class="page">
 
   <!-- ══ TOP BAR ══ -->


### PR DESCRIPTION
Replaces the hand-copied header shell

    <header id="ym-header">
      <div class="header-left"></div>
      <div class="header-right"></div>
    </header>

with the <ymir-header> custom element registered by shared/layout.js. The element upgrades to the same DOM shape shared/ui.js's buildHeader() already expects, so no JS call sites change.

Also teaches the element to forward its `class` attribute onto the generated <header>, so admin/payroll can keep its pr-standalone-only class.

Each portal now pulls in shared/layout.js right after shared/ui.js (synchronously, so the custom element is defined before the parser reaches it).

Net change: -29 lines across 17 files.

https://claude.ai/code/session_01Qc4Rni8as8NWvzY6eBwFKZ