### PR TITLE
fix: stop bouncing users to login on wrong password / bad Google token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — stop kicking users to login on wrong password / bad Google token
+
+`setPassword_` (`members.gs`) returned HTTP 401 when the user typed their
+current password wrong during a password change, and `linkGoogleAccount_`
+returned 401 when the submitted Google ID token failed verification. The
+frontend's global `_call` handler in `shared/api.js` treats any 401 from a
+non-public action as "session expired" and wipes local state before
+redirecting to `/login/`, so these input-credential failures were bouncing
+users out of a still-valid session before `settings.js` could surface its
+nice "Current password is incorrect" message. Both backend returns now use
+403 (session is valid, request credential rejected); reserve 401 for actual
+session-auth failures.
+
 ## Unreleased — light theme is the default
 
 New users (and anyone without a saved `ymirTheme`) now get light mode out of

--- a/members.gs
+++ b/members.gs
@@ -315,7 +315,7 @@ function linkGoogleAccount_(b, caller) {
   if (!caller) return failJ('Unauthorized', 401);
   const idToken = String((b && b.idToken) || '');
   const payload = verifyGoogleIdToken_(idToken);
-  if (!payload) return failJ('Invalid Google token', 401);
+  if (!payload) return failJ('Invalid Google token', 403);
   const email = payload.email;
 
   addColIfMissing_('members', 'googleEmail');
@@ -448,7 +448,7 @@ function setPassword_(b, caller) {
 
   const isAdminActing = caller && isAdmin_(caller) && caller.kennitala !== kt;
   if (!isAdminActing) {
-    if (!verifyPassword_(m, cur)) return failJ('Current password incorrect', 401);
+    if (!verifyPassword_(m, cur)) return failJ('Current password incorrect', 403);
   }
 
   addColIfMissing_('members', 'passwordHash');


### PR DESCRIPTION
setPassword_ and linkGoogleAccount_ returned HTTP 401 for input-credential failures (wrong current password, invalid Google ID token) even though the caller's session was perfectly valid. The frontend's global _call handler treats any 401 from a non-public action as "session expired" and wipes local state before the page-level error handler can run, so typing your current password wrong was kicking you out entirely instead of showing "Current password is incorrect."

Both returns now use 403 (session valid, request credential rejected); 401 stays reserved for genuine session-auth failures.