### PR TITLE
fix: stop double-encoding daily-log JSON fields

### DIFF
--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -689,7 +689,14 @@ function _renderDailyTide() {
 // ════════════════════════════════════════════════════════════════════════════
 function sjson(v, fallback) {
   if (!v) return fallback;
-  try { return typeof v === 'string' ? JSON.parse(v) : v; } catch(e) { return fallback; }
+  try {
+    var parsed = typeof v === 'string' ? JSON.parse(v) : v;
+    // Legacy rows were written double-encoded by the client; unwrap once more.
+    if (typeof parsed === 'string') {
+      try { parsed = JSON.parse(parsed); } catch (e) {}
+    }
+    return parsed;
+  } catch (e) { return fallback; }
 }
 
 async function loadDay() {
@@ -837,11 +844,11 @@ async function doSave(signOff) {
   try {
     const payload = {
       date:          viewDate,
-      openingChecks: JSON.stringify(amChecks),
-      closingChecks: JSON.stringify(pmChecks),
-      activities:    JSON.stringify(activities),
-      weatherLog:    JSON.stringify(wxLog),
-      tideData:      JSON.stringify(tideData),
+      openingChecks: amChecks,
+      closingChecks: pmChecks,
+      activities:    activities,
+      weatherLog:    wxLog,
+      tideData:      tideData,
       narrative:     dom.narrativeInput.value.trim(),
       signOff,
       ...(logId ? { id: logId } : {}),

--- a/members.gs
+++ b/members.gs
@@ -757,7 +757,7 @@ function saveDailyLog_(b) {
       openingChecks: b.openingChecks !== undefined ? JSON.stringify(b.openingChecks) : ex.openingChecks,
       closingChecks: b.closingChecks !== undefined ? JSON.stringify(b.closingChecks) : ex.closingChecks,
       activities: b.activities !== undefined ? JSON.stringify(b.activities) : ex.activities,
-      weatherLog: b.weatherLog !== undefined ? b.weatherLog : ex.weatherLog,
+      weatherLog: b.weatherLog !== undefined ? JSON.stringify(b.weatherLog) : ex.weatherLog,
       narrative: b.narrative !== undefined ? b.narrative : ex.narrative,
       tideData: b.tideData !== undefined ? JSON.stringify(b.tideData) : ex.tideData,
       signedOffBy: b.signedOffBy || ex.signedOffBy || '',
@@ -768,10 +768,11 @@ function saveDailyLog_(b) {
   } else {
     insertRow_('dailyLog', {
       id: uid_(), date,
-      openingChecks: JSON.stringify(b.openingChecks || []),
-      closingChecks: JSON.stringify(b.closingChecks || []),
+      openingChecks: JSON.stringify(b.openingChecks || {}),
+      closingChecks: JSON.stringify(b.closingChecks || {}),
       activities: JSON.stringify(b.activities || []),
-      weatherLog: b.weatherLog || '', narrative: b.narrative || '',
+      weatherLog: JSON.stringify(b.weatherLog || []),
+      narrative: b.narrative || '',
       tideData: JSON.stringify(b.tideData || {}),
       signedOffBy: b.signedOffBy || '', signedOffAt: b.signedOffAt || '',
       updatedBy: b.updatedBy || '', createdAt: ts, updatedAt: ts,

--- a/staff/staff.js
+++ b/staff/staff.js
@@ -977,7 +977,11 @@ async function openDlLinkModal(checkoutId) {
     const today = todayISO();
     const res   = await apiGet('getDailyLog', { date: today });
     const log   = res.log || {};
-    _dlLinkTodayActs = (typeof log.activities === 'string' ? JSON.parse(log.activities||'[]') : (log.activities||[]));
+    var _acts = log.activities;
+    if (typeof _acts === 'string') { try { _acts = JSON.parse(_acts); } catch(e) { _acts = []; } }
+    // Legacy rows were double-encoded; unwrap once more if needed.
+    if (typeof _acts === 'string') { try { _acts = JSON.parse(_acts); } catch(e) { _acts = []; } }
+    _dlLinkTodayActs = Array.isArray(_acts) ? _acts : [];
   } catch(e) { _dlLinkTodayActs = []; }
 
   const list = document.getElementById('dlLinkActList');


### PR DESCRIPTION
The dailylog client pre-stringified openingChecks / closingChecks / activities / weatherLog / tideData, and saveDailyLog_ then ran JSON.stringify over them a second time. Loaded rows parsed to a string instead of the intended object/array, so deleteActivity() crashed with "activities.filter is not a function" and syncDailyLogActivities_ silently skipped calendar sync (forEach on a string).

The client now sends raw objects; the backend is the single point that stringifies for storage. sjson() unwraps the legacy double-encoded rows already in the sheet so no migration is needed. staff.js does the same defensive double-parse where it reads activities.