### PR TITLE
Unify compact button size: introduce .btn-sm, replace ad-hoc overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — unified compact button size
+
+- **`.btn-sm` modifier in `shared/style.css`** — one canonical compact size
+  (`padding: 6px 12px; font-size: 11px; min-height: 0;`) replaces ~40 ad-hoc
+  inline `style="padding:…;font-size:…"` overrides spread across captain,
+  staff, coxswain, admin, member, weather, incidents, and the shared boat /
+  slot / maintenance / payroll / boats modules. Mobile caps the touch target
+  at 32px (between `.btn`'s 44px and `.btn-ghost`'s 36px).
+- **Captain's slot-week-nav aligns with the rest** — removed the
+  `.slot-week-nav .btn` size rule; the strip now uses `.btn-sm` directly,
+  so "Assign cred", "+ Add boat", "← →", "New Booking" and "Bulk Book" all
+  share the same height/padding instead of drifting by 1–3px each.
+
 ## Unreleased — logbook bug fixes
 
 Surface-level fixes for the logbook portal after the inline-style → utility-class

--- a/admin/boats.js
+++ b/admin/boats.js
@@ -370,7 +370,7 @@ function renderReservationList(boat) {
   var actEl = document.getElementById("bReservationActions");
   if (!boat || !boat.reservations || !boat.reservations.length) {
     el.innerHTML = '';
-    actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" data-admin-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
+    actEl.innerHTML = '<button class="btn btn-secondary btn-sm" data-admin-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
     return;
   }
   el.innerHTML = boat.reservations.map(function(r) {
@@ -380,7 +380,7 @@ function renderReservationList(boat) {
       + '<button style="font-size:10px;background:none;border:none;color:var(--red);cursor:pointer" data-admin-click="removeResFromModal" data-admin-arg="'+esc(r.id)+'">&times;</button>'
       + '</div>';
   }).join('');
-  actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" data-admin-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
+  actEl.innerHTML = '<button class="btn btn-secondary btn-sm" data-admin-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
 }
 
 function showResForm() {

--- a/admin/index.html
+++ b/admin/index.html
@@ -261,7 +261,7 @@
           <div class="d-flex gap-8 items-center flex-wrap">
             <input type="text" id="newCatInputEN" placeholder="Name (EN)" class="flex-1 text-md" style="min-width:120px">
             <input type="text" id="newCatInputIS" placeholder="Nafn (IS)" class="flex-1 text-md" style="min-width:120px">
-            <button class="btn btn-primary text-xs" style="padding:5px 12px" data-admin-click="addCertCategory" data-s="admin.addBtn"></button>
+            <button class="btn btn-primary btn-sm" data-admin-click="addCertCategory" data-s="admin.addBtn"></button>
           </div>
         </div>
       </div>
@@ -697,7 +697,7 @@
         <label class="text-10 text-muted" style="letter-spacing:.8px" data-s="admin.volRoles"></label>
         <div class="d-flex gap-6 items-center flex-wrap">
           <select id="atRolePresetPicker" data-admin-preset-change="addAtRoleFromPreset" class="text-xs bg-surface border-muted rounded-4 font-inherit" style="padding:4px 8px;color:var(--text)"></select>
-          <button class="btn btn-secondary text-xs" style="padding:4px 10px" data-admin-click="addAtRoleRow" data-s="btn.add"></button>
+          <button class="btn btn-secondary btn-sm" data-admin-click="addAtRoleRow" data-s="btn.add"></button>
         </div>
       </div>
       <div id="atRolesList"></div>
@@ -717,7 +717,7 @@
     <div class="mt-10">
       <div class="d-flex items-center justify-between mb-6">
         <label class="text-10 text-muted" style="letter-spacing:.8px" data-s="admin.subtypes"></label>
-        <button class="btn btn-secondary text-xs" style="padding:4px 10px" data-admin-click="addAtSubtypeRow" data-s="btn.add"></button>
+        <button class="btn btn-secondary btn-sm" data-admin-click="addAtSubtypeRow" data-s="btn.add"></button>
       </div>
       <div id="atSubtypesList"></div>
     </div>
@@ -779,7 +779,7 @@
         <label class="text-10 text-muted" style="letter-spacing:.8px" data-s="admin.volRoles" for="ccLabelEN"></label>
         <div class="d-flex gap-6 items-center flex-wrap">
           <select id="veRolePresetPicker" data-admin-preset-change="addVolRoleFromPreset" class="text-xs bg-surface border-muted rounded-4 font-inherit" style="padding:4px 8px;color:var(--text)"></select>
-          <button class="btn btn-secondary text-xs" style="padding:4px 10px" data-admin-click="addVolRoleRow" data-s="btn.add"></button>
+          <button class="btn btn-secondary btn-sm" data-admin-click="addVolRoleRow" data-s="btn.add"></button>
         </div>
       </div>
       <div id="volRolesList"></div>
@@ -869,7 +869,7 @@
     <div class="mt-14">
       <div class="d-flex items-center justify-between mb-6">
         <label class="text-10 text-muted" style="letter-spacing:.8px" data-s="admin.certSubcategories"></label>
-        <button class="btn btn-secondary text-xs" style="padding:4px 10px" data-admin-click="addSubcatRow" data-s="btn.add"></button>
+        <button class="btn btn-secondary btn-sm" data-admin-click="addSubcatRow" data-s="btn.add"></button>
       </div>
       <div id="subcatRows"></div>
       <div class="text-xs text-muted mt-6" style="padding-top:6px" data-s="admin.certSubcatHint">

--- a/admin/passport.js
+++ b/admin/passport.js
@@ -55,8 +55,8 @@ function _ppRenderItemRow(p, cat, it, pi, ci, ii) {
       <div style="font-size:9px;color:var(--faint);margin-top:2px">${esc(it.id)}</div>
     </div>
     <div style="display:flex;flex-direction:column;gap:4px">
-      <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="${ii}" data-s="passport.editItem">Edit</button>
-      <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="ppToggleRetire" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="${ii}">${retired ? esc(s('passport.unretire')) : esc(s('passport.retire'))}</button>
+      <button class="btn btn-secondary btn-sm" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="${ii}" data-s="passport.editItem">Edit</button>
+      <button class="btn btn-secondary btn-sm" data-admin-click="ppToggleRetire" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="${ii}">${retired ? esc(s('passport.unretire')) : esc(s('passport.retire'))}</button>
     </div>
   </div>`;
 }
@@ -84,7 +84,7 @@ function drawPassportEditor() {
   if (!def || !(def.passports || []).length) {
     card.innerHTML = `<div style="color:var(--muted);padding:12px 0">No passports configured. Import a CSV to get started.</div>
       <div style="margin-top:12px;display:flex;gap:8px;align-items:center">
-        <button class="btn btn-primary" style="font-size:11px" data-admin-click="ppSaveDef" data-s="passport.save">Save changes</button>
+        <button class="btn btn-primary btn-sm" data-admin-click="ppSaveDef" data-s="passport.save">Save changes</button>
         <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
       </div>`;
     applyStrings(card);
@@ -97,8 +97,8 @@ function drawPassportEditor() {
   // Sort-mode toggle (shared across all passports in the editor)
   html += `<div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
     <span style="font-size:10px;color:var(--muted);letter-spacing:.5px;text-transform:uppercase" data-s="passport.sortBy">Sort by</span>
-    <button class="btn ${isCatMod ? 'btn-primary' : 'btn-secondary'}" style="font-size:10px;padding:3px 10px" data-admin-click="ppSetSortMode" data-admin-arg="cat-mod" data-s="passport.sortCatMod">Category → Module</button>
-    <button class="btn ${!isCatMod ? 'btn-primary' : 'btn-secondary'}" style="font-size:10px;padding:3px 10px" data-admin-click="ppSetSortMode" data-admin-arg="mod-cat" data-s="passport.sortModCat">Module → Category</button>
+    <button class="btn ${isCatMod ? 'btn-primary' : 'btn-secondary'} btn-sm" data-admin-click="ppSetSortMode" data-admin-arg="cat-mod" data-s="passport.sortCatMod">Category → Module</button>
+    <button class="btn ${!isCatMod ? 'btn-primary' : 'btn-secondary'} btn-sm" data-admin-click="ppSetSortMode" data-admin-arg="mod-cat" data-s="passport.sortModCat">Module → Category</button>
   </div>`;
 
   (def.passports || []).forEach((p, pi) => {
@@ -120,7 +120,7 @@ function drawPassportEditor() {
             ${s('passport.promotesTo', { cert: esc(promoteId) })} (${esc(p.fromSub || 'restricted')} → ${esc(p.toSub || 'released')})
           </div>
         </div>
-        <button class="btn btn-secondary" style="font-size:10px;padding:4px 10px;white-space:nowrap" data-admin-click="openPassportSettingsModal" data-admin-arg="${pi}" data-s="passport.editSettings">Edit passport settings</button>
+        <button class="btn btn-secondary btn-sm" style="white-space:nowrap" data-admin-click="openPassportSettingsModal" data-admin-arg="${pi}" data-s="passport.editSettings">Edit passport settings</button>
       </div>`;
 
     if (isCatMod) {
@@ -135,7 +135,7 @@ function drawPassportEditor() {
               <div style="font-weight:600;font-size:12px">${esc(catNameEN)}${catNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(catNameIS)}</span>` : ''}</div>
               <div style="font-size:9px;color:var(--muted)">${esc(cat.id)}</div>
             </div>
-            <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-s="passport.editCategory">Edit category</button>
+            <button class="btn btn-secondary btn-sm" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-s="passport.editCategory">Edit category</button>
           </div>`;
 
         const items = (cat.items || []).map((it, ii) => ({ it, ii }));
@@ -154,7 +154,7 @@ function drawPassportEditor() {
         }
 
         html += `<div style="margin-top:8px">
-          <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="null" data-s="passport.addItem">+ Add item</button>
+          <button class="btn btn-secondary btn-sm" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="null" data-s="passport.addItem">+ Add item</button>
         </div></div>`;
       });
     } else {
@@ -202,7 +202,7 @@ function drawPassportEditor() {
               <div style="flex:1;min-width:0">
                 <div style="font-weight:600;font-size:11px">${esc(catNameEN)}${catNameIS ? ` <span style="color:var(--muted);font-weight:400">/ ${esc(catNameIS)}</span>` : ''}</div>
               </div>
-              <button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-s="passport.editCategory">Edit category</button>
+              <button class="btn btn-secondary btn-sm" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-s="passport.editCategory">Edit category</button>
             </div>`;
           const entries = byCat[ci].slice().sort((a, b) =>
             String(a.it.name?.EN || '').localeCompare(String(b.it.name?.EN || '')));
@@ -222,19 +222,19 @@ function drawPassportEditor() {
         <div style="display:flex;gap:6px;flex-wrap:wrap">`;
       (p.categories || []).forEach((cat, ci) => {
         const catNameEN = cat.name?.EN || cat.id;
-        html += `<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="null">+ ${esc(catNameEN)}</button>`;
+        html += `<button class="btn btn-secondary btn-sm" data-admin-click="openPassportItemModal" data-admin-arg="${pi}" data-admin-arg2="${ci}" data-admin-arg3="null">+ ${esc(catNameEN)}</button>`;
       });
       html += `</div></div>`;
     }
 
     html += `<div style="margin-top:12px">
-      <button class="btn btn-secondary" style="font-size:10px;padding:3px 10px" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="null" data-s="passport.addCategory">+ Add category</button>
+      <button class="btn btn-secondary btn-sm" data-admin-click="openPassportCategoryModal" data-admin-arg="${pi}" data-admin-arg2="null" data-s="passport.addCategory">+ Add category</button>
     </div>`;
     html += '</div>';
   });
 
   html += `<div style="margin-top:14px;display:flex;gap:8px;align-items:center">
-    <button class="btn btn-primary" style="font-size:11px" data-admin-click="ppSaveDef" data-s="passport.save">Save changes</button>
+    <button class="btn btn-primary btn-sm" data-admin-click="ppSaveDef" data-s="passport.save">Save changes</button>
     <span id="ppDirtyMark" style="font-size:10px;color:var(--brass-fg)">${_passportDirty ? '● unsaved' : ''}</span>
   </div>`;
   card.innerHTML = html;

--- a/admin/payroll/payroll.js
+++ b/admin/payroll/payroll.js
@@ -78,7 +78,7 @@ function prEmpRowHTML(m,emp,act){
   h+='<span class="emp-name">'+_e(m.name)+'</span>';
   h+='<span class="emp-kt">'+_e(m.kennitala||'')+'</span>';
   h+='<span class="'+(act?'pr-badge-on':'pr-badge-off')+'" data-s="'+(act?'payroll.tabEmployees':'payroll.notEnabled')+'"></span>';
-  h+='<button class="btn btn-secondary" style="font-size:11px;padding:3px 10px" data-pr-click="prToggleEdit" data-pr-arg="'+mid+'" data-s="btn.edit"></button>';
+  h+='<button class="btn btn-secondary btn-sm" data-pr-click="prToggleEdit" data-pr-arg="'+mid+'" data-s="btn.edit"></button>';
   h+='</div>';
   h+='<div id="empedit_'+mid+'" class="hidden" style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:8px">';
   h+='<div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">';
@@ -90,8 +90,8 @@ function prEmpRowHTML(m,emp,act){
   h+='<div class="field"><label data-s="payroll.titleField"></label><input id="prTitle_'+mid+'" type="text" value="'+_e(emp&&emp.title||'')+'"></div>';
   h+='</div>';
   h+='<div style="display:flex;gap:8px;margin-top:10px">';
-  h+='<button class="btn btn-primary" style="font-size:11px" data-pr-click="prSaveEmployee" data-pr-arg="'+mid+'" data-s="btn.save"></button>';
-  h+='<button class="btn btn-secondary" style="font-size:11px" data-pr-click="prToggleEdit" data-pr-arg="'+mid+'" data-s="btn.cancel"></button>';
+  h+='<button class="btn btn-primary btn-sm" data-pr-click="prSaveEmployee" data-pr-arg="'+mid+'" data-s="btn.save"></button>';
+  h+='<button class="btn btn-secondary btn-sm" data-pr-click="prToggleEdit" data-pr-arg="'+mid+'" data-s="btn.cancel"></button>';
   h+='<span id="prMsg_'+mid+'" style="font-size:11px;margin-left:4px"></span>';
   h+='</div></div>';
   return h;
@@ -309,7 +309,7 @@ function prRenderList(){
       var edited=e.originalTimestamp?('<span class="edited-badge">'+s('lbl.edited')+'</span>'):'';
       var edata=JSON.stringify(e).replace(/"/g,'&quot;');
       return '<tr><td>'+dateStr+'</td><td>'+inT+'</td><td>'+outT+edited+'</td><td>'+dur+'</td><td>'+srcLabel+'</td>'
-        +'<td style="text-align:right"><button class="btn btn-secondary" style="font-size:10px;padding:2px 7px"'
+        +'<td style="text-align:right"><button class="btn btn-secondary btn-sm"'
         +' data-pr-open-ds data-e="'+edata+'" data-s="btn.edit"></button></td></tr>';
     }).join('');
     return '<div><div class="ts-group-header" style="font-weight:600;font-size:13px;margin-bottom:6px;display:flex;justify-content:space-between">'

--- a/admin/volunteers.js
+++ b/admin/volunteers.js
@@ -77,7 +77,7 @@ function _volPastToggleHtml(count) {
     ? s('admin.volHidePast')
     : s('admin.volShowPast').replace('{n}', count);
   return '<div style="text-align:center;padding:10px 0 2px">'
-    + '<button class="btn btn-secondary" style="font-size:10px" data-admin-click="_volTogglePast">' + esc(lbl) + '</button>'
+    + '<button class="btn btn-secondary btn-sm" data-admin-click="_volTogglePast">' + esc(lbl) + '</button>'
     + '</div>';
 }
 

--- a/captain/captain.js
+++ b/captain/captain.js
@@ -303,7 +303,7 @@ function renderBoats() {
     return false;
   });
 
-  var addBtn = '<div style="margin-top:10px"><button class="btn btn-secondary" style="font-size:12px" data-cq-click="openBoatModal">+ ' + esc(s('admin.boatModal.add')) + '</button></div>';
+  var addBtn = '<div style="margin-top:10px"><button class="btn btn-secondary btn-sm" data-cq-click="openBoatModal">+ ' + esc(s('admin.boatModal.add')) + '</button></div>';
   if (!myBoats.length) { el.innerHTML = '<div class="empty-note">' + s('cq.noBoats') + '</div>' + addBtn; return; }
   el.innerHTML = myBoats.map(b => {
     var isOos = boolVal(b.oos);
@@ -1036,7 +1036,7 @@ function renderReservationList(boat) {
   var actEl = document.getElementById('bReservationActions');
   if (!boat || !boat.reservations || !boat.reservations.length) {
     el.innerHTML = '';
-    actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" data-cq-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
+    actEl.innerHTML = '<button class="btn btn-secondary btn-sm" data-cq-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
     return;
   }
   el.innerHTML = boat.reservations.map(function(r) {
@@ -1046,7 +1046,7 @@ function renderReservationList(boat) {
       + '<button style="font-size:10px;background:none;border:none;color:var(--red);cursor:pointer" data-cq-click="removeBmResFromModal" data-cq-arg="'+esc(r.id)+'">&times;</button>'
       + '</div>';
   }).join('');
-  actEl.innerHTML = '<button class="btn btn-secondary" style="font-size:11px" data-cq-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
+  actEl.innerHTML = '<button class="btn btn-secondary btn-sm" data-cq-click="showResForm">' + esc(s('boat.addReservation')) + '</button>';
 }
 
 function showResForm() {

--- a/captain/index.html
+++ b/captain/index.html
@@ -73,7 +73,7 @@
   <div class="cq-section" id="sectCredentials">
     <div class="cq-section-hdr" data-s="cq.assignCredTitle"></div>
     <div class="mb-10">
-      <button class="btn btn-primary text-xs" style="padding:6px 14px" data-cq-click="openMemberCertModal" data-s="cq.assignCred"></button>
+      <button class="btn btn-primary btn-sm" data-cq-click="openMemberCertModal" data-s="cq.assignCred"></button>
     </div>
   </div>
 
@@ -84,12 +84,12 @@
       <label data-s="slot.filterBoat" class="text-10 text-muted" style="text-transform:uppercase;letter-spacing:.5px" for="cqResBoat">Boat</label>
       <select id="cqResBoat" data-cq-change="loadCqSlots" class="bg-surface border-muted rounded-6 font-inherit text-xs" style="color:var(--text);padding:4px 8px"></select>
       <div class="slot-week-nav">
-        <button class="btn btn-secondary" data-cq-click="shiftCqWeek" data-cq-arg="-1">&larr;</button>
+        <button class="btn btn-secondary btn-sm" data-cq-click="shiftCqWeek" data-cq-arg="-1">&larr;</button>
         <span id="cqWeekLabel" class="week-label"></span>
-        <button class="btn btn-secondary" data-cq-click="shiftCqWeek" data-cq-arg="1">&rarr;</button>
-        <button class="btn btn-secondary" data-cq-click="cqWeekToday" data-s="slot.today">Today</button>
-        <button class="btn btn-primary" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" data-cq-click="openCreateSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
-        <button class="btn btn-primary" data-s="slot.bulkBook" data-s-attr="title" data-cq-click="openBulkSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
+        <button class="btn btn-secondary btn-sm" data-cq-click="shiftCqWeek" data-cq-arg="1">&rarr;</button>
+        <button class="btn btn-secondary btn-sm" data-cq-click="cqWeekToday" data-s="slot.today">Today</button>
+        <button class="btn btn-primary btn-sm" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" data-cq-click="openCreateSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
+        <button class="btn btn-primary btn-sm" data-s="slot.bulkBook" data-s-attr="title" data-cq-click="openBulkSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
       </div>
       <div class="d-flex items-center gap-6 ml-auto">
         <label for="cqBookingColor" class="text-10 text-muted" style="text-transform:uppercase;letter-spacing:.5px" data-s="cq.bookingColor">My booking color</label>
@@ -151,7 +151,7 @@
       </div>
       <textarea class="cq-bio-area" id="bioText" maxlength="500"></textarea>
       <div class="d-flex items-center mt-8" style="justify-content:flex-end">
-        <button class="btn btn-primary text-xs" style="padding:6px 14px" data-cq-click="saveBio" data-s="btn.save"></button>
+        <button class="btn btn-primary btn-sm" data-cq-click="saveBio" data-s="btn.save"></button>
       </div>
     </div>
   </div>

--- a/coxswain/coxswain.js
+++ b/coxswain/coxswain.js
@@ -262,10 +262,10 @@ function renderCrewCard(c) {
   if (isMine) {
     actionsHtml = '<div class="cb-actions">';
     if (c.status === 'forming' && (c.visibility || 'open') === 'invite_only') {
-      actionsHtml += '<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-cx-click="openCrewInvModal" data-cx-arg="'+esc(c.id)+'">' + s('cox.inviteMember') + '</button>';
+      actionsHtml += '<button class="btn btn-secondary btn-sm" data-cx-click="openCrewInvModal" data-cx-arg="'+esc(c.id)+'">' + s('cox.inviteMember') + '</button>';
     }
-    actionsHtml += '<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-cx-click="leaveCrewConfirm" data-cx-arg="'+esc(c.id)+'">' + s('cox.leave') + '</button>';
-    actionsHtml += '<button class="btn btn-secondary" style="font-size:10px;padding:3px 8px" data-cx-click="disbandCrewConfirm" data-cx-arg="'+esc(c.id)+'">' + s('cox.disband') + '</button>';
+    actionsHtml += '<button class="btn btn-secondary btn-sm" data-cx-click="leaveCrewConfirm" data-cx-arg="'+esc(c.id)+'">' + s('cox.leave') + '</button>';
+    actionsHtml += '<button class="btn btn-secondary btn-sm" data-cx-click="disbandCrewConfirm" data-cx-arg="'+esc(c.id)+'">' + s('cox.disband') + '</button>';
     actionsHtml += '</div>';
   }
 
@@ -316,8 +316,8 @@ function renderCrewInvites() {
         + '<div style="font-size:12px;font-weight:500">' + esc(inv.crewName || '') + '</div>'
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px">' + s('cox.invitedBy') + ': ' + esc(inv.fromName) + ' · ' + s('cox.boat') + ' ' + esc(inv.pairId || '').replace('pair_', '') + '</div>'
         + '<div style="display:flex;gap:6px;margin-top:8px">'
-          + '<button class="btn btn-primary" style="font-size:10px;padding:3px 10px" data-cx-click="respondInvite" data-cx-arg="'+esc(inv.id)+'" data-cx-arg2="accepted">' + s('cox.accept') + '</button>'
-          + '<button class="btn btn-secondary" style="font-size:10px;padding:3px 10px" data-cx-click="respondInvite" data-cx-arg="'+esc(inv.id)+'" data-cx-arg2="rejected">' + s('cox.reject') + '</button>'
+          + '<button class="btn btn-primary btn-sm" data-cx-click="respondInvite" data-cx-arg="'+esc(inv.id)+'" data-cx-arg2="accepted">' + s('cox.accept') + '</button>'
+          + '<button class="btn btn-secondary btn-sm" data-cx-click="respondInvite" data-cx-arg="'+esc(inv.id)+'" data-cx-arg2="rejected">' + s('cox.reject') + '</button>'
         + '</div>'
       + '</div>';
     }).join('');

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -99,7 +99,7 @@
         <div class="d-flex gap-8 items-center flex-wrap">
           <label class="text-10 text-muted" style="letter-spacing:.5px" data-s="passport.viewMember" for="ppMemberSearch">VIEW MEMBER</label>
           <input type="text" id="ppMemberSearch" autocomplete="off" placeholder="" data-cx-input-val="ppSearchMember" class="text-xs flex-1" style="min-width:160px">
-          <button class="btn btn-secondary text-10" style="padding:4px 10px" data-cx-click="ppViewSelf" data-s="passport.viewSelf">My passport</button>
+          <button class="btn btn-secondary btn-sm" data-cx-click="ppViewSelf" data-s="passport.viewSelf">My passport</button>
         </div>
         <div id="ppMemberSuggestions" class="suggest-drop hidden border-muted rounded-6 mt-2" style="position:absolute;left:0;right:0;top:100%;z-index:10;background:var(--card);max-height:240px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.2)"></div>
         <div id="ppCurrentTarget" class="text-10 text-brass mt-4"></div>
@@ -111,8 +111,8 @@
       <div id="passportSignerBanner" class="hidden text-10 text-brass bg-surface border-muted rounded-6 mb-10" style="padding:6px 10px" data-s="passport.signerMode">Sign-off mode — tap items to sign.</div>
       <div id="passportSortBar" class="d-flex gap-6 items-center mb-10 flex-wrap">
         <span class="text-9 text-muted" style="letter-spacing:.5px;text-transform:uppercase" data-s="passport.sortBy">Sort by</span>
-        <button class="btn btn-secondary text-10" id="ppSortCatMod" style="padding:3px 8px" data-cx-click="ppSetSortMode" data-cx-arg="cat-mod" data-s="passport.sortCatMod">Category → Module</button>
-        <button class="btn btn-secondary text-10" id="ppSortModCat" style="padding:3px 8px" data-cx-click="ppSetSortMode" data-cx-arg="mod-cat" data-s="passport.sortModCat">Module → Category</button>
+        <button class="btn btn-secondary btn-sm" id="ppSortCatMod" data-cx-click="ppSetSortMode" data-cx-arg="cat-mod" data-s="passport.sortCatMod">Category → Module</button>
+        <button class="btn btn-secondary btn-sm" id="ppSortModCat" data-cx-click="ppSetSortMode" data-cx-arg="mod-cat" data-s="passport.sortModCat">Module → Category</button>
       </div>
       <div id="passportCategories"><div class="empty-note" data-s="lbl.loading"></div></div>
     </div>

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -93,7 +93,7 @@
             <label id="boatLabel" for="iDesc"></label>
             <div class="d-flex gap-6 items-center">
               <select id="iBoat" class="flex-1" style="min-width:0"><option value="" id="iBoatNone"></option></select>
-              <button type="button" class="btn btn-secondary text-nowrap text-10" id="iBoatScanBtn" data-inc-click="scanBoatForIncident" style="padding:6px 10px" data-s="qr.scanBtn"></button>
+              <button type="button" class="btn btn-secondary btn-sm text-nowrap" id="iBoatScanBtn" data-inc-click="scanBoatForIncident" data-s="qr.scanBtn"></button>
             </div>
           </div>
         </div>

--- a/member/member.js
+++ b/member/member.js
@@ -308,7 +308,7 @@ function renderNonClubLaunchForm() {
     '<div class="field"><label>'+s('lbl.location')+'</label>'+
     '<div style="display:flex;gap:6px;align-items:center">'+
       '<input type="text" id="launchLocFree" placeholder="'+s('logbook.locationNamePh')+'" autocomplete="off" style="flex:1">'+
-      '<button type="button" class="btn btn-secondary" data-member-click="useMyLocation" data-member-arg="launchLocFree" data-member-arg2="launchLocGeoStatus" style="white-space:nowrap;font-size:10px;padding:6px 10px">📍 '+s('logbook.useMyLocation')+'</button>'+
+      '<button type="button" class="btn btn-secondary btn-sm" data-member-click="useMyLocation" data-member-arg="launchLocFree" data-member-arg2="launchLocGeoStatus" style="white-space:nowrap">📍 '+s('logbook.useMyLocation')+'</button>'+
     '</div>'+
     '<div id="launchLocGeoStatus" class="text-xs text-muted" style="margin-top:4px;display:none"></div></div>'+
     '<div class="grid2 mb-12 gap-10">'+
@@ -317,9 +317,9 @@ function renderNonClubLaunchForm() {
       '<div class="field"><label>'+s('staff.coForm.estReturn')+'</label>'+
       '<input type="text" id="launchReturnBy" placeholder="HH:MM" maxlength="5" style="width:80px" data-member-time-format>'+
       '<div class="flex-center gap-4" style="margin-top:5px">'+
-        '<button type="button" class="btn btn-secondary" style="font-size:10px;padding:2px 7px" data-member-click="_addToLaunchOut" data-member-arg="60">+1h</button>'+
-        '<button type="button" class="btn btn-secondary" style="font-size:10px;padding:2px 7px" data-member-click="_addToLaunchOut" data-member-arg="90">+1.5h</button>'+
-        '<button type="button" class="btn btn-secondary" style="font-size:10px;padding:2px 7px" data-member-click="_addToLaunchOut" data-member-arg="120">+2h</button>'+
+        '<button type="button" class="btn btn-secondary btn-sm" data-member-click="_addToLaunchOut" data-member-arg="60">+1h</button>'+
+        '<button type="button" class="btn btn-secondary btn-sm" data-member-click="_addToLaunchOut" data-member-arg="90">+1.5h</button>'+
+        '<button type="button" class="btn btn-secondary btn-sm" data-member-click="_addToLaunchOut" data-member-arg="120">+2h</button>'+
       '</div></div>'+
     '</div>'+
     '<div class="field"><label>'+s('staff.coForm.crew')+'</label>'+
@@ -367,9 +367,9 @@ function renderLaunchForm(boat) {
       '<div class="field"><label>'+s('staff.coForm.estReturn')+'</label>'+
       '<input type="text" id="launchReturnBy" placeholder="HH:MM" maxlength="5" style="width:80px" data-member-time-format>'+
       '<div class="flex-center gap-4" style="margin-top:5px">'+
-        '<button type="button" class="btn btn-secondary" style="font-size:10px;padding:2px 7px" data-member-click="_addToLaunchOut" data-member-arg="60">+1h</button>'+
-        '<button type="button" class="btn btn-secondary" style="font-size:10px;padding:2px 7px" data-member-click="_addToLaunchOut" data-member-arg="90">+1.5h</button>'+
-        '<button type="button" class="btn btn-secondary" style="font-size:10px;padding:2px 7px" data-member-click="_addToLaunchOut" data-member-arg="120">+2h</button>'+
+        '<button type="button" class="btn btn-secondary btn-sm" data-member-click="_addToLaunchOut" data-member-arg="60">+1h</button>'+
+        '<button type="button" class="btn btn-secondary btn-sm" data-member-click="_addToLaunchOut" data-member-arg="90">+1.5h</button>'+
+        '<button type="button" class="btn btn-secondary btn-sm" data-member-click="_addToLaunchOut" data-member-arg="120">+2h</button>'+
       '</div></div>'+
     '</div>'+
     '<div class="field"><label>'+s('staff.coForm.crew')+'</label>'+
@@ -815,8 +815,8 @@ function renderLandingChecklist() {
     (items.length?'<div class="section-label mb-10">LANDING — '+_fmtCatLabel(cat)+'</div>'+checks:'')+
     '<div id="landCheckErr" class="text-sm text-red" style="display:none;margin:6px 0">'+s('member.confirmAllItems')+'</div>'+
     '<div style="display:flex;gap:8px;margin:12px 0">'+
-      '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--orange);border-color:var(--orange)55" data-member-click="openInlineReport" data-member-arg="damage"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;vertical-align:-.125em"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z"/></svg> '+s('member.reportDamage')+'</button>'+
-      '<button type="button" class="btn btn-secondary" style="flex:1;font-size:11px;color:var(--red);border-color:var(--red)55" data-member-click="openInlineReport" data-member-arg="incident"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;vertical-align:-.125em"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg> '+s('member.reportIncident')+'</button>'+
+      '<button type="button" class="btn btn-secondary btn-sm" style="flex:1;color:var(--orange);border-color:var(--orange)55" data-member-click="openInlineReport" data-member-arg="damage"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;vertical-align:-.125em"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z"/></svg> '+s('member.reportDamage')+'</button>'+
+      '<button type="button" class="btn btn-secondary btn-sm" style="flex:1;color:var(--red);border-color:var(--red)55" data-member-click="openInlineReport" data-member-arg="incident"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:1em;height:1em;vertical-align:-.125em"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg> '+s('member.reportIncident')+'</button>'+
     '</div>'+
     '<div id="reportFlagNote" style="display:none;font-size:11px;padding:5px 8px;border-radius:4px;background:var(--surface);margin-bottom:8px"></div>'+
     (((returnCo.crew||1)>1&&/^(keelboat|dinghy)$/.test((returnCo.boatCategory||'').toLowerCase()))?'<div id="helmSection" style="margin-bottom:14px">'+
@@ -963,7 +963,7 @@ function _maintFormHtml() {
     +'<div class="field hidden" id="irBoatField"><label>Boat</label>'
       +'<div style="display:flex;gap:6px;align-items:center">'
         +'<select id="irBoat" style="flex:1;min-width:0"><option value="">Select boat...</option>'+boatOpts+'</select>'
-        +'<button type="button" class="btn btn-secondary" data-member-click="scanBoatForIssue" data-member-arg="irBoat" style="white-space:nowrap;font-size:10px;padding:6px 10px">'+s('qr.scanBtn')+'</button>'
+        +'<button type="button" class="btn btn-secondary btn-sm" data-member-click="scanBoatForIssue" data-member-arg="irBoat" style="white-space:nowrap">'+s('qr.scanBtn')+'</button>'
       +'</div>'
     +'</div>'
     +'<div class="field hidden" id="irItemField"><label id="irItemLabel">Item</label><input type="text" id="irItem" placeholder="e.g. Wetsuit #3"></div>'
@@ -1000,7 +1000,7 @@ function _incidentFormHtml() {
     +'<div class="field"><label>Boat involved (optional)</label>'
       +'<div style="display:flex;gap:6px;align-items:center">'
         +'<select id="irIncBoat" style="flex:1;min-width:0"><option value="">None</option>'+boatOpts+'</select>'
-        +'<button type="button" class="btn btn-secondary" data-member-click="scanBoatForIssue" data-member-arg="irIncBoat" style="white-space:nowrap;font-size:10px;padding:6px 10px">'+s('qr.scanBtn')+'</button>'
+        +'<button type="button" class="btn btn-secondary btn-sm" data-member-click="scanBoatForIssue" data-member-arg="irIncBoat" style="white-space:nowrap">'+s('qr.scanBtn')+'</button>'
       +'</div>'
     +'</div>'
     +'<div class="field"><label>Description <span style="color:var(--red)">*</span></label><textarea id="irDesc" rows="3" placeholder="Describe what happened..." style="width:100%;resize:none;font-size:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:8px 10px;font-family:inherit;box-sizing:border-box"></textarea></div>'

--- a/shared/boat-modal.js
+++ b/shared/boat-modal.js
@@ -122,8 +122,8 @@
         </div>
         <div class="field"><label data-s="cq.resNote">Note</label><input type="text" id="bResNote"></div>
         <div class="btn-row">
-          <button class="btn btn-secondary" style="font-size:11px" data-bm-click="cancelResForm" data-s="btn.cancel"></button>
-          <button class="btn btn-primary" style="font-size:11px" data-bm-click="saveResFromModal" data-s="btn.save"></button>
+          <button class="btn btn-secondary btn-sm" data-bm-click="cancelResForm" data-s="btn.cancel"></button>
+          <button class="btn btn-primary btn-sm" data-bm-click="saveResFromModal" data-s="btn.save"></button>
         </div>
       </div>
       <div id="bReservationActions"></div>

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -492,12 +492,12 @@ function renderCheckoutCard(co, opts) {
   let actionsHtml = "";
   if (staffView && (opts.onCheckIn || opts.onDelete)) {
     actionsHtml = `<div style="display:flex;gap:6px;margin-top:10px">`
-                + (opts.onCheckIn ? `<button class="btn btn-primary" style="font-size:11px;flex:1" data-boat-action="check-in" data-boat-fn="${opts.onCheckIn}" data-co-id="${co.id}">✓ ${_besc(s("fleet.checkIn"))}</button>` : "")
-                + (opts.onDelete  ? `<button class="btn btn-secondary" style="font-size:11px;padding:6px 12px;color:var(--muted)" data-boat-action="delete" data-boat-fn="${opts.onDelete}" data-co-id="${co.id}">× ${_besc(s("fleet.delete"))}</button>` : "")
+                + (opts.onCheckIn ? `<button class="btn btn-primary btn-sm" style="flex:1" data-boat-action="check-in" data-boat-fn="${opts.onCheckIn}" data-co-id="${co.id}">✓ ${_besc(s("fleet.checkIn"))}</button>` : "")
+                + (opts.onDelete  ? `<button class="btn btn-secondary btn-sm" style="color:var(--muted)" data-boat-action="delete" data-boat-fn="${opts.onDelete}" data-co-id="${co.id}">× ${_besc(s("fleet.delete"))}</button>` : "")
                 + `</div>`;
   } else if (!staffView && isMe && (opts.onReturn || opts.onDelete)) {
     actionsHtml = `<div style="display:flex;gap:6px;margin-top:8px">`
-                + (opts.onReturn ? `<button class="btn btn-secondary" style="font-size:10px;padding:4px 9px" data-boat-action="return" data-boat-fn="${opts.onReturn}" data-co-id="${co.id}">${_besc(s("fleet.checkIn"))}</button>` : "")
+                + (opts.onReturn ? `<button class="btn btn-secondary btn-sm" data-boat-action="return" data-boat-fn="${opts.onReturn}" data-co-id="${co.id}">${_besc(s("fleet.checkIn"))}</button>` : "")
                 + (opts.onDelete ? `<button class="btn-ghost" style="font-size:10px;padding:4px 6px;color:var(--muted)" title="${_besc(s("fleet.delete"))}" data-boat-action="delete" data-boat-fn="${opts.onDelete}" data-co-id="${co.id}">×</button>` : "")
                 + `</div>`;
   }

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -190,7 +190,7 @@ function maintOpenDetail(r, currentUser) {
           </div>`).join('')}
         ${!resolved ? `<div style="display:flex;gap:6px;align-items:center;margin-top:8px">
           <input id="mdMaterialInput" type="text" placeholder="${s('maint.addMaterialPh')}" style="flex:1">
-          <button id="mdAddMaterialBtn" class="btn btn-secondary" style="font-size:11px;padding:4px 12px">${s('maint.addMaterialBtn')}</button>
+          <button id="mdAddMaterialBtn" class="btn btn-secondary btn-sm">${s('maint.addMaterialBtn')}</button>
         </div>` : ''}
       </div>` : '';
 
@@ -210,8 +210,8 @@ function maintOpenDetail(r, currentUser) {
         <span class="badge" style="background:var(--brass)22;color:var(--brass-fg);border:1px solid var(--brass)44">🧵 ${s('maint.saumaBadge')}</span>
         ${isOnHold ? `<span class="badge" style="background:var(--yellow)22;color:var(--yellow);border:1px solid var(--yellow)44">⏸ ${s('maint.onHoldBadge')}</span>` : ''}
         ${r.verkstjori ? `<span style="font-size:12px;color:var(--muted)">${s('maint.verkstjoriPrefix')} <strong style="color:var(--text)">${esc(r.verkstjori)}</strong></span>` : `<span style="font-size:12px;color:var(--muted);font-style:italic">${s('maint.noVerkstjori')}</span>`}
-        ${!r.verkstjori && !resolved ? `<button id="mdAdoptBtn" class="btn btn-secondary" style="font-size:11px;padding:4px 12px">${s('maint.adoptProject')}</button>` : ''}
-        ${_mKt && !resolved ? `<button id="mdFollowBtn" class="btn btn-secondary" style="font-size:11px;padding:4px 12px">${isFollowing ? s('sauma.unfollow') : s('sauma.follow')}</button>` : ''}
+        ${!r.verkstjori && !resolved ? `<button id="mdAdoptBtn" class="btn btn-secondary btn-sm">${s('maint.adoptProject')}</button>` : ''}
+        ${_mKt && !resolved ? `<button id="mdFollowBtn" class="btn btn-secondary btn-sm">${isFollowing ? s('sauma.unfollow') : s('sauma.follow')}</button>` : ''}
       </div>` : ''}
       <div class="req-meta" style="margin-bottom:12px;font-size:12px;color:var(--muted)">
         ${r.reportedBy ? `<span>${s('maint.reportedByLabel')} <span style="color:var(--text);font-weight:500">${esc(r.reportedBy)}</span></span>` : ''}
@@ -228,16 +228,16 @@ function maintOpenDetail(r, currentUser) {
           <label style="cursor:pointer;font-size:16px;padding:4px;color:var(--muted);flex-shrink:0" title="${s('maint.attachPhoto')}">📷
             <input id="mdCommentPhoto" type="file" accept="image/*" style="display:none">
           </label>
-          <button id="mdCommentBtn" class="btn btn-secondary" style="font-size:12px">${s('maint.postBtn')}</button>
+          <button id="mdCommentBtn" class="btn btn-secondary btn-sm">${s('maint.postBtn')}</button>
         </div>
         <div id="mdCommentPhotoPreview" style="margin-top:6px"></div>
       </div>
-      ${isSauma && !boolVal(r.approved) ? `<div style="margin-bottom:10px;padding:8px 12px;border-radius:6px;background:var(--brass)11;border:1px solid var(--brass)44;font-size:12px;color:var(--brass-fg)">⏳ ${s('maint.pendingReview')}<button id="mdApproveBtn" class="btn btn-primary" style="font-size:11px;padding:4px 14px;margin-left:12px">${s('maint.approveBtn')}</button></div>` : ''}
+      ${isSauma && !boolVal(r.approved) ? `<div style="margin-bottom:10px;padding:8px 12px;border-radius:6px;background:var(--brass)11;border:1px solid var(--brass)44;font-size:12px;color:var(--brass-fg)">⏳ ${s('maint.pendingReview')}<button id="mdApproveBtn" class="btn btn-primary btn-sm" style="margin-left:12px">${s('maint.approveBtn')}</button></div>` : ''}
       <div class="req-actions" style="margin-top:10px;display:flex;gap:8px;align-items:center">
-        <button id="mdDeleteBtn" class="btn btn-secondary" style="font-size:12px;color:var(--red)">${s('maint.deleteBtn')}</button>
-        ${typeof window.maintOpenEdit === 'function' ? `<button id="mdEditBtn" class="btn btn-secondary" style="font-size:12px;padding:7px 14px">${s('btn.edit')}</button>` : ''}
-        ${isSauma && boolVal(r.approved) ? `<button id="mdHoldBtn" class="btn btn-secondary" style="font-size:12px;padding:7px 14px;margin-left:auto">${isOnHold ? '▶ '+s('maint.resumeBtn') : '⏸ '+s('maint.putOnHold')}</button>` : ''}
-        <button id="mdResolveBtn" class="btn btn-primary" style="font-size:12px;padding:7px 16px${isSauma && boolVal(r.approved) ? '' : ';margin-left:auto'}">${isSauma ? s('maint.markCompleted') : s('maint.markResolved2')}</button>
+        <button id="mdDeleteBtn" class="btn btn-secondary btn-sm" style="color:var(--red)">${s('maint.deleteBtn')}</button>
+        ${typeof window.maintOpenEdit === 'function' ? `<button id="mdEditBtn" class="btn btn-secondary btn-sm">${s('btn.edit')}</button>` : ''}
+        ${isSauma && boolVal(r.approved) ? `<button id="mdHoldBtn" class="btn btn-secondary btn-sm" style="margin-left:auto">${isOnHold ? '▶ '+s('maint.resumeBtn') : '⏸ '+s('maint.putOnHold')}</button>` : ''}
+        <button id="mdResolveBtn" class="btn btn-primary btn-sm"${isSauma && boolVal(r.approved) ? '' : ' style="margin-left:auto"'}>${isSauma ? s('maint.markCompleted') : s('maint.markResolved2')}</button>
       </div>`
       : `<div style="margin-top:10px;font-size:11px;color:var(--muted)">${s(isSauma ? 'maint.completedBy' : 'maint.resolvedBy', { date: sstr(r.resolvedAt).slice(0,10), by: esc(r.resolvedBy||'') })}</div>`}
     `;

--- a/shared/payroll.js
+++ b/shared/payroll.js
@@ -471,8 +471,8 @@ function punchClockWidget(el, employeeId, opts) {
       + '<input type="datetime-local" id="pcEditTs" value="' + localDt + '">'
       + '<input type="text" id="pcEditNote" placeholder="Note (optional)">'
       + '<div style="display:flex;gap:6px">'
-      + '<button class="btn btn-primary" style="flex:1;font-size:11px" data-pc-action="save-edit" data-pc-id="' + id + '" data-pc-emp="' + empId + '">Save</button>'
-      + '<button class="btn btn-secondary" style="font-size:11px" data-pc-clear="pcEditArea">Cancel</button>'
+      + '<button class="btn btn-primary btn-sm" style="flex:1" data-pc-action="save-edit" data-pc-id="' + id + '" data-pc-emp="' + empId + '">Save</button>'
+      + '<button class="btn btn-secondary btn-sm" data-pc-clear="pcEditArea">Cancel</button>'
       + '</div></div>';
   };
 

--- a/shared/slot-modal.js
+++ b/shared/slot-modal.js
@@ -55,7 +55,7 @@
       +     (c.showNote ? '<div class="field"><label data-s="slot.note"></label><input type="text" id="smNote" style="font-size:11px"></div>' : '')
       +     (c.showBookedInfo ? '<div id="slotBookedInfo" class="hidden" style="font-size:11px;color:var(--green);margin-bottom:8px"></div>' : '')
       +     '<div class="btn-row">'
-      +       (deleteFn ? '<button class="btn btn-danger hidden" id="smDeleteBtn" style="font-size:11px" data-sm-fn="' + deleteFn + '" data-s="btn.delete"></button>' : '')
+      +       (deleteFn ? '<button class="btn btn-danger hidden" id="smDeleteBtn" data-sm-fn="' + deleteFn + '" data-s="btn.delete"></button>' : '')
       +       '<button class="btn btn-secondary" data-sm-close="slotModal" data-s="btn.cancel"></button>'
       +       '<button class="btn btn-primary" data-sm-fn="' + saveFn + '" data-s="' + saveKey + '"></button>'
       +     '</div>'

--- a/shared/style.css
+++ b/shared/style.css
@@ -434,6 +434,9 @@ textarea { min-height: 70px; }
 .btn-ghost:hover        { color: var(--navy); border-color: var(--navy); background: color-mix(in srgb, var(--navy) 8%, transparent); }
 .btn-ghost.danger:hover { color: var(--red);  border-color: var(--red);  background: color-mix(in srgb, var(--red) 8%, transparent); }
 
+/* Compact modifier — for section-level CTAs, slot-calendar nav, row actions, etc. */
+.btn-sm { padding: 6px 12px; font-size: 11px; min-height: 0; }
+
 .btn-row { display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap; }
 .btn-row .btn { flex: 1; text-align: center; }
 
@@ -1112,7 +1115,6 @@ textarea { min-height: 70px; }
 
 /* ── Slot-calendar week navigation (captain/coxswain/admin) ── */
 .slot-week-nav { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-.slot-week-nav .btn { font-size: 11px; padding: 4px 10px; min-height: 0; }
 .slot-week-nav .week-label { font-size: 11px; min-width: 140px; text-align: center; }
 .slot-week-nav .btn .btn-icon { display: inline-block; width: 14px; height: 14px; vertical-align: middle; margin-right: 5px; }
 
@@ -1142,6 +1144,7 @@ textarea { min-height: 70px; }
   .btn { min-height: 44px; padding: 10px 16px; }
   .btn-row .btn { flex: 1 1 auto; min-width: 0; }
   .btn-ghost { min-height: 36px; }
+  .btn.btn-sm { min-height: 32px; padding: 6px 12px; }
 
   /* ── Forms — touch-friendly ── */
   input[type=text], input[type=number], input[type=email],

--- a/staff/index.html
+++ b/staff/index.html
@@ -59,11 +59,11 @@
       <span id="foActiveBadge" class="items-center gap-6 text-md fw-500" style="display:inline-flex;padding:4px 10px;border-radius:20px;border:1px solid"></span>
       <span id="foActiveNotes" class="text-md flex-1 text-pre-wrap" style="color:var(--text);min-width:160px"></span>
       <span id="foActiveMeta" class="text-xs text-muted"></span>
-      <button class="btn btn-secondary text-sm" style="padding:4px 10px" data-staff-click="clearFlagOverride"><span data-s="staff.flagOverrideClear">Clear override</span></button>
+      <button class="btn btn-secondary btn-sm" data-staff-click="clearFlagOverride"><span data-s="staff.flagOverrideClear">Clear override</span></button>
     </div>
     <div id="foInactiveRow" class="d-flex flex-wrap items-center gap-10">
       <span class="text-xs text-muted" data-s="staff.flagOverrideHint">Using live scoring. Set an override to post a staff-picked flag + note until midnight.</span>
-      <button class="btn btn-secondary text-sm ml-auto" style="padding:4px 10px" data-staff-click="toggleFlagOverrideForm" data-staff-arg="true"><span data-s="staff.flagOverrideSet">Set override</span></button>
+      <button class="btn btn-secondary btn-sm ml-auto" data-staff-click="toggleFlagOverrideForm" data-staff-arg="true"><span data-s="staff.flagOverrideSet">Set override</span></button>
     </div>
     <div id="foForm" class="hidden mt-10" style="border-top:1px solid var(--border);padding-top:10px">
       <div class="flex-center flex-wrap gap-6 mb-8" id="foFlagBtns"></div>
@@ -77,8 +77,8 @@
       </label>
       <div class="flex-center gap-8">
         <span class="text-xs text-muted" data-s="staff.flagOverrideMidnight">Auto-reverts to live data at midnight UTC.</span>
-        <button class="btn btn-secondary text-sm ml-auto" style="padding:4px 10px" data-staff-click="toggleFlagOverrideForm" data-staff-arg="false"><span data-s="btn.cancel">Cancel</span></button>
-        <button class="btn btn-primary text-sm" style="padding:4px 10px" data-staff-click="saveFlagOverride"><span data-s="staff.flagOverrideSave">Save override</span></button>
+        <button class="btn btn-secondary btn-sm ml-auto" data-staff-click="toggleFlagOverrideForm" data-staff-arg="false"><span data-s="btn.cancel">Cancel</span></button>
+        <button class="btn btn-primary btn-sm" data-staff-click="saveFlagOverride"><span data-s="staff.flagOverrideSave">Save override</span></button>
       </div>
     </div>
   </div>
@@ -97,8 +97,8 @@
     <div class="section-head">
       <h3 id="boatsOutNowLabel"></h3>
       <div class="flex-center gap-6">
-        <button class="btn btn-primary text-sm" style="padding:5px 12px" data-staff-click="toggleCheckoutForm" id="checkOutBtn" data-s="staff.checkOutBtn"></button>
-        <button class="btn btn-secondary text-sm" style="padding:5px 12px" data-staff-click="openGroupModal" id="groupCheckOutBtn" data-s="staff.groupCheckout"></button>
+        <button class="btn btn-primary btn-sm" data-staff-click="toggleCheckoutForm" id="checkOutBtn" data-s="staff.checkOutBtn"></button>
+        <button class="btn btn-secondary btn-sm" data-staff-click="openGroupModal" id="groupCheckOutBtn" data-s="staff.groupCheckout"></button>
       </div>
     </div>
 

--- a/staff/staff.js
+++ b/staff/staff.js
@@ -957,8 +957,8 @@ function renderGroupCard(c) {
     + '</div>'
     + '<div class="gc-meta">' + esc(c.locationName||'—') + ' \u00b7 Out ' + esc(tout) + '</div>'
     + '<div style="display:flex;gap:6px;margin-top:10px">'
-    + '<button class="btn btn-primary" style="font-size:11px;flex:1" data-staff-click="staffGroupCheckIn" data-staff-arg="' + esc(c.id) + '">\u2693 ' + s('staff.checkInAll') + '</button>'
-    + '<button class="btn btn-secondary" style="font-size:11px;padding:6px 12px;color:var(--muted)" data-staff-click="staffDeleteCheckout" data-staff-arg="' + esc(c.id) + '">\u2715</button>'
+    + '<button class="btn btn-primary btn-sm" style="flex:1" data-staff-click="staffGroupCheckIn" data-staff-arg="' + esc(c.id) + '">\u2693 ' + s('staff.checkInAll') + '</button>'
+    + '<button class="btn btn-secondary btn-sm" style="color:var(--muted)" data-staff-click="staffDeleteCheckout" data-staff-arg="' + esc(c.id) + '">\u2715</button>'
     + '</div>';
   return div;
 }

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -97,7 +97,7 @@
             <div class="text-lg fw-500" id="certPanelName"></div>
             <div class="text-sm text-muted" id="certPanelMeta"></div>
           </div>
-          <button data-slr-click="openCertAssignModal" class="btn btn-primary text-sm" style="padding:5px 12px">+ Add / Change cert</button>
+          <button data-slr-click="openCertAssignModal" class="btn btn-primary btn-sm">+ Add / Change cert</button>
         </div>
         <div id="certPanelList"></div>
       </div>

--- a/staff/staff_logbook-review.js
+++ b/staff/staff_logbook-review.js
@@ -204,9 +204,9 @@ function renderTrips() {
         <input type="text" id="comment-${esc(t.id)}" placeholder="${s('logrev.staffComment')}"
                value="${esc(t.staffComment || '')}" class="text-md">
         ${isVer
-          ? `<button class="btn btn-secondary text-sm" style="padding:5px 12px;flex-shrink:0"
+          ? `<button class="btn btn-secondary btn-sm" style="flex-shrink:0"
                data-slr-click="unverifyTrip" data-slr-arg="${esc(t.id)}">✗ ${s('logrev.unverify')}</button>`
-          : `<button class="btn btn-primary text-sm" style="padding:5px 14px;flex-shrink:0"
+          : `<button class="btn btn-primary btn-sm" style="flex-shrink:0"
                data-slr-click="verifyTrip" data-slr-arg="${esc(t.id)}">✓ ${s('logrev.verify')}</button>`}
       </div>
     </div>`;
@@ -319,9 +319,9 @@ function renderCertPanelList() {
         <div class="cert-meta">${expiry}${c.assignedAt ? ' · Issued ' + esc(c.assignedAt) : ''}</div>
       </div>
       <div class="cert-actions">
-        <button class="btn btn-secondary text-sm" style="padding:4px 10px"
+        <button class="btn btn-secondary btn-sm"
           data-slr-click="editCert" data-slr-arg="${esc(c.certId)}" data-slr-arg2="${esc(c.sub||'')}">Edit</button>
-        <button class="btn btn-secondary text-sm text-red" style="padding:4px 10px"
+        <button class="btn btn-secondary btn-sm text-red"
           data-slr-click="deleteCert" data-slr-arg="${esc(c.certId)}" data-slr-arg2="${esc(c.sub||'')}">✕</button>
       </div>
     </div>`;

--- a/weather/index.html
+++ b/weather/index.html
@@ -31,9 +31,9 @@
       <div class="text-xs text-muted" id="updatedAt" data-s="weather.loading"></div>
     </div>
     <div class="top-bar-right">
-      <button class="btn btn-secondary text-sm" id="geoBtn" style="padding:6px 12px"><span data-s="wx.useMyLocation">📍 My location</span></button>
-      <button class="btn btn-secondary text-sm d-none" id="fossBtn" style="padding:6px 12px"><span data-s="wx.useFossvogur">⚓ Fossvogur</span></button>
-      <button class="btn btn-secondary text-sm refresh-btn" id="refreshBtn" aria-label="Refresh" title="Refresh"><span class="refresh-icon" id="refreshIcon">↻</span></button>
+      <button class="btn btn-secondary btn-sm" id="geoBtn"><span data-s="wx.useMyLocation">📍 My location</span></button>
+      <button class="btn btn-secondary btn-sm d-none" id="fossBtn"><span data-s="wx.useFossvogur">⚓ Fossvogur</span></button>
+      <button class="btn btn-secondary btn-sm refresh-btn" id="refreshBtn" aria-label="Refresh" title="Refresh"><span class="refresh-icon" id="refreshIcon">↻</span></button>
     </div>
   </div>
 


### PR DESCRIPTION
Captain's page had three different "compact" button sizes coexisting: the slot-week-nav strip (4x10/11px), the assign-cred / save-bio buttons (6x14/11px with text-xs), and the + Add boat / Add reservation buttons (default 10x20 padding with only font-size overridden to 11-12px). Same story across staff, coxswain, admin, member, and the shared boat/slot/ maintenance modules — each site reaching for its own inline padding and font-size.

Adds a single .btn-sm modifier in shared/style.css (padding: 6px 12px; font-size: 11px; min-height: 0; 32px on mobile) and replaces the inline style overrides across 22 files. The .slot-week-nav .btn size rule is folded into .btn-sm applied directly in markup, so blue/grey now vary only by color, not geometry.

Logbook's standalone .btn-primary/.btn-secondary (no .btn prefix, defined in logbook/logbook.css) is left untouched — it's a separate local system that needs its own cleanup.