### PR TITLE
Defer loadConfirmations lookup so shared/logbook.js can reach its IIFE

### DIFF
--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -409,8 +409,12 @@ async function reload(){
 
 // ── Edit trip (skipper only) ────────────────────────────────────────────────
 
-// Load confirmations after page init
-setTimeout(loadConfirmations,1500);
+// Load confirmations after page init. Wrap so the loadConfirmations
+// lookup is deferred until the callback fires — the function lives in
+// shared/logbook-confirm.js, which loads after this file.
+setTimeout(function () {
+  if (typeof loadConfirmations === 'function') loadConfirmations();
+}, 1500);
 
 
 // Delegated handlers for data-trip-* attrs on rendered logbook DOM


### PR DESCRIPTION
shared/logbook.js line 413 had `setTimeout(loadConfirmations, 1500)`, but after 7c707df split the module, loadConfirmations moved to shared/logbook-confirm.js — which loads AFTER this file. The identifier is read synchronously at script evaluation, so the classic-script scope chain sees it as undefined and throws a ReferenceError.

That ReferenceError aborts the rest of shared/logbook.js, including the IIFE at lines 419-468 that registers the document-level `data-trip-action` click listener. Net effect: clicking the header of a trip card (open-card), the close X, "Edit trip", track/photo upload, delete, lightbox — all silently dead, because the listener was never attached.

Wrap the setTimeout call in an anonymous function that defers the name lookup until the timer fires (by which point every defer script on the page has run and loadConfirmations is a global). The `typeof === …` guard keeps the call a no-op on any portal that doesn't load logbook-confirm.js.

https://claude.ai/code/session_01PpREW2U1uni8mwmvQbzxFf