### PR TITLE
admin: fix chevron-tiling wave pattern in settings mobile dropdown

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -6,10 +6,11 @@
     .tab-btn.active { color:var(--accent); border-bottom-color:var(--accent); }
     .tab-btn:hover:not(.active) { color:var(--text); }
 
-    /* ── Tab dropdown (mobile) ── */
-    .tab-select { display:none; width:100%; padding:10px 12px; margin-bottom:20px;
-      font-family:inherit; font-size:13px; color:var(--text); background:var(--surface);
-      border:1px solid var(--border); border-radius:var(--radius-sm); cursor:pointer; }
+    /* ── Tab dropdown (mobile) ──
+       Only declares display + spacing. All other look-and-feel (border, bg,
+       chevron, padding, font) is inherited from the shared `select` rule so
+       the caret stays theme-aware and doesn't tile into a wave pattern. */
+    .tab-select { display:none; margin-bottom:20px; }
 
     /* ── Collapsible section ── */
     .col-section { margin-bottom:16px; }


### PR DESCRIPTION
The .tab-select rule used `background: var(--surface)` shorthand, which resets background-repeat to `repeat` and background-position to `0 0`. In light mode, `[data-theme="light"] select` has higher specificity for background-image (re)applying the chevron SVG — but doesn't restore the repeat/position longhands. Result: the V-chevron tiles across the whole pill, rendering a zigzag "wave" pattern instead of a single caret.

Fix: drop the shadowing rule entirely. Keep only display + margin so the shared `select` styling (border, bg, chevron, padding, font) flows through unbroken. The mobile caret now renders once, themed correctly.