### PR TITLE
Fix CSP blocking Leaflet source maps; show heatmap container before m…

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-GB">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://unpkg.com https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-GB">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://unpkg.com https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">

--- a/logbook/logbook.js
+++ b/logbook/logbook.js
@@ -246,7 +246,7 @@ async function initMemberHeatmap() {
   const trackPts = getAllTrackPoints();
   if (!locData.length && !trackPts.length) return;
 
-  document.getElementById('memberHeatmapWrap').style.display = '';
+  document.getElementById('memberHeatmapWrap').classList.remove('d-none');
 
   await loadLeaflet();
   if (_hmMap) { _hmMap.remove(); _hmMap = null; }

--- a/member/index.html
+++ b/member/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-GB">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-src https://calendar.google.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://unpkg.com https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-src https://calendar.google.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://unpkg.com https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">

--- a/shared/layout.js
+++ b/shared/layout.js
@@ -41,7 +41,9 @@
     "upgrade-insecure-requests";
 
   // Portals that embed Leaflet (captain, logbook, public) need to whitelist
-  // unpkg for script + style.
+  // unpkg for script + style. connect-src must also include unpkg so DevTools
+  // can fetch source maps (leaflet.js.map, leaflet-heat.js.map) without CSP
+  // blocking the request.
   var CSP_LEAFLET_ =
     CSP_BASE_.replace(
       "script-src 'self'",
@@ -49,6 +51,9 @@
     ).replace(
       "style-src 'self' 'unsafe-inline'",
       "style-src 'self' 'unsafe-inline' https://unpkg.com"
+    ).replace(
+      "connect-src 'self'",
+      "connect-src 'self' https://unpkg.com"
     );
 
   // Alert-action is the public email-response page — minimal surface area,


### PR DESCRIPTION
…ap init

- Add https://unpkg.com to connect-src on all Leaflet-enabled portals (captain, logbook, public, member) and in shared/layout.js's CSP_LEAFLET_ builder, so DevTools source-map fetches for leaflet.js.map and leaflet-heat.js.map aren't blocked.
- In logbook/logbook.js, toggle the heatmap wrapper's d-none class instead of clearing inline style — style.display = '' doesn't override the .d-none class rule, leaving the container 0-width when L.map() initializes and triggering IndexSizeError in leaflet-heat's canvas.