### PR TITLE
Default to light theme + respect saved theme on login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — light theme is the default
+
+New users (and anyone without a saved `ymirTheme`) now get light mode out of
+the box. `shared/api.js` `getTheme()` defaults to `"light"`; `settings.js`
+`saveSettings` falls back to `"light"` when nothing is selected. The login
+page now calls `applyTheme()` on load — previously it didn't load `ui.js`, so
+the form always rendered with the `:root` dark palette regardless of the
+user's saved preference. The Google sign-in button also measures its
+container and renders at the card's actual inner width (clamped to GSI's
+200-400px range) so it lines up flush with the password inputs on every
+screen instead of sitting at a hard-coded 320px.
+
 ## Unreleased — Google sign-in (one-click, with password fallback)
 
 Members can link a Google account and sign in with Google Identity Services'

--- a/login/login.js
+++ b/login/login.js
@@ -1,3 +1,6 @@
+// login/ doesn't load shared/ui.js, which is where every other page calls this.
+applyTheme();
+
 // Track the dynamic screen currently shown so we can re-render it when the
 // language changes without losing the user's place in the login flow.
 var _currentScreen = null;
@@ -117,16 +120,21 @@ apiGet('getConfig').catch(function() {});
       auto_select: false,
       cancel_on_tap_outside: true,
     });
-    google.accounts.id.renderButton(document.getElementById('googleBtn'), {
+    // Unhide first so getBoundingClientRect returns the real inner width —
+    // GSI's width param is a fixed pixel int (min 200, max 400), so match it
+    // to the card so the button lines up with the inputs below on any screen.
+    document.getElementById('googleBtnWrap').classList.remove('d-none');
+    var wrap = document.getElementById('googleBtn');
+    var avail = Math.round(wrap.getBoundingClientRect().width) || 320;
+    google.accounts.id.renderButton(wrap, {
       type: 'standard',
-      theme: document.documentElement.getAttribute('data-theme') === 'light' ? 'outline' : 'filled_black',
+      theme: document.documentElement.getAttribute('data-theme') === 'dark' ? 'filled_black' : 'outline',
       size: 'large',
       text: 'signin_with',
       shape: 'rectangular',
       logo_alignment: 'center',
-      width: 320,
+      width: Math.max(200, Math.min(400, avail)),
     });
-    document.getElementById('googleBtnWrap').classList.remove('d-none');
     document.getElementById('googleDividerText').textContent = s('login.or');
     google.accounts.id.prompt();
   } catch (e) {

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -366,7 +366,7 @@ async function saveSettings() {
   var initials = document.getElementById('sInitials').value.trim().toUpperCase() || _autoInitials;
   var lang     = getToggle('langToggle') || 'IS';
   var windUnit = document.getElementById('sWindUnit').value;
-  var theme    = getToggle('themeToggle') || 'dark';
+  var theme    = getToggle('themeToggle') || 'light';
 
   var statsVisibility = {
     career:     document.getElementById('svCareer').checked,

--- a/shared/api.js
+++ b/shared/api.js
@@ -552,7 +552,7 @@ function getLang()  { return localStorage.getItem("ymirLang") || "IS"; }
 function setLang(l) { localStorage.setItem("ymirLang", l); }
 
 // ── Theme ─────────────────────────────────────────────────────────────────────
-function getTheme()  { return localStorage.getItem("ymirTheme") || "dark"; }
+function getTheme()  { return localStorage.getItem("ymirTheme") || "light"; }
 function setTheme(t) {
   localStorage.setItem("ymirTheme", t);
   document.documentElement.setAttribute("data-theme", t);


### PR DESCRIPTION
- getTheme() now defaults to "light" (was "dark") so new users land in light mode, which matches the rest of the app's visual identity better.
- login.js calls applyTheme() on load. The login page doesn't include shared/ui.js, which is where every other page does this — so the saved theme preference was being ignored and the form always rendered dark.
- Google sign-in button now measures its card and renders at that width (clamped to GSI's 200-400px range) instead of a hard-coded 320, so it lines up with the password inputs and primary button on every screen.