### PR TITLE
fix: admin boats tab — working chevrons, category-tinted cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — admin boats tab polish
+
+Three small fixes to the admin → Boats sub-tab:
+
+- Chevron now reliably expands/collapses a category. The `▼` span used to sit
+  inside the header's `data-admin-nobubble` wrapper, so the delegated
+  `toggleSection` handler ignored clicks on it and the chevron had no handler
+  of its own — dead zone. Moved the chevron out of the nobubble region.
+- Boat cards now shade with their category color (background + border pulled
+  from `BOAT_CAT_COLORS` in `shared/boats.js`). The per-card category badge is
+  redundant once cards are grouped under a category section, so it's gone.
+- Tightened the card grid (180px min, 8px gap) and padding (8px 10px) for a
+  more compact look; `.boat-card-meta` replaces inline `style="font-size:…"`
+  on the reg-no / model / OOS-reason lines.
+
+Touches `admin/boats.js`, `admin/admin.css`.
+
 ## Unreleased — color token cleanup (`--brass` → `--accent`)
 
 The `--brass` family of CSS variables was semantically confused: the token was

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -33,17 +33,23 @@
     .member-kt   { color:var(--muted); font-size:11px; width:88px; flex-shrink:0; }
 
     /* ── Boat cards ── */
-    .boat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:10px; }
-    .boat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 14px; box-shadow:var(--shadow-sm); min-width:0; overflow:hidden; }
+    .boat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:8px; }
+    .boat-card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); padding:8px 10px; box-shadow:var(--shadow-sm); min-width:0; overflow:hidden; }
     .boat-card.oos { opacity:.55; }
-    .boat-card-head { display:flex; align-items:flex-start; justify-content:space-between; gap:6px; margin-bottom:4px; flex-wrap:wrap; }
-    .boat-card-name { font-size:13px; font-weight:500; color:var(--text); margin-bottom:6px; min-width:0; flex:1 1 auto; word-break:break-word; overflow-wrap:anywhere; }
+    .boat-card-head { display:flex; align-items:flex-start; justify-content:space-between; gap:6px; flex-wrap:wrap; }
+    .boat-card-name { font-size:13px; font-weight:500; color:var(--text); min-width:0; flex:1 1 auto; word-break:break-word; overflow-wrap:anywhere; }
     .boat-card-badges { display:flex; gap:4px; flex-wrap:wrap; justify-content:flex-end; max-width:100%; }
     .boat-card-badges > * { max-width:100%; }
     .boat-card-badge-controlled { font-size:8px; letter-spacing:.5px; padding:2px 6px; border-radius:10px;
       border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);
       background:color-mix(in srgb, var(--accent) 10%, transparent); color:var(--accent); }
-    .boat-card-actions { display:flex; gap:6px; margin-top:10px; }
+    .boat-card-meta { font-size:10px; color:var(--muted); margin-top:2px; }
+    .boat-card-actions { display:flex; gap:6px; margin-top:8px; }
+
+    /* Collapsible section head — the chevron sits outside the nobubble region
+       so clicks on it still toggle the section. */
+    .col-head-actions { display:flex; align-items:center; gap:8px; }
+    .col-head-btns { display:inline-flex; align-items:center; gap:6px; }
 
     /* ── Generic row ── */
     .list-row { display:flex; align-items:center; gap:10px; padding:9px 0;

--- a/admin/boats.js
+++ b/admin/boats.js
@@ -111,21 +111,21 @@ function renderBoats() {
   });
   el.innerHTML = sortedCats
     .map(cat => {
-      const label = (L === 'IS' && cat.labelIS) ? cat.labelIS : cat.labelEN;
+      const col = (typeof BOAT_CAT_COLORS !== 'undefined' && BOAT_CAT_COLORS[cat.key]) || (typeof BOAT_CAT_COLORS !== 'undefined' ? BOAT_CAT_COLORS.other : null);
+      const cardStyle = col ? `background:${col.bg};border-color:${col.border}` : '';
       const cards = (groups[cat.key] || []).map(b => `
-        <div class="boat-card${bool(b.oos) ? " oos" : ""}">
+        <div class="boat-card${bool(b.oos) ? " oos" : ""}" style="${cardStyle}">
           <div class="boat-card-head">
             <div class="boat-card-name">${cat.emoji || boatEmoji(cat.key)} ${esc(b.name)}</div>
             <div class="boat-card-badges">
               ${b.accessMode === 'controlled' ? `<span class="boat-card-badge boat-card-badge-controlled">${esc(s('fleet.badgeControlled'))}</span>` : ""}
               ${bool(b.oos) ? `<span class="oos-badge">OOS</span>` : ""}
-              ${boatCatBadge(cat.key)}
             </div>
           </div>
-          ${b.oosReason ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${esc(b.oosReason)}</div>` : ""}
-          ${(b.registrationNo || b.typeModel) ? `<div style="font-size:10px;color:var(--muted);margin-bottom:4px">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
+          ${b.oosReason ? `<div class="boat-card-meta">${esc(b.oosReason)}</div>` : ""}
+          ${(b.registrationNo || b.typeModel) ? `<div class="boat-card-meta">${[b.registrationNo, b.typeModel].filter(Boolean).map(esc).join(' · ')}</div>` : ""}
           <div class="boat-card-actions">
-            <button class="row-edit" style="flex:1" data-admin-click="openBoatModal" data-admin-arg="${b.id}">Edit</button>
+            <button class="row-edit flex-1" data-admin-click="openBoatModal" data-admin-arg="${b.id}">Edit</button>
             <button class="row-edit" data-admin-click="showBoatQR" data-admin-arg="${b.id}" title="Show QR code">🔳</button>
             <button class="row-del"  data-admin-click="deleteBoat" data-admin-arg="${b.id}" title="Delete">×</button>
           </div>
@@ -134,9 +134,11 @@ function renderBoats() {
       return `<div class="col-section">
         <div class="col-head" data-admin-toggle-section>
           <div class="col-title">${cat.emoji || boatEmoji(cat.key)} ${boatCatBadge(cat.key)}</div>
-          <div style="display:flex;align-items:center;gap:6px" data-admin-nobubble>
-            <button class="row-edit" data-admin-click="openBoatModalForCat" data-admin-arg="${cat.key}">+ Add boat</button>
-            <button class="row-edit" data-admin-click="openBoatCatModal" data-admin-arg="${cat.key}">Edit</button>
+          <div class="col-head-actions">
+            <span class="col-head-btns" data-admin-nobubble>
+              <button class="row-edit" data-admin-click="openBoatModalForCat" data-admin-arg="${cat.key}">+ Add boat</button>
+              <button class="row-edit" data-admin-click="openBoatCatModal" data-admin-arg="${cat.key}">Edit</button>
+            </span>
             <span class="col-toggle">▼</span>
           </div>
         </div>


### PR DESCRIPTION
- Move col-toggle chevron outside data-admin-nobubble so clicks on it reach the delegated toggleSection handler (previously a dead zone because the span had no data-admin-click either).
- Tint boat cards with their category color (bg + border from BOAT_CAT_COLORS) and drop the redundant per-card category badge — cards already group under a category section header.
- Tighten .boat-grid (180px min, 8px gap) and card padding, plus a reusable .boat-card-meta class for the reg-no / model / OOS-reason meta lines.