### PR TITLE
Light-theme the public dashboard and stop the flag modal from leaking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://unpkg.com https://script.google.com https://script.googleusercontent.com https://api.open-meteo.com https://marine-api.open-meteo.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta charset="utf-8">
@@ -22,6 +22,7 @@
 <script src="../shared/strings.js"></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>
+<link rel="stylesheet" href="../shared/style.css">
 <link rel="stylesheet" href="public.css">
 </head>
 <body>

--- a/public/public.css
+++ b/public/public.css
@@ -1,31 +1,5 @@
-:root {
-  --bg:      #0a1a33;
-  --surface: #11264a;
-  --card:    #15305a;
-  --border:  #23457a;
-  --border-l:#365f9e;
-  --text:    #dce7f5;
-  --muted:   #7a9bc2;
-  --navy:    #3a5ea8;
-  --navy-l:  #5b83cf;
-  --moss:    #4fa55e;
-  --brass:   #d9b441;
-  --brass-fg:#d9b441;
-  --green:   var(--moss);
-  --red:     #e74c3c;
-  --yellow:  #f1c40f;
-  --orange:  #e67e22;
-  --blue:    var(--navy);
-  --faint:   #1a3863;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --font-mono: 'DM Mono', 'Courier New', monospace;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,.22);
-  --shadow-md: 0 2px 10px rgba(0,0,0,.28);
-  --shadow-lg: 0 10px 32px rgba(0,0,0,.40);
-  --radius-sm: 8px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
-}
+/* Theme tokens come from shared/style.css; <html data-theme="light"> selects light mode. */
+
 /* ── Tide chart (shared SVG classes) ───────────────────────────── */
 .c-brass  { fill: var(--brass);  stroke: var(--brass);  }
 .c-blue   { fill: var(--blue);   stroke: var(--blue);   }


### PR DESCRIPTION
public/index.html now pulls in shared/style.css and sets data-theme="light" on <html>. The shared stylesheet provides the .modal-overlay/.hidden rules that shared/weather.js relies on when it lazy-injects #wxFlagModal into <body>; without them the modal rendered inline at the foot of the page. Drop public.css's duplicate :root so the shared light-theme tokens take effect.

https://claude.ai/code/session_01BvBaB9HpeKS8cmfG3eTo1i