### PR TITLE
fix: don't prompt Google OAuth users to change temp password

### DIFF
--- a/members.gs
+++ b/members.gs
@@ -294,10 +294,13 @@ function loginWithGoogle_(b) {
   clearLoginAttempts_(m.kennitala);
   const session = createSession_(m.kennitala, m.role || 'member', stay, ua);
   const wards = bool_(m.isMinor) ? [] : findWardsOf_(m.kennitala);
+  // The temp-password-rotation prompt is only meaningful when the user actually
+  // authenticated with that password. A Google OAuth sign-in is its own trust
+  // path, so don't nag them about a password they never used.
   return okJ({
     member: publicMember_(m),
     wards: wards,
-    usingDefaultPassword: bool_(m.passwordIsTemp),
+    usingDefaultPassword: false,
     sessionToken: session.token,
     expiresAt: session.expiresAt,
     sessionId: session.id,


### PR DESCRIPTION
Members created by admin get a generated temp password with passwordIsTemp=true so they're forced to rotate it on first login. loginWithGoogle_ was surfacing that flag too, which prompted a password change right after a successful Google sign-in — a password the user never used and never will.

The temp-password-rotation prompt only makes sense on the password login path. Google OAuth is its own trust path, so drop the flag from the loginWithGoogle_ response.