### PR TITLE
style: enlarge trip card chevrons

### DIFF
--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -14,7 +14,7 @@
 .badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}
 .badge-verified{color:var(--moss);border-color:color-mix(in srgb, var(--moss) 33%, transparent);background:color-mix(in srgb, var(--moss) 8%, transparent)}
 .badge-helm{color:var(--accent);border-color:var(--accent)55;background:var(--accent)11}
-.trip-arrow{padding:14px 18px 14px 10px;display:flex;align-items:center;color:var(--muted);font-size:14px;transition:transform .2s,color .2s;flex-shrink:0}
+.trip-arrow{padding:14px 18px 14px 10px;display:flex;align-items:center;color:var(--muted);font-size:18px;transition:transform .2s,color .2s;flex-shrink:0}
 .trip-card:hover .trip-arrow,.trip-card.open .trip-arrow{color:var(--accent)}
 .trip-card.open .trip-arrow{transform:rotate(180deg)}
 
@@ -38,7 +38,7 @@
 .exp-section-hdr{font-size:9px;color:var(--muted);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px;font-weight:500}
 .exp-section-hdr.expandable{cursor:pointer;display:flex;align-items:center;gap:6px;padding:4px 0}
 .exp-section-hdr.expandable:hover{color:var(--accent)}
-.exp-section-hdr .exp-chevron{font-size:13px;line-height:1;transition:transform .2s;transform:rotate(0deg)}
+.exp-section-hdr .exp-chevron{font-size:16px;line-height:1;transition:transform .2s;transform:rotate(0deg)}
 .exp-section-hdr.expanded .exp-chevron{transform:rotate(180deg)}
 .exp-section-detail{display:none;margin-top:4px}
 .exp-section-detail.open{display:block}


### PR DESCRIPTION
Bump the main trip-card chevron from 14px to 18px and the expandable section chevrons (trip details, weather) from 13px to 16px so they read as clearer affordances.

https://claude.ai/code/session_01MkCubKV7uShAup2zFkwcHR