### PR TITLE
Five follow-ups: strings parity, html@lang, focus trap, pagination, t…

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">

--- a/guardian/index.html
+++ b/guardian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">

--- a/member/index.html
+++ b/member/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-src https://calendar.google.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">

--- a/members.gs
+++ b/members.gs
@@ -528,7 +528,11 @@ function savePreferences_(b) {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 function getDailyLog_(date) {
-  const d = date || now_().slice(0, 10);
+  // Daily-log rows are keyed by the local date the user sees on the hub,
+  // not by UTC. now_().slice(0,10) gave UTC, which wraps a day late for
+  // any non-UTC script timezone — fine at UTC+0 (Iceland today) but wrong
+  // anywhere else. nowLocalDate_() matches the format saveDailyLog_ writes.
+  const d = date || nowLocalDate_();
   const log = findOne_('dailyLog', 'date', d);
   return okJ({ log: log || null, date: d });
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -14,6 +14,13 @@
   var base = here ? here.substring(0, here.lastIndexOf('/') + 1) : '';
   var lang = (localStorage.getItem('ymirLang') || 'IS').toLowerCase();
   if (lang !== 'en' && lang !== 'is') lang = 'is';
+  // Sync <html lang> to the active UI language so screen readers, search
+  // engines, and browser translation prompts pick the right language. The
+  // static lang= in each portal's HTML head is a placeholder — this is
+  // the canonical value. Runs before the language file loads so any
+  // server-rendered lang-aware text (none today, but future-proof) is
+  // consistent with the strings about to be applied.
+  try { document.documentElement.lang = lang; } catch (e) {}
   document.write('<script src="' + base + 'strings-' + lang + '.js"><\/script>');
 })();
 

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -193,23 +193,80 @@ window.replaceWithFragment = function (container, items, buildNodeFn) {
   window.isModalDirty        = function (modalId) { return _isDirty(modalId); };
   window.resnapshotModal     = function (modalId) { if (_tracked.has(modalId)) _snapshot(modalId); };
 
+  // Focus management. Tracks which element had focus before each modal
+  // opened so we can restore on close; picks the first focusable inside
+  // the modal to focus on open. Keyed by modal id so nested modals (rare
+  // but possible — maintenance detail inside admin) don't clobber each
+  // other.
+  const _priorFocus = new Map();
+  const FOCUSABLE_SEL = 'a[href],button:not([disabled]),textarea:not([disabled]),' +
+    'input:not([disabled]):not([type=hidden]),select:not([disabled]),' +
+    '[tabindex]:not([tabindex="-1"])';
+  function _focusablesIn(el) {
+    return Array.from(el.querySelectorAll(FOCUSABLE_SEL))
+      .filter(n => !n.hidden && n.offsetParent !== null);
+  }
+
   window.openModal = function (id) {
     const el = document.getElementById(id);
     if (!el) return;
     el.classList.remove('hidden');
     if (_tracked.has(id)) _snapshot(id);
+    // Save whatever had focus so closeModal can put it back.
+    _priorFocus.set(id, document.activeElement);
+    // Focus the first focusable inside the modal. Fall back to the modal
+    // container itself (with tabindex=-1) so ESC / Tab still work even
+    // when the body is empty at open time.
+    const first = _focusablesIn(el)[0];
+    if (first) { try { first.focus(); } catch (e) {} }
+    else {
+      if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '-1');
+      try { el.focus(); } catch (e) {}
+    }
   };
 
   window.closeModal = function (id, force) {
     const el = document.getElementById(id);
     if (!el) return;
-    const doClose = () => { el.classList.add('hidden'); _baseline.delete(id); };
+    const doClose = () => {
+      el.classList.add('hidden');
+      _baseline.delete(id);
+      // Restore focus to whatever had it before open — keyboard users
+      // don't want to be kicked back to <body>.
+      const prior = _priorFocus.get(id);
+      _priorFocus.delete(id);
+      if (prior && typeof prior.focus === 'function' && document.contains(prior)) {
+        try { prior.focus(); } catch (e) {}
+      }
+    };
     if (force === true || !_tracked.has(id) || !_isDirty(id)) { doClose(); return; }
     const msg = (typeof s === 'function') ? s('msg.unsavedChanges')
               : 'You have unsaved changes. Discard them?';
     // ymConfirm returns a promise; close only if the user confirms.
     Promise.resolve(ymConfirm(msg)).then(ok => { if (ok) doClose(); });
   };
+
+  // Focus trap: keep Tab / Shift+Tab within the top-most open modal.
+  // Registered once at module load.
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Tab') return;
+    const overlays = document.querySelectorAll(
+      '.modal-overlay:not(.hidden), .modal-bg:not(.hidden), ' +
+      '.group-modal-overlay:not(.hidden), .guest-modal-overlay:not(.hidden), ' +
+      '.map-modal-overlay:not(.hidden)'
+    );
+    if (!overlays.length) return;
+    const top = overlays[overlays.length - 1];
+    const focusables = _focusablesIn(top);
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last  = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      last.focus(); e.preventDefault();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      first.focus(); e.preventDefault();
+    }
+  });
 
   // Warn before leaving the page while a guarded modal has unsaved edits.
   window.addEventListener('beforeunload', function (e) {

--- a/tools/check-strings.js
+++ b/tools/check-strings.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Parity check for shared/strings-en.js and shared/strings-is.js.
+// Extracts "key": entries from each file (simple regex — both files are
+// flat object literals) and diffs the key sets. Exits non-zero with a
+// human-readable diff if they differ. Safe to wire into CI.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function extractKeys(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const keys = new Set();
+  const re = /^\s*"([^"]+)":/gm;
+  let m;
+  while ((m = re.exec(text))) keys.add(m[1]);
+  return keys;
+}
+
+const en = extractKeys(path.join(__dirname, '..', 'shared', 'strings-en.js'));
+const is = extractKeys(path.join(__dirname, '..', 'shared', 'strings-is.js'));
+
+const missingInIs = [...en].filter(k => !is.has(k)).sort();
+const missingInEn = [...is].filter(k => !en.has(k)).sort();
+
+if (!missingInIs.length && !missingInEn.length) {
+  console.log(`OK — ${en.size} keys, both files in sync.`);
+  process.exit(0);
+}
+
+if (missingInIs.length) {
+  console.error(`Missing in strings-is.js (${missingInIs.length}):`);
+  missingInIs.forEach(k => console.error(`  ${k}`));
+}
+if (missingInEn.length) {
+  console.error(`\nMissing in strings-en.js (${missingInEn.length}):`);
+  missingInEn.forEach(k => console.error(`  ${k}`));
+}
+process.exit(1);

--- a/trips.gs
+++ b/trips.gs
@@ -7,7 +7,10 @@ function getTrips_(kennitala, limit, p) {
   const all = readAll_('trips');
   const filtered = all.filter(t => (!kennitala || String(t.kennitala) === String(kennitala)) && (!p.date || (t.date || '').slice(0, 10) === p.date) && (!p.linkedCheckoutId || String(t.linkedCheckoutId) === String(p.linkedCheckoutId)) && (!p.category || (t.boatCategory || '').toLowerCase() === p.category.toLowerCase()));
   const sorted = filtered.sort((a, b) => (b.date || '') > (a.date || '') ? 1 : -1);
-  return okJ({ trips: sorted.slice(0, limit || 100) });
+  const offset = parseInt(p.offset) || 0;
+  const lim    = limit || 100;
+  const page   = sorted.slice(offset, offset + lim);
+  return okJ({ trips: page, total: sorted.length, offset: offset, limit: lim });
 }
 
 function saveTrip_(b) {

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://script.googleusercontent.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="UTF-8">


### PR DESCRIPTION
…z fix

Three frontend fixes + two backend tweaks (.gs files — warning per CLAUDE.md).

 1. STRINGS PARITY CHECK. tools/check-strings.js — ~35-line Node script that regex-extracts keys from shared/strings-en.js and shared/strings-is.js and diffs the sets. Exits non-zero with a per-language missing-keys list, clean otherwise. Ready to wire into a CI step. Current state: 1,552 keys, both files in sync.

 2. HTML@LANG DYNAMIC. shared/strings.js now sets document.documentElement.lang = 'en' | 'is' during the same IIFE that picks the strings file to load — so screen readers, browser translation prompts, and search indexers all see the right value. Also unified the static fallback across all 19 portal HTML files (was a mix of lang="en" and lang="en-GB"; now all lang="en"; the dynamic setter overrides once strings.js loads).

 3. MODAL FOCUS MANAGEMENT. shared/ui.js openModal now: - saves document.activeElement in a per-modal-id Map - focuses the first focusable inside the modal (buttons / links / text inputs / selects / explicit tabindex); falls back to focusing the modal itself with tabindex=-1 closeModal: - restores focus to the saved prior element if still in the DOM, so keyboard users return to where they were And a document-level Tab / Shift-Tab handler keeps focus trapped within the top-most open modal.

 4. PAGINATION ON getTrips. getMembers_ already had {offset, limit, total}. trips.gs: getTrips_ now accepts p.offset and returns {trips, total, offset, limit} instead of a bare trimmed array. Default limit stays 100; callers that pass {limit: 500} keep working unchanged.

 5. TIMEZONE FIX. members.gs: getDailyLog_(date) defaulted to now_().slice(0,10) which is UTC — wrong for daily-log rows that users expect to be keyed by local date. Switched to nowLocalDate_() which matches how saveDailyLog_ writes the key. Zero impact at UTC+0 (Iceland today), correct anywhere else. Rest of the codebase already separates now_() (ISO UTC, metadata columns) from nowLocal*_() (local, user-visible columns) cleanly — grepped for cross-format misuse and found only this one stray.

https://claude.ai/code/session_01MiU5pjfVEtZbpf663FcSck