### PR TITLE
Lift modal/overlay z-indexes above Leaflet (maps no longer paint over…

### DIFF
--- a/logbook/logbook.css
+++ b/logbook/logbook.css
@@ -60,7 +60,7 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .trip-detailed.open{display:block}
 
 /* Full-screen map modal */
-.map-modal-overlay{position:fixed;inset:0;background:#000e;z-index:600;display:flex;flex-direction:column}
+.map-modal-overlay{position:fixed;inset:0;background:#000e;z-index:2100;display:flex;flex-direction:column}
 .map-modal-overlay.hidden{display:none}
 .map-modal-bar{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:var(--bg);border-bottom:1px solid var(--border);flex-shrink:0}
 .map-modal-bar span{font-size:12px;color:var(--text)}
@@ -68,11 +68,11 @@ details#portDetails:not([open]) #portSummaryLabel::after{content:' ▾';font-siz
 .map-modal-body{flex:1;position:relative}
 
 /* Lightbox */
-.lightbox-overlay{position:fixed;inset:0;background:#000e;z-index:600;display:flex;align-items:center;justify-content:center;flex-direction:column;cursor:zoom-out}
+.lightbox-overlay{position:fixed;inset:0;background:#000e;z-index:2100;display:flex;align-items:center;justify-content:center;flex-direction:column;cursor:zoom-out}
 .lightbox-overlay.hidden{display:none}
 .lightbox-img{max-width:92vw;max-height:85vh;object-fit:contain;border-radius:6px}
-.lightbox-close{position:absolute;top:14px;right:18px;background:none;border:none;color:#fff;font-size:28px;cursor:pointer;z-index:601}
-.lightbox-nav{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);border:none;color:#fff;font-size:24px;cursor:pointer;padding:8px 12px;border-radius:6px;z-index:601}
+.lightbox-close{position:absolute;top:14px;right:18px;background:none;border:none;color:#fff;font-size:28px;cursor:pointer;z-index:2101}
+.lightbox-nav{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);border:none;color:#fff;font-size:24px;cursor:pointer;padding:8px 12px;border-radius:6px;z-index:2101}
 .lightbox-nav.prev{left:12px}
 .lightbox-nav.next{right:12px}
 

--- a/maintenance/maintenance.css
+++ b/maintenance/maintenance.css
@@ -88,7 +88,7 @@
     .photo-preview.show { display:block; }
 
     /* Full-size photo overlay */
-    .photo-overlay { position:fixed; inset:0; background:rgba(0,0,0,.9); z-index:300;
+    .photo-overlay { position:fixed; inset:0; background:rgba(0,0,0,.9); z-index:2100;
       display:flex; align-items:center; justify-content:center; cursor:pointer; }
     .photo-overlay.hidden { display:none; }
     .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:var(--radius-md); }

--- a/saumaklubbur/saumaklubbur.css
+++ b/saumaklubbur/saumaklubbur.css
@@ -68,7 +68,7 @@
       border:1px solid var(--border); margin-top:6px; display:none; }
     .photo-preview.show { display:block; }
 
-    .photo-overlay { position:fixed; inset:0; background:rgba(0,0,0,.9); z-index:300;
+    .photo-overlay { position:fixed; inset:0; background:rgba(0,0,0,.9); z-index:2100;
       display:flex; align-items:center; justify-content:center; cursor:pointer; }
     .photo-overlay.hidden { display:none; }
     .photo-overlay img { max-width:95vw; max-height:92vh; object-fit:contain; border-radius:var(--radius-md); }

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -1,4 +1,4 @@
-.settings-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);display:flex;align-items:center;justify-content:center;z-index:200;padding:20px}
+.settings-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);display:flex;align-items:center;justify-content:center;z-index:2000;padding:20px}
 .settings-page{max-width:560px;width:100%;background:var(--card);border:1px solid var(--border-l);border-radius:var(--radius-lg);padding:24px 20px 20px;max-height:88vh;overflow-y:auto;position:relative;box-shadow:var(--shadow-lg)}
 .settings-section{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:16px 18px;margin-bottom:12px;box-shadow:var(--shadow-sm)}
 .settings-section-title{font-size:9px;color:var(--muted);letter-spacing:1.2px;text-transform:uppercase;margin-bottom:12px;font-weight:600}

--- a/shared/payroll.js
+++ b/shared/payroll.js
@@ -281,7 +281,7 @@ function punchClockWidget(el, employeeId, opts) {
       '.pc-row{display:flex;align-items:center;gap:8px;font-size:12px;padding:5px 0;border-bottom:1px solid var(--border)}' +
       '.pc-row:last-child{border-bottom:none}' +
       // End-of-shift modal
-      '.pc-modal-bg{position:fixed;inset:0;background:#00000088;z-index:600;display:flex;align-items:flex-end;justify-content:center}' +
+      '.pc-modal-bg{position:fixed;inset:0;background:#00000088;z-index:2000;display:flex;align-items:flex-end;justify-content:center}' +
       '.pc-modal{background:var(--bg);border-radius:16px 16px 0 0;padding:20px 20px 36px;width:100%;max-width:520px;max-height:80vh;overflow-y:auto}' +
       '.pc-modal-title{font-size:14px;font-weight:600;color:var(--brass-fg);margin-bottom:4px;letter-spacing:.3px}' +
       '.pc-modal-sub{font-size:11px;color:var(--muted);margin-bottom:16px}' +

--- a/shared/qr.js
+++ b/shared/qr.js
@@ -63,7 +63,7 @@
     var overlay = document.createElement('div');
     overlay.className = 'qr-scan-overlay';
     overlay.style.cssText =
-      'position:fixed;inset:0;background:#000e;z-index:800;display:flex;' +
+      'position:fixed;inset:0;background:#000e;z-index:2100;display:flex;' +
       'flex-direction:column;align-items:center;justify-content:center;padding:20px;' +
       'font-family:inherit';
 

--- a/shared/style.css
+++ b/shared/style.css
@@ -498,7 +498,7 @@ textarea { min-height: 70px; }
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   display: flex; align-items: center; justify-content: center;
-  z-index: 200; padding: 20px;
+  z-index: 2000; padding: 20px;
 }
 .modal-overlay.hidden { display: none; }
 
@@ -509,8 +509,13 @@ textarea { min-height: 70px; }
 .modal-overlay:has(> .modal--sheet) {
   align-items: flex-end;
   padding: 0;
-  z-index: 500;
 }
+
+/* Leaflet maps set position:relative on .leaflet-container and give internal
+   panes z-indexes up to 1000 (controls). Without a stacking context, those
+   escape into the root and paint over modals. `isolation: isolate` caps them
+   inside the map's own box so every modal overlay can safely sit above. */
+.leaflet-container { isolation: isolate; }
 
 .modal {
   background: var(--card);
@@ -866,7 +871,7 @@ textarea { min-height: 70px; }
 .ts-table td{padding:5px 8px;border-bottom:1px solid var(--border)44;vertical-align:middle}
 .ts-table tr:last-child td{border-bottom:none}
 .src-admin{color:var(--brass-fg)}
-.modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:200;display:flex;align-items:center;justify-content:center}
+.modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:2000;display:flex;align-items:center;justify-content:center}
 .modal-box{background:var(--card);border-radius:var(--radius-lg);padding:22px 26px;min-width:320px;max-width:460px;width:90vw;box-shadow:var(--shadow-lg)}
 .modal-title{margin:0 0 16px;font-size:15px;font-weight:700}
 .modal-err{font-size:11px;color:var(--red);min-height:14px;margin-bottom:2px}

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -308,7 +308,9 @@ document.addEventListener('keydown', function (e) {
     _overlay = document.createElement('div');
     _overlay.id = 'ym-dialog';
     _overlay.className = 'modal-overlay hidden';
-    _overlay.style.zIndex = '300';
+    // Above .modal-overlay (2000) + full-screen viewers (2100) so confirm /
+    // alert / prompt can fire from inside another modal and still sit on top.
+    _overlay.style.zIndex = '2200';
     _overlay.addEventListener('click', function (e) {
       if (e.target === _overlay) dismiss();
     });

--- a/staff/staff.css
+++ b/staff/staff.css
@@ -185,7 +185,7 @@
 /* Fleet status bar — emoji pip */
 .fsb-emoji { font-size:14px; flex-shrink:0; }
 /* ── Group checkout modal ────────────────────────────────────────── */
-.group-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:400;display:flex;align-items:flex-end;justify-content:center}
+.group-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:2000;display:flex;align-items:flex-end;justify-content:center}
 .group-modal-overlay.hidden{display:none}
 .group-modal-sheet{background:var(--bg);border-radius:var(--radius-lg) var(--radius-lg) 0 0;padding:20px 20px 36px;width:100%;max-width:680px;max-height:92vh;overflow-y:auto;box-shadow:var(--shadow-lg)}
 .group-modal-title{font-size:14px;font-weight:500;margin-bottom:16px;display:flex;align-items:center;justify-content:space-between}
@@ -219,7 +219,7 @@
 .gc-staff{font-size:11px;color:var(--muted)}
 
 /* ── Guest prompt modal ── */
-.guest-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:600;display:flex;align-items:center;justify-content:center}
+.guest-modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);z-index:2100;display:flex;align-items:center;justify-content:center}
 .guest-modal-overlay.hidden{display:none}
 .guest-modal{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-lg);padding:20px;width:90%;max-width:360px;box-shadow:var(--shadow-lg)}
 .guest-modal h4{font-size:12px;color:var(--brass-fg);letter-spacing:.5px;margin:0 0 14px}
@@ -232,7 +232,7 @@
 
 #groupCheckOutBtn{background:var(--navy);border-color:var(--navy);color:#fff}
 #groupCheckOutBtn:hover{background:var(--navy-d);border-color:var(--navy-d)}
-.dl-link-overlay{position:fixed;inset:0;background:#00000099;z-index:500;display:flex;align-items:flex-end;justify-content:center}
+.dl-link-overlay{position:fixed;inset:0;background:#00000099;z-index:2000;display:flex;align-items:flex-end;justify-content:center}
 .dl-link-overlay.hidden{display:none}
 .dl-link-sheet{background:var(--bg);border-radius:16px 16px 0 0;padding:20px 20px 36px;width:100%;max-width:680px;max-height:80vh;overflow-y:auto}
 .dl-link-title{font-size:14px;font-weight:500;margin-bottom:4px}


### PR DESCRIPTION
… modals)

Leaflet's internal panes and controls use z-indexes up to 1000 in the root stacking context, so every .modal-overlay sitting at z-index 200 / 500 was getting painted over by the heatmap / track thumbnails / map modal whenever they overlapped on-page.

Two-pronged fix so the problem can't recur:

1. `.leaflet-container { isolation: isolate }` in shared/style.css caps every Leaflet map's internal z-index inside its own stacking context. From outside the map looks like z-index:auto, so even the legacy 200/500 modals would now stack correctly.

2. Raise every dialog/overlay to a consistent banded scheme so a confirm inside a modal inside a lightbox still layers right: 2000  .modal-overlay, .modal-bg, .settings-overlay, .group-modal-overlay, .dl-link-overlay, .pc-modal-bg 2100  .map-modal-overlay, .lightbox-overlay, .photo-overlay, .guest-modal-overlay, qr scan overlay 2101  .lightbox-close, .lightbox-nav 2200  ym-dialog (ymAlert / ymConfirm / ymPrompt)

Also drops the now-stale `z-index: 500` from the unused `.modal-overlay:has(> .modal-sheet)` branch so the base 2000 applies.

https://claude.ai/code/session_01PpREW2U1uni8mwmvQbzxFf