### PR TITLE
Parse staffStatus in getConfig_ instead of wrapping it in jsonR_

### DIFF
--- a/config.gs
+++ b/config.gs
@@ -17,7 +17,8 @@ function getConfig_() {
   } catch (e) { }
   const overdueAlerts = getAlertConfigFromMap_(cfgMap);
   const flagConfig = getFlagConfigFromMap_(cfgMap);
-  const staffStatus   = jsonR_(getConfigValue_('staffStatus', cfgMap));
+  let staffStatus = null;
+  try { staffStatus = JSON.parse(getConfigValue_('staffStatus', cfgMap) || 'null'); } catch (e) {}
   // Staff-set flag override — auto-clears when past `expiresAt` (set to next UTC
   // midnight by the staff page). Cleared by writing an empty value back so the
   // next getConfig build is clean, then bypassed for this response.


### PR DESCRIPTION
⚠️ Backend (.gs) change — config.gs.

getConfig_ was calling jsonR_ (the ContentService response wrapper used by okJ/failJ) on the raw staffStatus string pulled from the config sheet. That returned a TextOutput object which landed inside the config bundle; okJ(config) then ran JSON.stringify over a host TextOutput object and threw, so doPost's outer try/catch returned a generic "Server error" 500 — surfacing on the client as

    admin.js:88 loadAll failed: Error: Server error

Use JSON.parse with a null fallback (matching the pattern used for every other parsed config key) so staffStatus arrives at the frontend as a plain object again.

https://claude.ai/code/session_01WeXze4redNB79i5atZA79b