### PR TITLE
Weather widget: preserve utility classes on re-render

### DIFF
--- a/shared/weather.js
+++ b/shared/weather.js
@@ -624,7 +624,8 @@ function wxWidget(targetEl, { onData, showRefreshBtn = true, label, getStaffStat
       });
 
       const updTime = fmtTimeNow();
-      targetEl.className = `wx-widget flag-${flagKey}`;
+      targetEl.classList.remove('flag-green', 'flag-yellow', 'flag-orange', 'flag-red', 'flag-black');
+      targetEl.classList.add('wx-widget', `flag-${flagKey}`);
       targetEl.innerHTML = `
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
           <div style="font-size:9px;color:var(--muted);letter-spacing:1.2px">${s('wx.birkConditions')}${c._obs_time ? ' · ' + c._obs_time.slice(11,16) + ' UTC' : ''}</div>


### PR DESCRIPTION
The render loop set `targetEl.className = 'wx-widget flag-<key>'`, wiping the `mb-14` utility class on `#wxWidget` in member/staff HTML. That removed the 14px gap between the weather widget's duty badges and the tide widget below it, leaving them flush.

Switch to `classList.add/remove` so the flag-* class still rotates per render but pre-existing classes (`mb-14`, etc.) survive.

https://claude.ai/code/session_01BLRw8aH3Kr6jzMUTMpFABT