### PR TITLE
Naming + dead/stale: unify underscore convention, add requiredCol_ he…

### DIFF
--- a/alerts.gs
+++ b/alerts.gs
@@ -99,9 +99,9 @@ function setConfigSheetValue_(key, value) {
   if (lastRow >= 2) {
     const keys = sheet.getRange(2, 1, lastRow - 1, 1).getValues().map(r => String(r[0]).trim());
     const idx = keys.indexOf(key);
-    if (idx !== -1) { sheet.getRange(idx + 2, 2).setValue(_literalWrite_(value)); return; }
+    if (idx !== -1) { sheet.getRange(idx + 2, 2).setValue(literalWrite_(value)); return; }
   }
-  sheet.appendRow([key, _literalWrite_(value)]);
+  sheet.appendRow([key, literalWrite_(value)]);
 }
 
 // ── Config-list CRUD helpers ──────────────────────────────────────────────────
@@ -188,7 +188,7 @@ function getOverdueAlerts_(b) {
   if (sheet.getLastRow() < 2) return okJ({ alerts: [], snoozeMins: cfg.snoozeMins });
   const lastCol = sheet.getLastColumn();
   const headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
-  const col = name => headers.indexOf(name);
+  const col = name => requiredCol_(headers, name);
   const now_ms = Date.now();
   const now_dt = new Date();
   const todayStr = Utilities.formatDate(now_dt, Session.getScriptTimeZone(), 'yyyy-MM-dd');
@@ -264,7 +264,7 @@ function silenceAlert_(b) {
   const row = getCheckoutRow_(b.id);
   if (!row) throw new Error('Checkout not found: ' + b.id);
   row._sheet.getRange(row._sheetRow, row._col1('alertSilenced')).setValue(true);
-  row._sheet.getRange(row._sheetRow, row._col1('alertSilencedBy')).setValue(_literalWrite_(b.silencedBy || ''));
+  row._sheet.getRange(row._sheetRow, row._col1('alertSilencedBy')).setValue(literalWrite_(b.silencedBy || ''));
   row._sheet.getRange(row._sheetRow, row._col1('alertSilencedAt')).setValue(now_());
   return okJ({ id: b.id });
 }
@@ -286,7 +286,7 @@ function getCheckoutRow_(id) {
   if (sheet.getLastRow() < 2) return null;
   const lastCol = sheet.getLastColumn();
   const headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
-  const col1 = name => headers.indexOf(name) + 1;
+  const col1 = name => requiredCol_(headers, name) + 1;
   const ids = sheet.getRange(2, col1('id'), sheet.getLastRow() - 1, 1).getValues().map(r => String(r[0]));
   const rowIdx = ids.indexOf(String(id));
   if (rowIdx === -1) return null;
@@ -342,7 +342,7 @@ function resolveFromEmail_(b) {
     const sheet = getSheet_('checkouts');
     const data  = sheet.getDataRange().getValues();
     const headers = data[0];
-    const col = h => headers.indexOf(h);
+    const col = h => requiredCol_(headers, h);
     const rowIdx = data.findIndex((r, i) => i > 0 && String(r[col('id')]) === String(id));
     if (rowIdx > 0) {
       // Silence the alert
@@ -380,7 +380,7 @@ function handleAlertAction_(b) {
     const sheet   = getSheet_('checkouts');
     const data    = sheet.getDataRange().getValues();
     const headers = data[0];
-    const col     = h => headers.indexOf(h);
+    const col     = h => requiredCol_(headers, h);
     const rowIdx  = data.findIndex((r, i) => i > 0 && String(r[col('id')]) === String(id));
     if (rowIdx < 1) return failJ('Checkout not found');
     const L = CLUB_LANG_;
@@ -528,7 +528,7 @@ function resolveAlert_(b) {
     const sheet  = getSheet_('checkouts');
     const data   = sheet.getDataRange().getValues();
     const headers = data[0];
-    const col    = h => headers.indexOf(h);
+    const col    = h => requiredCol_(headers, h);
     const rowIdx = data.findIndex((r, i) => i > 0 && String(r[col('id')]) === String(id));
     if (rowIdx < 1) return failJ('Checkout not found');
     // Silence the alert in all cases

--- a/checkouts.gs
+++ b/checkouts.gs
@@ -44,7 +44,7 @@ function saveCheckout_(b) {
             var _coDefs = getCertDefsFromMap_(cfgMap);
             var _coGate = normalizeAccessGate_(checkBoat, _coDefs);
             if (_coGate) {
-              var memberCerts = _parseMemberCerts_(checkMember.certifications);
+              var memberCerts = parseMemberCerts_(checkMember.certifications);
               if (memberHasGate_(memberCerts, _coGate, _coDefs)) hasAccess = true;
             }
           }
@@ -648,7 +648,7 @@ function bookSlot_(b) {
         if (!member) return failJ('Member not found');
         var isStaffRole = member.role === 'staff' || member.role === 'admin';
         if (!isStaffRole) {
-          var certs = _parseMemberCerts_(member.certifications);
+          var certs = parseMemberCerts_(member.certifications);
           if (!memberHasGate_(certs, _bsGate, _bsDefs)) {
             return failJ('You do not have the required certification to book this boat');
           }
@@ -722,7 +722,7 @@ function bulkBookSlots_(b) {
         if (!member) return failJ('Member not found');
         var isStaffRole = member.role === 'staff' || member.role === 'admin';
         if (!isStaffRole) {
-          var certs = _parseMemberCerts_(member.certifications);
+          var certs = parseMemberCerts_(member.certifications);
           if (!memberHasGate_(certs, _bbGate, _bbDefs)) {
             return failJ('You do not have the required certification to book this boat');
           }

--- a/code.gs
+++ b/code.gs
@@ -71,7 +71,7 @@ const BULK_ACTIONS_ = {
 };
 
 // Actions that can be called without a session token. Everything else
-// requires a valid session (see _authCaller_). GET-only public endpoints
+// requires a valid session (see authCaller_). GET-only public endpoints
 // (lookup, captain, boat, resolveFromEmail, shared records) are gated
 // separately inside doGet.
 const PUBLIC_ACTIONS_ = {
@@ -284,6 +284,16 @@ function now_() { return new Date().toISOString(); }
 function nowLocalDate_() { return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd'); }
 function nowLocalTime_() { return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'HH:mm'); }
 function nowLocalDateTime_() { return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm"); }
+// Required-column lookup. Use this when you INDEX into a row with the result
+// (e.g. values[i][col]) — a plain headers.indexOf() silently returns -1 and
+// miswrites to/reads from column "−1" if the sheet drifts from the code.
+// requiredCol_ throws loudly instead, turning a silent bug into a stack trace.
+// For existence checks (e.g. addColIfMissing_) keep using headers.indexOf().
+function requiredCol_(headers, name) {
+  var i = headers.indexOf(name);
+  if (i < 0) throw new Error('Missing column "' + name + '" in sheet');
+  return i;
+}
 function uid_() { return Utilities.getUuid().replace(/-/g, '').slice(0, 16); }
 function bool_(v) { return v === true || v === 'TRUE' || v === 'true' || v === 1 || v === '1'; }
 // Prefix a literal apostrophe onto any string whose first character Sheets
@@ -291,7 +301,7 @@ function bool_(v) { return v === true || v === 'TRUE' || v === 'true' || v === 1
 // (CR/LF/TAB). The apostrophe itself is not rendered to the user; it just
 // forces Sheets to treat the cell as text. Non-strings pass through.
 // Named distinctly from the read-side `sanitizeCell_(col, val)` normalizer.
-function _literalWrite_(v) {
+function literalWrite_(v) {
   if (typeof v !== 'string' || v === '') return v;
   var c = v.charCodeAt(0);
   if (c === 0x3D || c === 0x2B || c === 0x2D || c === 0x40 ||
@@ -351,7 +361,7 @@ function extractInitials_(name) {
 // be tuned later without a schema change:
 //   pbkdf2-sha256$<iterations>$<base64 salt>$<base64 hash>
 // There is no shared default password; admin-issued temp passwords are
-// generated per-member by _genTempPassword_() and flagged via the members
+// generated per-member by genTempPassword_() and flagged via the members
 // sheet column `passwordIsTemp` so the login flow can force a change.
 // ─────────────────────────────────────────────────────────────────────────────
 // Iteration count is limited by Apps Script's per-HMAC-call overhead
@@ -364,7 +374,7 @@ const PBKDF2_ITERATIONS_ = 10000;
 // 10-character random password using an unambiguous alphabet (no O/0/I/1/l).
 // Used for admin-issued temp passwords — communicated to the member once and
 // replaced by a user-chosen password on first login.
-function _genTempPassword_() {
+function genTempPassword_() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
   const bytes = Utilities.computeDigest(
     Utilities.DigestAlgorithm.SHA_256,
@@ -375,7 +385,7 @@ function _genTempPassword_() {
   return out;
 }
 
-function _genSalt16_() {
+function genSalt16_() {
   // UUID v4 gives ~122 bits of randomness; two of them hashed to SHA-256 and
   // truncated to 16 bytes yields a uniform salt well above the birthday bound
   // for any realistic user population.
@@ -388,7 +398,7 @@ function _genSalt16_() {
 // PBKDF2-HMAC-SHA256, one output block (32 bytes). Apps Script's HMAC
 // primitive is slow-ish, so 100k iterations is the target; adjust via
 // PBKDF2_ITERATIONS_ if login latency becomes a problem.
-function _pbkdf2_(password, saltBytes, iterations) {
+function pbkdf2_(password, saltBytes, iterations) {
   const passBytes = Utilities.newBlob(String(password)).getBytes();
   // Salt || INT(1) — block index is always 1 since we only need 32 bytes.
   const block = saltBytes.concat([0, 0, 0, 1]);
@@ -403,8 +413,8 @@ function _pbkdf2_(password, saltBytes, iterations) {
 
 function hashPassword_(password) {
   if (!password) return '';
-  const salt = _genSalt16_();
-  const hash = _pbkdf2_(password, salt, PBKDF2_ITERATIONS_);
+  const salt = genSalt16_();
+  const hash = pbkdf2_(password, salt, PBKDF2_ITERATIONS_);
   return 'pbkdf2-sha256$' + PBKDF2_ITERATIONS_ + '$' +
          Utilities.base64Encode(salt) + '$' + Utilities.base64Encode(hash);
 }
@@ -419,7 +429,7 @@ function verifyPassword_(member, password) {
   if (!iter || iter < 1000 || iter > 10000000) return false;
   const salt = Utilities.base64Decode(parts[2]);
   const expected = Utilities.base64Decode(parts[3]);
-  const actual = _pbkdf2_(password, salt, iter);
+  const actual = pbkdf2_(password, salt, iter);
   if (actual.length !== expected.length) return false;
   // Constant-time compare to avoid leaking the matching prefix via timing.
   let diff = 0;
@@ -482,7 +492,7 @@ function bootstrapAdminPassword() {
   }
   if (rowIdx < 0) { Logger.log('No member with kennitala ' + kt); return; }
 
-  const temp = preset || _genTempPassword_();
+  const temp = preset || genTempPassword_();
   const hash = hashPassword_(temp);
   Logger.log('Writing hash of length ' + hash.length + ' to row ' + (rowIdx + 2));
   if (preset) Logger.log('Using preset password from BOOTSTRAP_PRESET_PASSWORD.');
@@ -504,7 +514,7 @@ function bootstrapAdminPassword() {
 // prints "verify ok" but real logins still fail, the bug is in the
 // storage/login path, not the crypto.
 function testPasswordRoundTrip() {
-  const pw = _genTempPassword_();
+  const pw = genTempPassword_();
   const hash = hashPassword_(pw);
   Logger.log('password: ' + pw);
   Logger.log('hash:     ' + hash);
@@ -560,7 +570,7 @@ function testVerifyStoredHash() {
   const salt     = Utilities.base64Decode(parts[2]);
   const expected = Utilities.base64Decode(parts[3]);
   const iter     = parseInt(parts[1], 10);
-  const actual   = _pbkdf2_(pw, salt, iter);
+  const actual   = pbkdf2_(pw, salt, iter);
   Logger.log('salt bytes:     [' + Array.prototype.slice.call(salt).join(',') + ']');
   Logger.log('expected bytes: [' + Array.prototype.slice.call(expected).join(',') + ']');
   Logger.log('actual bytes:   [' + Array.prototype.slice.call(actual).join(',') + ']');
@@ -577,21 +587,21 @@ function testVerifyStoredHash() {
 
 // Editor-run helper: clear the login rate-limit lockout for
 // BOOTSTRAP_KENNITALA so the next login attempt isn't rejected by
-// `_checkLoginRate_`. Use after a debugging session where repeated
+// `checkLoginRate_`. Use after a debugging session where repeated
 // failed attempts have tripped the 5-in-15-min lockout.
 function clearLoginLockout() {
   const kt = String(
     PropertiesService.getScriptProperties().getProperty('BOOTSTRAP_KENNITALA') || ''
   ).trim();
   if (!kt) { Logger.log('Set BOOTSTRAP_KENNITALA first.'); return; }
-  _clearLoginAttempts_(kt);
+  clearLoginAttempts_(kt);
   Logger.log('Cleared login_attempts row for ' + kt + '. You can try signing in again.');
 }
 
 // Find a member for login by either kennitala (10 digits) or initials
 // (case-insensitive). Returns { member, ambiguous, notFound } so the caller
 // can surface a specific error when initials collide between members.
-function _findMemberForLogin_(username) {
+function findMemberForLogin_(username) {
   if (!username) return { notFound: true };
   const u = String(username).trim();
   if (!u) return { notFound: true };
@@ -630,7 +640,7 @@ const LOGIN_ATTEMPT_COLS_ = ['kennitala', 'firstAt', 'count', 'blockedUntil'];
 
 // Create the sheet lazily if it's missing. Called from every session/rate-
 // limit helper so a fresh deployment doesn't need a manual setup step.
-function _ensureSheet_(tabKey, columns) {
+function ensureSheet_(tabKey, columns) {
   const name = TABS_[tabKey] || tabKey;
   const ss = ss_();
   let sh = ss.getSheetByName(name);
@@ -649,14 +659,14 @@ function _ensureSheet_(tabKey, columns) {
 // 256-bit random token, base64url-encoded (no padding). Two UUIDs give 256
 // bits of entropy; Apps Script has no direct access to a CSPRNG byte API but
 // getUuid() is cryptographically random per the V8 runtime docs.
-function _randomToken_() {
+function randomToken_() {
   const hex = Utilities.getUuid().replace(/-/g, '') + Utilities.getUuid().replace(/-/g, '');
   const bytes = [];
   for (let i = 0; i < hex.length; i += 2) bytes.push(parseInt(hex.substr(i, 2), 16));
   return Utilities.base64EncodeWebSafe(bytes).replace(/=+$/, '');
 }
 
-function _hashToken_(token) {
+function hashToken_(token) {
   const bytes = Utilities.computeDigest(
     Utilities.DigestAlgorithm.SHA_256, String(token || ''), Utilities.Charset.UTF_8);
   return Utilities.base64Encode(bytes);
@@ -664,15 +674,15 @@ function _hashToken_(token) {
 
 // Truncate the User-Agent string so a malicious client cannot blow up a row
 // with megabytes of junk, while still preserving enough to identify a device.
-function _trimUA_(ua) {
+function trimUA_(ua) {
   ua = String(ua == null ? '' : ua);
   return ua.length > 200 ? ua.slice(0, 200) : ua;
 }
 
-function _createSession_(kennitala, role, stayLoggedIn, userAgent) {
-  _ensureSheet_('sessions', SESSION_COLS_);
-  const raw = _randomToken_();
-  const hash = _hashToken_(raw);
+function createSession_(kennitala, role, stayLoggedIn, userAgent) {
+  ensureSheet_('sessions', SESSION_COLS_);
+  const raw = randomToken_();
+  const hash = hashToken_(raw);
   const ttl  = stayLoggedIn ? SESSION_TTL_LONG_MS_ : SESSION_TTL_SHORT_MS_;
   const now = Date.now();
   const session = {
@@ -684,30 +694,30 @@ function _createSession_(kennitala, role, stayLoggedIn, userAgent) {
     lastSeenAt:    new Date(now).toISOString(),
     expiresAt:     new Date(now + ttl).toISOString(),
     stayLoggedIn:  !!stayLoggedIn,
-    userAgent:     _trimUA_(userAgent),
+    userAgent:     trimUA_(userAgent),
   };
   insertRow_('sessions', session);
   return { token: raw, expiresAt: session.expiresAt, id: session.id };
 }
 
-function _findSessionByHash_(hash) {
-  _ensureSheet_('sessions', SESSION_COLS_);
+function findSessionByHash_(hash) {
+  ensureSheet_('sessions', SESSION_COLS_);
   return findOne_('sessions', 'tokenHash', hash);
 }
 
-function _deleteSessionByHash_(hash) {
+function deleteSessionByHash_(hash) {
   try { deleteRow_('sessions', 'tokenHash', hash); } catch (e) {}
 }
 
-function _deleteSessionById_(id) {
+function deleteSessionById_(id) {
   try { return deleteRow_('sessions', 'id', id); } catch (e) { return false; }
 }
 
 // Revoke every session belonging to a member, optionally keeping one token's
 // session alive (so "changed my password" can sign out every *other* device).
 // Returns the count of sessions that were removed.
-function _revokeSessionsForMember_(kennitala, exceptHash) {
-  _ensureSheet_('sessions', SESSION_COLS_);
+function revokeSessionsForMember_(kennitala, exceptHash) {
+  ensureSheet_('sessions', SESSION_COLS_);
   const kt = String(kennitala || '').trim();
   if (!kt) return 0;
   const rows = readAll_('sessions').filter(function(r) {
@@ -724,7 +734,7 @@ function _revokeSessionsForMember_(kennitala, exceptHash) {
 // touched. Short sessions keep their original expiry. lastSeenAt is throttled
 // so the sheet isn't written on every request; 60s resolution is good enough
 // for "recent activity" displays.
-function _touchSession_(session) {
+function touchSession_(session) {
   const now = Date.now();
   const last = session.lastSeenAt ? new Date(session.lastSeenAt).getTime() : 0;
   const updates = {};
@@ -747,25 +757,25 @@ function _touchSession_(session) {
 // Resolve the caller from a request body. Returns { kennitala, role, session }
 // on success, or null if the session is missing/expired/invalid. Expired
 // sessions are deleted on encounter so the sheet self-cleans.
-function _authCaller_(b) {
+function authCaller_(b) {
   const raw = String((b && b.sessionToken) || '').trim();
   if (!raw) return null;
-  const hash = _hashToken_(raw);
-  const session = _findSessionByHash_(hash);
+  const hash = hashToken_(raw);
+  const session = findSessionByHash_(hash);
   if (!session) return null;
   const now = Date.now();
   const expiresAt = session.expiresAt ? new Date(session.expiresAt).getTime() : 0;
   if (!expiresAt || expiresAt < now) {
-    _deleteSessionByHash_(hash);
+    deleteSessionByHash_(hash);
     return null;
   }
   // Member role/active state can change after login; always re-check.
   const m = findOne_('members', 'kennitala', String(session.kennitala || '').trim());
   if (!m || !bool_(m.active)) {
-    _deleteSessionByHash_(hash);
+    deleteSessionByHash_(hash);
     return null;
   }
-  _touchSession_(session);
+  touchSession_(session);
   return {
     kennitala: String(m.kennitala),
     role:      String(m.role || session.role || 'member'),
@@ -775,18 +785,18 @@ function _authCaller_(b) {
   };
 }
 
-function _isAdmin_(caller) { return caller && caller.role === 'admin'; }
-function _isStaff_(caller) { return caller && (caller.role === 'staff' || caller.role === 'admin'); }
+function isAdmin_(caller) { return caller && caller.role === 'admin'; }
+function isStaff_(caller) { return caller && (caller.role === 'staff' || caller.role === 'admin'); }
 
 // Decide whether `caller` is permitted to run `action` with body `b`.
 // Returns null on allow or a failJ response on deny. Centralises all
 // role/self-or-admin gating so route_ stays a plain dispatch table.
-function _authorize_(action, caller, b) {
+function authorize_(action, caller, b) {
   if (!caller) return failJ('Unauthorized', 401);
-  if (ADMIN_ACTIONS_[action] && !_isAdmin_(caller)) {
+  if (ADMIN_ACTIONS_[action] && !isAdmin_(caller)) {
     return failJ('Admin only', 403);
   }
-  if (STAFF_ACTIONS_[action] && !_isStaff_(caller)) {
+  if (STAFF_ACTIONS_[action] && !isStaff_(caller)) {
     return failJ('Staff only', 403);
   }
   // Self-or-admin: caller.kennitala must equal the body's target kennitala,
@@ -795,7 +805,7 @@ function _authorize_(action, caller, b) {
   if (ktField) {
     const target = String((b && b[ktField]) || '').trim();
     if (!target) return failJ('kennitala required');
-    if (target !== caller.kennitala && !_isAdmin_(caller)) {
+    if (target !== caller.kennitala && !isAdmin_(caller)) {
       return failJ('Forbidden', 403);
     }
   }
@@ -803,7 +813,7 @@ function _authorize_(action, caller, b) {
   if (action === 'saveMemberCert') {
     const mid = String((b && b.memberId) || '').trim();
     if (!mid) return failJ('memberId required');
-    if (!_isAdmin_(caller)) {
+    if (!isAdmin_(caller)) {
       const m = findOne_('members', 'id', mid);
       if (!m || String(m.kennitala) !== caller.kennitala) {
         return failJ('Forbidden', 403);
@@ -820,8 +830,8 @@ function _authorize_(action, caller, b) {
 // IP. 5 failures in a 15-min window trip a 15-min lockout. A successful login
 // clears the counter. Admin "reset password" also clears.
 // ─────────────────────────────────────────────────────────────────────────────
-function _checkLoginRate_(kennitala) {
-  _ensureSheet_('loginAttempts', LOGIN_ATTEMPT_COLS_);
+function checkLoginRate_(kennitala) {
+  ensureSheet_('loginAttempts', LOGIN_ATTEMPT_COLS_);
   const row = findOne_('loginAttempts', 'kennitala', String(kennitala).trim());
   if (!row) return { ok: true };
   const now = Date.now();
@@ -832,8 +842,8 @@ function _checkLoginRate_(kennitala) {
   return { ok: true };
 }
 
-function _bumpLoginAttempts_(kennitala) {
-  _ensureSheet_('loginAttempts', LOGIN_ATTEMPT_COLS_);
+function bumpLoginAttempts_(kennitala) {
+  ensureSheet_('loginAttempts', LOGIN_ATTEMPT_COLS_);
   const kt = String(kennitala).trim();
   if (!kt) return;
   const row = findOne_('loginAttempts', 'kennitala', kt);
@@ -859,7 +869,7 @@ function _bumpLoginAttempts_(kennitala) {
   updateRow_('loginAttempts', 'kennitala', kt, updates);
 }
 
-function _clearLoginAttempts_(kennitala) {
+function clearLoginAttempts_(kennitala) {
   const kt = String(kennitala || '').trim();
   if (!kt) return;
   try { deleteRow_('loginAttempts', 'kennitala', kt); } catch (e) {}
@@ -869,7 +879,7 @@ function _clearLoginAttempts_(kennitala) {
 // + bucket + current minute, so a new window opens every 60s automatically.
 // Internal `__system` callers (time triggers invoking route_ directly) are
 // exempt because they aren't subject to the user-facing fairness contract.
-function _checkMutationRate_(caller, action) {
+function checkMutationRate_(caller, action) {
   if (!caller || caller.__system) return { ok: true };
   const bucket = BULK_ACTIONS_[action] ? 'bulk' : 'normal';
   const limit  = BULK_ACTIONS_[action] ? MUTATION_RATE_BULK_ : MUTATION_RATE_NORMAL_;
@@ -885,10 +895,10 @@ function _checkMutationRate_(caller, action) {
 }
 
 // Time-driven trigger: wipe expired session rows. Safe to run infrequently
-// because _authCaller_ also removes expired rows on encounter.
+// because authCaller_ also removes expired rows on encounter.
 function sweepExpiredSessions() {
   try { clearSheetCache_(); } catch (e) {}
-  _ensureSheet_('sessions', SESSION_COLS_);
+  ensureSheet_('sessions', SESSION_COLS_);
   const now = Date.now();
   const rows = readAll_('sessions');
   let n = 0;
@@ -1012,7 +1022,7 @@ function validateRow_(tabKey, obj) {
 function insertRow_(tabKey, obj) {
   validateRow_(tabKey, obj);
   const c = getSheetData_(tabKey);
-  const row = c.headers.map(h => _literalWrite_(obj[h] !== undefined ? obj[h] : ''));
+  const row = c.headers.map(h => literalWrite_(obj[h] !== undefined ? obj[h] : ''));
   c.sheet.appendRow(row);
   // appendRow lands at the first blank row, which may not equal
   // values.length + 2 if the sheet has trailing blanks. Invalidate to keep
@@ -1057,7 +1067,7 @@ function updateRow_(tabKey, keyField, keyValue, updates) {
           // Per-column setValue preserves existing concurrency semantics:
           // two executions touching disjoint columns on the same row don't
           // clobber each other.  Keep cache coherent with the write.
-          sheet.getRange(i + 2, col + 1).setValue(_literalWrite_(v));
+          sheet.getRange(i + 2, col + 1).setValue(literalWrite_(v));
           values[i][col] = v;
           wrote = true;
         }
@@ -1131,12 +1141,12 @@ function doGet(e) {
     }
     if (b.share)                return publicShareRecord_(b);
     // Session-authenticated GETs, if any.
-    const callerGet = _authCaller_(b);
+    const callerGet = authCaller_(b);
     if (callerGet) {
       if (!b.action) return okJ({ status: 'ok', ts: now_() });
-      const deniedGet = _authorize_(b.action, callerGet, b);
+      const deniedGet = authorize_(b.action, callerGet, b);
       if (deniedGet) return deniedGet;
-      const throttledGet = _checkMutationRate_(callerGet, b.action);
+      const throttledGet = checkMutationRate_(callerGet, b.action);
       if (!throttledGet.ok) return failJ('Too many requests', 429);
       return route_(b.action, b, callerGet);
     }
@@ -1155,11 +1165,11 @@ function doPost(e) {
     // Public POST endpoints — no auth required.
     if (action && PUBLIC_ACTIONS_[action]) return route_(action, b, null);
     // Everything else requires a valid per-user session token.
-    const caller = _authCaller_(b);
+    const caller = authCaller_(b);
     if (!caller) return failJ('Unauthorized', 401);
-    const denied = _authorize_(action, caller, b);
+    const denied = authorize_(action, caller, b);
     if (denied) return denied;
-    const throttled = _checkMutationRate_(caller, action);
+    const throttled = checkMutationRate_(caller, action);
     if (!throttled.ok) return failJ('Too many requests', 429);
     return route_(action, b, caller);
   } catch (err) {

--- a/config.gs
+++ b/config.gs
@@ -359,7 +359,7 @@ function normalizeAccessGate_(boat, certDefs) {
   return { certId: '', sub: raw, minRank: 0 };
 }
 
-function _gateSubcatRank_(certDefs, certId, subKey) {
+function gateSubcatRank_(certDefs, certId, subKey) {
   if (!Array.isArray(certDefs) || !certDefs.length || !certId || !subKey) return 0;
   var def = null;
   for (var i = 0; i < certDefs.length; i++) { if (certDefs[i] && certDefs[i].id === certId) { def = certDefs[i]; break; } }
@@ -381,14 +381,14 @@ function memberHasGate_(certs, gate, certDefs) {
     if (!gate.certId) return gate.sub && c.sub === gate.sub;
     if (c.certId !== gate.certId) return false;
     if (gate.minRank > 0) {
-      return _gateSubcatRank_(certDefs, gate.certId, c.sub) >= gate.minRank;
+      return gateSubcatRank_(certDefs, gate.certId, c.sub) >= gate.minRank;
     }
     if (gate.sub) return c.sub === gate.sub;
     return true;
   });
 }
 
-function _parseMemberCerts_(raw) {
+function parseMemberCerts_(raw) {
   if (!raw) return [];
   if (Array.isArray(raw)) return raw;
   try { var p = JSON.parse(raw); return Array.isArray(p) ? p : []; } catch (e) { return []; }

--- a/members.gs
+++ b/members.gs
@@ -2,7 +2,7 @@
 // MEMBERS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-function _publicMember_(m) {
+function publicMember_(m) {
   return {
     id: m.id, kennitala: m.kennitala, name: m.name, role: m.role,
     email: m.email || '', phone: m.phone || '',
@@ -19,7 +19,7 @@ function _publicMember_(m) {
 
 // Find all active minor members whose guardianKennitala matches the given kennitala.
 // Returns a trimmed list with just enough info for the account picker.
-function _findWardsOf_(guardianKt) {
+function findWardsOf_(guardianKt) {
   const kt = String(guardianKt || '').trim();
   if (!kt) return [];
   const all = readAll_('members');
@@ -45,7 +45,7 @@ function _findWardsOf_(guardianKt) {
 // guardian stub using the guardianName/guardianPhone stored on the ward
 // record (or an explicit hint, used when saving a minor). Returns null if
 // the kt has no relationship to any active minor and no hint was provided.
-function _ensureGuardianRecord_(kt, hintName, hintPhone) {
+function ensureGuardianRecord_(kt, hintName, hintPhone) {
   const s = String(kt || '').trim();
   if (!s || s.length !== 10) return null;
   const existing = findOne_('members', 'kennitala', s);
@@ -62,7 +62,7 @@ function _ensureGuardianRecord_(kt, hintName, hintPhone) {
     phone = phone || String(ward.guardianPhone || '').trim();
   }
   const ts = now_();
-  const tempPassword = _genTempPassword_();
+  const tempPassword = genTempPassword_();
   const row = {
     id: uid_(), kennitala: s, name: name, role: 'guardian',
     email: '', phone: phone, birthYear: '',
@@ -87,7 +87,7 @@ function validateMember_(kennitala, caller) {
   const kt = String(kennitala).trim();
   // Only the member themselves (or an admin) can re-read a full member
   // record. All other callers must go through the public lookup endpoints.
-  if (caller && kt !== caller.kennitala && !_isAdmin_(caller)) {
+  if (caller && kt !== caller.kennitala && !isAdmin_(caller)) {
     return failJ('Forbidden', 403);
   }
   const m = findOne_('members', 'kennitala', kt);
@@ -95,9 +95,9 @@ function validateMember_(kennitala, caller) {
   if (!bool_(m.active)) return failJ('Inactive account', 403);
   // If this member is not themselves a minor, surface any wards they guard
   // so the login UI can offer account switching.
-  const wards = bool_(m.isMinor) ? [] : _findWardsOf_(m.kennitala);
+  const wards = bool_(m.isMinor) ? [] : findWardsOf_(m.kennitala);
   return okJ({
-    member: _publicMember_(m),
+    member: publicMember_(m),
     wards: wards,
   });
 }
@@ -114,7 +114,7 @@ function loginMember_(b) {
   if (!username) return failJ('Username required');
   if (!password) return failJ('Password required');
 
-  const r = _findMemberForLogin_(username);
+  const r = findMemberForLogin_(username);
   if (r.ambiguous) return failJ('Ambiguous initials', 409);
   if (r.notFound || !r.member) return failJ('Not found', 404);
   const m = r.member;
@@ -122,23 +122,23 @@ function loginMember_(b) {
 
   // Rate limit is keyed off the resolved kennitala so initials and kennitala
   // attempts share a counter.
-  const rate = _checkLoginRate_(m.kennitala);
+  const rate = checkLoginRate_(m.kennitala);
   if (!rate.ok) return failJ('Too many attempts', 429);
 
   if (!verifyPassword_(m, password)) {
-    _bumpLoginAttempts_(m.kennitala);
+    bumpLoginAttempts_(m.kennitala);
     // Re-read the row: this attempt may have crossed the lockout threshold.
-    const after = _checkLoginRate_(m.kennitala);
+    const after = checkLoginRate_(m.kennitala);
     if (!after.ok) return failJ('Too many attempts', 429);
     return failJ('Invalid credentials', 401);
   }
 
-  _clearLoginAttempts_(m.kennitala);
-  const session = _createSession_(m.kennitala, m.role || 'member', stay, ua);
+  clearLoginAttempts_(m.kennitala);
+  const session = createSession_(m.kennitala, m.role || 'member', stay, ua);
 
-  const wards = bool_(m.isMinor) ? [] : _findWardsOf_(m.kennitala);
+  const wards = bool_(m.isMinor) ? [] : findWardsOf_(m.kennitala);
   return okJ({
-    member: _publicMember_(m),
+    member: publicMember_(m),
     wards: wards,
     usingDefaultPassword: bool_(m.passwordIsTemp),
     sessionToken: session.token,
@@ -161,11 +161,11 @@ function signOut_(b, caller) {
   if (targetId) {
     const row = findOne_('sessions', 'id', targetId);
     if (row && String(row.kennitala) === caller.kennitala) {
-      _deleteSessionById_(targetId);
+      deleteSessionById_(targetId);
     }
     return okJ({ signedOut: true });
   }
-  if (caller.tokenHash) _deleteSessionByHash_(caller.tokenHash);
+  if (caller.tokenHash) deleteSessionByHash_(caller.tokenHash);
   return okJ({ signedOut: true });
 }
 
@@ -177,7 +177,7 @@ function signOutAll_(b, caller) {
   if (!caller) return failJ('Unauthorized', 401);
   const exceptCurrent = bool_(b && b.exceptCurrent);
   const keep = exceptCurrent ? caller.tokenHash : null;
-  const n = _revokeSessionsForMember_(caller.kennitala, keep);
+  const n = revokeSessionsForMember_(caller.kennitala, keep);
   return okJ({ signedOut: true, count: n });
 }
 
@@ -185,7 +185,7 @@ function signOutAll_(b, caller) {
 // hashes are never exposed — the UI uses `id` to drive per-row revoke.
 function listSessions_(b, caller) {
   if (!caller) return failJ('Unauthorized', 401);
-  _ensureSheet_('sessions', SESSION_COLS_);
+  ensureSheet_('sessions', SESSION_COLS_);
   const now = Date.now();
   const currentHash = caller.tokenHash || '';
   const rows = readAll_('sessions')
@@ -215,22 +215,22 @@ function listSessions_(b, caller) {
 // row so the login flow forces a change, and revoke every active session.
 // The plaintext is returned to the admin once and never persisted.
 function adminResetMemberPassword_(b, caller) {
-  if (!caller || !_isAdmin_(caller)) return failJ('Admin only', 403);
+  if (!caller || !isAdmin_(caller)) return failJ('Admin only', 403);
   const kt = String((b && b.kennitala) || '').trim();
   if (!kt) return failJ('kennitala required');
   const m = findOne_('members', 'kennitala', kt);
   if (!m) return failJ('Member not found', 404);
   addColIfMissing_('members', 'passwordHash');
   addColIfMissing_('members', 'passwordIsTemp');
-  const tempPassword = _genTempPassword_();
+  const tempPassword = genTempPassword_();
   updateRow_('members', 'kennitala', kt, {
     passwordHash: hashPassword_(tempPassword),
     passwordIsTemp: true,
     updatedAt: now_(),
   });
   cDel_('members');
-  _clearLoginAttempts_(kt);
-  const n = _revokeSessionsForMember_(kt);
+  clearLoginAttempts_(kt);
+  const n = revokeSessionsForMember_(kt);
   return okJ({ reset: true, sessionsRevoked: n, tempPassword: tempPassword });
 }
 
@@ -249,7 +249,7 @@ function setPassword_(b, caller) {
   if (!next) return failJ('newPassword required');
   if (next.length < 4) return failJ('Password must be at least 4 characters');
 
-  const isAdminActing = caller && _isAdmin_(caller) && caller.kennitala !== kt;
+  const isAdminActing = caller && isAdmin_(caller) && caller.kennitala !== kt;
   if (!isAdminActing) {
     if (!verifyPassword_(m, cur)) return failJ('Current password incorrect', 401);
   }
@@ -262,13 +262,13 @@ function setPassword_(b, caller) {
     updatedAt: now_(),
   });
   cDel_('members');
-  _clearLoginAttempts_(kt);
+  clearLoginAttempts_(kt);
   // Invalidate every other session for this member so a stolen laptop is
   // logged out the moment the owner changes their password. Preserve the
   // caller's own session when they're changing their own password so the
   // current tab doesn't get booted in the middle of the save.
   const keepHash = (caller && caller.kennitala === kt) ? caller.tokenHash : null;
-  const revoked = _revokeSessionsForMember_(kt, keepHash);
+  const revoked = revokeSessionsForMember_(kt, keepHash);
   return okJ({ saved: true, sessionsRevoked: revoked });
 }
 
@@ -282,7 +282,7 @@ function validateWard_(b, caller) {
   const wardKt     = String((b && b.wardKennitala) || '').trim();
   if (!guardianKt || !wardKt) return failJ('guardianKennitala and wardKennitala required');
   // The caller must be the guardian they claim to be (or an admin helping out).
-  if (guardianKt !== caller.kennitala && !_isAdmin_(caller)) {
+  if (guardianKt !== caller.kennitala && !isAdmin_(caller)) {
     return failJ('Forbidden', 403);
   }
   const guardian = findOne_('members', 'kennitala', guardianKt);
@@ -301,9 +301,9 @@ function validateWard_(b, caller) {
   // arbitrary ward-targeted calls. Always short-lived — a guardian switching
   // into a ward should not be able to "stay logged in" as the minor.
   const ua = String((b && b.userAgent) || (caller.session && caller.session.userAgent) || '');
-  const s  = _createSession_(ward.kennitala, ward.role || 'member', false, ua);
+  const s  = createSession_(ward.kennitala, ward.role || 'member', false, ua);
   return okJ({
-    member: _publicMember_(ward),
+    member: publicMember_(ward),
     sessionToken: s.token,
     expiresAt: s.expiresAt,
     sessionId: s.id,
@@ -353,7 +353,7 @@ function getBoatMap_(cfgMap) {
 
 function saveMember_(b, caller) {
   const ts = now_(), ex = b.id ? findOne_('members', 'id', b.id) : null;
-  const isAdminCaller = _isAdmin_(caller) || (caller && caller.__system);
+  const isAdminCaller = isAdmin_(caller) || (caller && caller.__system);
   // Non-admin guardrails: members can only register new guests (used by the
   // member hub's walk-in flow). Anything else — editing any record, creating
   // non-guest members, role changes — is admin only.
@@ -376,7 +376,7 @@ function saveMember_(b, caller) {
     cDel_('members');
     let guardianTemp = null;
     if (bool_(b.isMinor) && b.guardianKennitala) {
-      const g = _ensureGuardianRecord_(b.guardianKennitala, b.guardianName, b.guardianPhone);
+      const g = ensureGuardianRecord_(b.guardianKennitala, b.guardianName, b.guardianPhone);
       if (g && g.tempPassword) guardianTemp = { kennitala: g.kennitala, name: g.name, tempPassword: g.tempPassword };
     }
     const out = { id: b.id, updated: true };
@@ -389,7 +389,7 @@ function saveMember_(b, caller) {
     const role = isAdminCaller ? (b.role || 'member') : 'guest';
     addColIfMissing_('members', 'passwordHash');
     addColIfMissing_('members', 'passwordIsTemp');
-    const tempPassword = _genTempPassword_();
+    const tempPassword = genTempPassword_();
     insertRow_('members', {
       id, kennitala: b.kennitala, name: b.name, role: role,
       email: b.email || '', phone: b.phone || '', birthYear: b.birthYear || '',
@@ -403,7 +403,7 @@ function saveMember_(b, caller) {
     cDel_('members');
     let guardianTemp = null;
     if (bool_(b.isMinor) && b.guardianKennitala) {
-      const g = _ensureGuardianRecord_(b.guardianKennitala, b.guardianName, b.guardianPhone);
+      const g = ensureGuardianRecord_(b.guardianKennitala, b.guardianName, b.guardianPhone);
       if (g && g.tempPassword) guardianTemp = { kennitala: g.kennitala, name: g.name, tempPassword: g.tempPassword };
     }
     const out = { id, created: true, tempPassword: tempPassword };
@@ -441,7 +441,7 @@ function importMembers_(rows) {
       });
       updated++;
     } else {
-      const temp = _genTempPassword_();
+      const temp = genTempPassword_();
       const kt = String(r.kennitala).trim();
       insertRow_('members', {
         id: uid_(), kennitala: kt, name: r.name || '',
@@ -462,7 +462,7 @@ function importMembers_(rows) {
   // guardian gets its own temp password so the admin can relay it.
   rows.forEach(r => {
     if (bool_(r.isMinor) && r.guardianKennitala) {
-      const g = _ensureGuardianRecord_(r.guardianKennitala, r.guardianName, r.guardianPhone);
+      const g = ensureGuardianRecord_(r.guardianKennitala, r.guardianName, r.guardianPhone);
       if (g && g.tempPassword) {
         tempPasswords.push({ kennitala: g.kennitala, name: g.name, tempPassword: g.tempPassword });
       }

--- a/passport.gs
+++ b/passport.gs
@@ -181,7 +181,7 @@ function saveRowingPassportDef_(b) {
   return okJ({ saved: true });
 }
 
-function _slugify_(s) {
+function slugify_(s) {
   return String(s || '').toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
@@ -230,7 +230,7 @@ function importRowingPassportCsv_(b) {
   const existingCatByLabel = {};
   (current.passports || []).forEach(p => {
     (p.categories || []).forEach(c => {
-      const catLabelKey = (p.id + '|' + _slugify_(c.name && c.name.EN || c.id));
+      const catLabelKey = (p.id + '|' + slugify_(c.name && c.name.EN || c.id));
       existingCatByLabel[catLabelKey] = c.id;
       (c.items || []).forEach(i => {
         const itemLabelKey = (p.id + '|' + c.id + '|' + String((i.name && i.name.EN) || '').toLowerCase().trim());
@@ -260,8 +260,8 @@ function importRowingPassportCsv_(b) {
     if (!catId) {
       const catLabelEn = (r.category_label_en || '').trim();
       if (!catLabelEn) { errors.push('Row ' + lineNo + ': needs either category_id or category_label_en'); return; }
-      const catKey = pid + '|' + _slugify_(catLabelEn);
-      catId = existingCatByLabel[catKey] || _slugify_(catLabelEn);
+      const catKey = pid + '|' + slugify_(catLabelEn);
+      catId = existingCatByLabel[catKey] || slugify_(catLabelEn);
     }
 
     let cat = p._catIndex[catId];
@@ -282,7 +282,7 @@ function importRowingPassportCsv_(b) {
     let itemId = (r.item_id || '').trim();
     if (!itemId) {
       const itemKey = pid + '|' + catId + '|' + labelEn.toLowerCase();
-      itemId = existingItemByLabel[itemKey] || _slugify_(labelEn);
+      itemId = existingItemByLabel[itemKey] || slugify_(labelEn);
     }
 
     // Detect duplicate item ids within the same category in this CSV

--- a/payroll.gs
+++ b/payroll.gs
@@ -176,7 +176,7 @@ function adminAddTime_(b) {
     var id = 'entry_' + Date.now() + '_' + Math.random().toString(36).slice(2,6);
     // Column order matches sheet: id, employeeId, type, timestamp(clockOut), source, originalTimestamp(clockIn), note, periodKey, durationMinutes
     var periodKey = b.clockIn ? b.clockIn.slice(0,7) + '-01' : new Date().toISOString().slice(0,7) + '-01';
-    sh.appendRow([id, b.employeeId, '', b.timestamp, 'admin', b.clockIn, _literalWrite_(b.note || 'admin entry'), periodKey, b.durationMinutes]);
+    sh.appendRow([id, b.employeeId, '', b.timestamp, 'admin', b.clockIn, literalWrite_(b.note || 'admin entry'), periodKey, b.durationMinutes]);
     return okJ({ success: true, id: id });
   } catch(e) {
     return failJ(e.message);

--- a/public.gs
+++ b/public.gs
@@ -1282,7 +1282,7 @@ function ensureVolunteerSignupsTab() {
 // runs on the backend so that events are persisted to config, not computed
 // lazily on the client.
 
-function _volExpandActType_(at, fromIso, toIso) {
+function volExpandActType_(at, fromIso, toIso) {
   if (!at || at.active === false || at.active === 'false') return [];
   var isVol = at.volunteer === true || at.volunteer === 'true';
   if (!isVol) return [];
@@ -1361,7 +1361,7 @@ function _volExpandActType_(at, fromIso, toIso) {
 // already exist (matched by id) are left untouched so individual admin edits
 // and soft-deletes are preserved. Returns { arr, added } where arr is the
 // updated array and added is the count of new events inserted.
-function _volMergeMaterialized_(arr, expanded) {
+function volMergeMaterialized_(arr, expanded) {
   var existing = {};
   (arr || []).forEach(function(e) { if (e && e.id) existing[e.id] = true; });
   var added = 0;
@@ -1384,11 +1384,11 @@ function materializeVolunteerEventsForAt_(at) {
   var fromIso = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
   // Honor subtype's own toDate; fallback to a far-future cap if absent.
   var toIso = '2099-12-31';
-  var expanded = _volExpandActType_(at, fromIso, toIso);
+  var expanded = volExpandActType_(at, fromIso, toIso);
   if (!expanded.length) return 0;
   var arr = [];
   try { arr = JSON.parse(getConfigSheetValue_('volunteer_events') || '[]'); } catch(e) { arr = []; }
-  var merged = _volMergeMaterialized_(arr, expanded);
+  var merged = volMergeMaterialized_(arr, expanded);
   if (merged.added > 0) {
     setConfigSheetValue_('volunteer_events', JSON.stringify(merged.arr));
     cDel_('config');
@@ -1417,12 +1417,12 @@ function reconcileVolunteerEventsForAt_(at) {
   var arr = [];
   try { arr = JSON.parse(getConfigSheetValue_('volunteer_events') || '[]'); } catch(e) { arr = []; }
   // Compute the set of event IDs the current config would produce. If the
-  // activity type is inactive or no longer volunteer-flagged, _volExpandActType_
+  // activity type is inactive or no longer volunteer-flagged, volExpandActType_
   // returns [] and the "wanted" set is empty — meaning everything materialized
   // for this type becomes prune-eligible.
   var fromIso = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
   var toIso = '2099-12-31';
-  var expanded = _volExpandActType_(at, fromIso, toIso);
+  var expanded = volExpandActType_(at, fromIso, toIso);
   var wanted = {};
   expanded.forEach(function(e) { if (e && e.id) wanted[e.id] = true; });
   // Load signups once so we can tell which events are still referenced.
@@ -1455,7 +1455,7 @@ function reconcileVolunteerEventsForAt_(at) {
     }
   });
   // Merge in any newly-expanded events (existing IDs are left untouched).
-  var merged = _volMergeMaterialized_(next, expanded);
+  var merged = volMergeMaterialized_(next, expanded);
   result.added = merged.added;
   if (result.added > 0 || result.removed > 0 || result.softDeleted > 0) {
     setConfigSheetValue_('volunteer_events', JSON.stringify(merged.arr));
@@ -1481,10 +1481,10 @@ function syncVolunteerEvents_(b) {
     var wantedIds = {};
     var totalAdded = 0;
     actTypes.forEach(function(at) {
-      var expanded = _volExpandActType_(at, fromIso, '2099-12-31');
+      var expanded = volExpandActType_(at, fromIso, '2099-12-31');
       expanded.forEach(function(e) { if (e && e.id) wantedIds[e.id] = true; });
       if (!expanded.length) return;
-      var merged = _volMergeMaterialized_(arr, expanded);
+      var merged = volMergeMaterialized_(arr, expanded);
       arr = merged.arr;
       totalAdded += merged.added;
     });


### PR DESCRIPTION
…lper

⚠️ Backend (.gs) changes — see code.gs, alerts.gs, and the wider .gs family via the rename pass.

 NAMING #1 (underscore convention). CLAUDE.md specifies trailing
 underscore for internal helpers (foo_, not _foo_). 31 functions
 across code.gs / config.gs / members.gs / passport.gs / public.gs
 carried BOTH a leading AND trailing underscore, which is
 inconsistent and muddies the public-vs-internal distinction.

 Renamed all 31 with a scripted pass using a word-boundary-safe
 regex (lookbehind + lookahead on the JS identifier set) so nested
 references and comments updated atomically. No collisions with
 existing single-trailing-underscore names. Examples:
   _literalWrite_         → literalWrite_
   _ensureGuardianRecord_ → ensureGuardianRecord_
   _createSession_        → createSession_
   _authCaller_           → authCaller_
 Every .gs file still parses.

 NAMING #2 (public vs internal). Surveyed the 7 functions with no
 trailing underscore: all are one-time migration helpers the
 developer runs directly from the Apps Script editor Run menu
 (setupSpreadsheet, addHandshakeColumns, migrateMemberLangIntoPreferences,
 etc.) — NOT action-routed. Their lack of trailing underscore is
 the valid "this is admin-runnable scaffolding" convention. Left
 as-is, documented here.

 NAMING #3 (magic column lookups). Added requiredCol_(headers, name)
 to code.gs — throws "Missing column '<name>' in sheet" instead of
 returning -1. The five alerts.gs sites that declared
 `const col = h => headers.indexOf(h)` (and indexed into rows with
 the result) now delegate to requiredCol_, turning silent
 miswrite-to-column-minus-one bugs into loud stack traces if the
 sheet ever drifts from the code. Existence checks
 (addColIfMissing_, the two _setup.gs migrations) still use the
 bare indexOf() because -1 is semantically meaningful there.

 DEAD / STALE. Both items from the original review were actually
 non-issues on closer look:
   • code.gs:7-11 "Removed one-time setup functions" — grepped
     for the referenced names (addLangColumnIfNeeded,
     addAlertColumnsIfNeeded, createSheetStructure, getBoats_,
     saveBoat_, etc.); they're all genuinely gone. The comment is
     accurate changelog, not a stale reference.
   • "dailyLog removed from TABS_" — I misread the comment; the
     actual line says "dailyCL removed" (a different key), and
     dailyCL is indeed removed. dailyLog is intentionally still
     in TABS_.

https://claude.ai/code/session_01MiU5pjfVEtZbpf663FcSck