### PR TITLE
fix(logbook): remove 1.5s confirmations load delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — logbook confirmations load without the 1.5s lag
+
+The logbook page had a hard-coded 1500ms delay before the crew-confirmations
+badge would populate (and before confirmation badges would appear on trip
+cards). The `setTimeout(..., 1500)` in `shared/logbook.js` was a safety buffer
+meant to wait for `shared/logbook-confirm.js` to define `loadConfirmations` —
+but `defer` scripts execute in document order before `DOMContentLoaded`, so
+the buffer was always unnecessary. Worse, the `typeof loadConfirmations`
+guard would silently fail if the function weren't defined in time, masking
+any future load-order regression.
+
+- Removed the 1500ms timer. `loadConfirmations` is now auto-invoked from
+  `shared/logbook-confirm.js` itself on `DOMContentLoaded`, gated on the
+  presence of `#confBadge` so captain/ (which loads the file for its
+  helpers but has its own confirmation machinery) doesn't fire a stray
+  request.
+- Added `Confirmations` to the initial `prefetch()` in `logbook/logbook.js`
+  so the GET races with `getTrips`/`getConfig`/`getMembers` instead of
+  firing serially after init.
+- Added `getConfirmations` to the `_CACHEABLE` map in `shared/api.js`
+  (30s TTL, same as `getNotifications`) and wired cache invalidation for
+  every POST that mutates confirmation state: `respondConfirmation`,
+  `createConfirmation`, `requestVerification`, `requestValidation`,
+  `dismissConfirmation`, `dismissAllConfirmations`.
+
+Touches `shared/logbook.js`, `shared/logbook-confirm.js`, `shared/api.js`,
+`logbook/logbook.js`.
+
 ## Unreleased — admin boats tab polish
 
 Three small fixes to the admin → Boats sub-tab:

--- a/logbook/logbook.js
+++ b/logbook/logbook.js
@@ -1,8 +1,14 @@
-prefetch({Trips:['getTrips',{limit:500}],Config:['getConfig'],Members:['getMembers']});
+const _u = getUser();
+prefetch({
+  Trips:['getTrips',{limit:500}],
+  Config:['getConfig'],
+  Members:['getMembers'],
+  Confirmations: _u ? ['getConfirmations', {kennitala: _u.kennitala}] : null,
+});
 
 requireAuth();
 buildHeader('logbook');
-const user = getUser();
+const user = _u;
 const IS   = getLang() === 'IS';
 const _windUnit = getPref('windUnit', 'ms');
 const _statsVis = (getPrefs().statsVisibility) || {};

--- a/shared/api.js
+++ b/shared/api.js
@@ -31,7 +31,7 @@ try {
 async function apiGet(action, params) {
   params = params || {};
   // Cache getConfig in sessionStorage for 60s — called on every page load
-  var _CACHEABLE = { getConfig: 120000, getWeather: 300000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewBoard: 30000, getCrewInvites: 30000, getNotifications: 30000 };
+  var _CACHEABLE = { getConfig: 120000, getWeather: 300000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewBoard: 30000, getCrewInvites: 30000, getNotifications: 30000, getConfirmations: 30000 };
   if (_CACHEABLE[action] && !params._fresh) {
     try {
       var _ck = 'ymir_' + action + '_';
@@ -101,7 +101,10 @@ var _INVALIDATES = {
   deleteTrip:              ['getTrips'],
   setHelm:                 ['getTrips'],
   // respondConfirmation can mint a new crew-trip row AND clear a notification.
-  respondConfirmation:     ['getTrips', 'getNotifications'],
+  respondConfirmation:     ['getTrips', 'getNotifications', 'getConfirmations'],
+  createConfirmation:      ['getConfirmations', 'getNotifications'],
+  requestVerification:     ['getConfirmations', 'getNotifications'],
+  requestValidation:       ['getConfirmations', 'getNotifications'],
   // Maintenance — most also change notification counts (follower pings, etc.).
   saveMaintenance:         ['getMaintenance', 'getNotifications'],
   resolveMaintenance:      ['getMaintenance', 'getNotifications'],
@@ -116,8 +119,8 @@ var _INVALIDATES = {
   followProject:           ['getMaintenance', 'getNotifications'],
   unfollowProject:         ['getMaintenance', 'getNotifications'],
   // Notification-only.
-  dismissConfirmation:     ['getNotifications'],
-  dismissAllConfirmations: ['getNotifications'],
+  dismissConfirmation:     ['getNotifications', 'getConfirmations'],
+  dismissAllConfirmations: ['getNotifications', 'getConfirmations'],
   markProjectSeen:         ['getNotifications'],
   // Session-state changes. Settings page re-fetches its "signed in on…" list.
   signOut:                 ['listSessions'],

--- a/shared/logbook-confirm.js
+++ b/shared/logbook-confirm.js
@@ -25,7 +25,10 @@ let _confirmations={incoming:[],outgoing:[]}, _confirmationsLoaded=false;
 
 async function loadConfirmations(){
   try{
-    const res=await apiGet('getConfirmations',{kennitala:user.kennitala});
+    const res=await (window._earlyConfirmations || apiGet('getConfirmations',{kennitala:user.kennitala}));
+    // One-shot: clear the prefetch handle so the next call (e.g. after a
+    // mutation invalidates the cache) refetches instead of reusing stale data.
+    window._earlyConfirmations = null;
     const incoming = res.incoming||[], outgoing = res.outgoing||[];
     // Auto-dismiss resolved confirmations server-side in background.
     // Exception: keep rejected outgoing crew_assigned visible — the skipper
@@ -269,4 +272,16 @@ async function dismissAllConf() {
     showToast(s('logbook.allDismissed'), 'success');
   } catch(e) { showToast(s('logbook.errGeneric',{msg:e.message}), 'err'); }
 }
+
+// Auto-load on page ready for portals that mount the confirmations UI.
+// Gated on the #confBadge element so captain/ — which loads this file for
+// its helpers but has its own confirmation UI — doesn't fire an unused call.
+(function () {
+  if (typeof document === 'undefined') return;
+  var start = function () {
+    if (document.getElementById('confBadge')) loadConfirmations();
+  };
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start);
+  else start();
+})();
 

--- a/shared/logbook.js
+++ b/shared/logbook.js
@@ -408,13 +408,6 @@ async function reload(){
 
 // ── Edit trip (skipper only) ────────────────────────────────────────────────
 
-// Load confirmations after page init. Wrap so the loadConfirmations
-// lookup is deferred until the callback fires — the function lives in
-// shared/logbook-confirm.js, which loads after this file.
-setTimeout(function () {
-  if (typeof loadConfirmations === 'function') loadConfirmations();
-}, 1500);
-
 
 // Delegated handlers for data-trip-* attrs on rendered logbook DOM
 // (replaces inline onclick/onerror in the trip-card / confirmation /


### PR DESCRIPTION
The logbook page had a hard-coded setTimeout(..., 1500) before firing loadConfirmations — a buffer to wait for logbook-confirm.js to define the function. Since defer scripts execute in document order before DOMContentLoaded, the buffer was never necessary, and the silent typeof guard masked load-order bugs.

- Move the initial loadConfirmations call into logbook-confirm.js itself, running on DOMContentLoaded and gated on #confBadge so captain/ doesn't fire an unused request.
- Prefetch getConfirmations alongside the other init GETs.
- Cache getConfirmations for 30s and invalidate on all mutating POSTs (respondConfirmation, createConfirmation, requestVerification, requestValidation, dismissConfirmation, dismissAllConfirmations).

https://claude.ai/code/session_01FBSvjcKXfaY43WcVjoKiys