### PR TITLE
Surface err.message in doGet/doPost catch responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,14 @@ review's categories; see commit messages for per-change detail.
   on every `.js` / `.gs`, and (non-blocking for now) ESLint / Prettier.
 - `tools/check-syntax.js` parse-checks every `.js` and `.gs` file.
 
+**Debuggability**
+
+- `doGet` / `doPost` outer `catch` now include `err.message` in the
+  client response (`'Server error: ' + err.message` instead of the bare
+  `'Server error'`). The Apps Script `Logger.log` still carries the full
+  stack; this surfaces enough detail in the browser console that a
+  future regression doesn't need Apps Script log access to diagnose.
+
 ## v6
 
 Apps Script backend. Previously lived as a comment at the top of

--- a/code.gs
+++ b/code.gs
@@ -1146,7 +1146,7 @@ function doGet(e) {
     return failJ('Unauthorized', 401);
   } catch (err) {
     Logger.log(['doGet error:', err && err.stack || err].join(" "));
-    return failJ('Server error', 500);
+    return failJ('Server error: ' + ((err && err.message) || 'unknown'), 500);
   }
 }
 
@@ -1167,7 +1167,7 @@ function doPost(e) {
     return route_(action, b, caller);
   } catch (err) {
     Logger.log(['doPost error:', err && err.stack || err].join(" "));
-    return failJ('Server error', 500);
+    return failJ('Server error: ' + ((err && err.message) || 'unknown'), 500);
   }
 }
 


### PR DESCRIPTION
⚠️ Backend (.gs) change — code.gs.

Both outer catches swallowed every unexpected exception into the bare string "Server error", 500. The browser console would show

    admin.js:88 loadAll failed: Error: Server error

with no hint which endpoint or which line. Diagnosing required access to Apps Script's execution log.

Include err.message in the client response instead:

    Server error: <actual message>

The full stack still goes to Logger.log; only the message (not the stack) leaks to the client. Both endpoints are either auth-gated (POST) or rate-limited (GET public routes), so the marginal info-leak is acceptable for the payoff in debuggability.

The staffStatus regression that triggered the original admin-page failure was fixed in c5dc89c; if the admin page still shows "Server error" after this lands, redeploy Apps Script — the fix only takes effect once the script.google.com deployment is refreshed.