### PR TITLE
style(act-btn): drop rest-state shading, add --full modifier

### DIFF
--- a/logbook/index.html
+++ b/logbook/index.html
@@ -68,8 +68,8 @@
 
   <!-- Share logbook -->
   <div id="shareBar" class="quick-actions">
+    <button class="act-btn act-btn--log act-btn--full" data-lb-click="openLogModal"><span data-s="lb.addManualBtn"></span></button>
     <button class="act-btn act-btn--share" data-lb-click="toggleSharePanel" data-s="logbook.shareBtn"></button>
-    <button class="act-btn act-btn--log" data-lb-click="openLogModal"><span data-s="lb.addManualBtn"></span></button>
     <button class="act-btn act-btn--confirm" data-lb-click="openConfirmationsModal"><span data-s="member.pendingConfirmations"></span><span class="conf-badge" id="confBadge" style="display:none">0</span></button>
     <div id="sharePanel" class="w-full mt-4" style="display:none;padding-top:8px;border-top:1px solid var(--border)">
       <div id="shareCatChecks" class="flex-center flex-wrap gap-8 mb-8"></div>

--- a/member/member.css
+++ b/member/member.css
@@ -2,7 +2,7 @@
 .member-actions { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
 .member-actions .act-btn {
   flex:1 1 140px; min-width:110px; min-height:56px;
-  background:var(--accent)12; border:1px solid var(--accent);
+  background:transparent; border:1px solid var(--accent);
   border-radius:var(--radius-md); padding:10px 14px; cursor:pointer; font-family:inherit;
   font-size:13px; font-weight:600; color:var(--accent-fg); text-align:center; text-decoration:none;
   display:inline-flex; align-items:center; justify-content:center; gap:10px;
@@ -17,7 +17,7 @@
   -webkit-mask-position:center; mask-position:center;
 }
 .member-actions .act-btn:hover {
-  background:var(--accent)22;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
   transform:translateY(-1px); box-shadow:var(--shadow-md);
 }
 /* Per-button monochrome SVG glyphs (rendered in --accent via mask-image) */

--- a/shared/style.css
+++ b/shared/style.css
@@ -550,13 +550,14 @@ textarea { min-height: 70px; }
 .btn-ghost:hover        { color: var(--navy); border-color: var(--navy); background: color-mix(in srgb, var(--navy) 8%, transparent); }
 .btn-ghost.danger:hover { color: var(--red);  border-color: var(--red);  background: color-mix(in srgb, var(--red) 8%, transparent); }
 
-/* Quick-action strip — big accent-wash buttons for landing-page actions.
+/* Quick-action strip — big accent-outlined buttons for landing-page actions.
    Use .quick-actions as the flex wrapper and .act-btn for each button.
+   Add .act-btn--full on a button to make it span its row.
    Portal CSS supplies the per-button SVG glyph via .act-btn--<name>::before. */
 .quick-actions { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
 .act-btn {
   flex:1 1 140px; min-width:110px; min-height:56px;
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  background: transparent;
   border:1px solid var(--accent);
   border-radius:var(--radius-md); padding:10px 14px; cursor:pointer; font-family:inherit;
   font-size:13px; font-weight:600; color:var(--accent-fg); text-align:center; text-decoration:none;
@@ -564,6 +565,7 @@ textarea { min-height: 70px; }
   line-height:1.25; box-shadow:var(--shadow-sm);
   transition:background-color .15s, transform .15s, box-shadow .15s;
 }
+.act-btn.act-btn--full { flex-basis:100%; }
 .act-btn::before {
   content:''; display:inline-block; width:16px; height:16px; flex-shrink:0;
   background-color:var(--accent-fg);
@@ -572,11 +574,12 @@ textarea { min-height: 70px; }
   -webkit-mask-position:center; mask-position:center;
 }
 .act-btn:hover {
-  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
   transform:translateY(-1px); box-shadow:var(--shadow-md);
 }
 @media (max-width:600px) {
   .act-btn { flex-basis:calc(50% - 4px); min-width:0; min-height:50px; padding:8px 10px; font-size:12px; gap:8px; }
+  .act-btn.act-btn--full { flex-basis:100%; }
   .act-btn::before { width:14px; height:14px; }
 }
 


### PR DESCRIPTION
- .act-btn is now transparent at rest (border + icon + label only). Hover keeps a subtle 10% accent wash for tactile feedback.
- New .act-btn--full modifier spans 100% of its row (works on desktop and inside the <=600px mobile layout rule).
- logbook shareBar: "Manually log a trip" is now a full-width button on its own row; Share + Pending Confirmations share the row below.

Applied to both the shared .act-btn base and the member portal's .member-actions .act-btn override so the two portals stay visually consistent.

https://claude.ai/code/session_019WT3rLSuFr4sGWM64aGUei