### PR TITLE
style(boats): snap boat cards to a CSS grid; tint OOS left accent by …

### DIFF
--- a/member/member.css
+++ b/member/member.css
@@ -133,7 +133,7 @@
 .fsb-count.none-avail { color:var(--muted); }
 .fsb-arrow { font-size:11px;color:var(--muted); }
 .fsb-body { padding:4px 0; }
-.fleet-cat-grid { display:flex;flex-wrap:wrap;gap:6px;padding:4px; }
+.fleet-cat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:6px; padding:4px; }
 .bc-card { background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;font-size:12px; }
 .bc-avail { border-left:3px solid var(--moss);cursor:pointer; }
 .bc-avail:hover { background:var(--faint); }

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -415,8 +415,10 @@ function renderBoatCard(boat, opts) {
   // Muted card style for restricted boats (controlled access without authorization)
   const isMuted = (!opts.staffView && controlled && !userCanAccess);
   const charteredMuted = isMuted ? "opacity:.55;pointer-events:none;" : "";
+  // OOS cards keep a muted left accent in the category color (opacity from .bc-oos)
+  const oosBorder = status === "oos" ? `border-left:3px solid ${boatCatColors(cat).color};` : "";
 
-  return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}">`
+  return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}${oosBorder}">`
        + `<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:4px">`
        + `<div style="font-size:14px;font-weight:500;color:var(--text)">${emoji} ${name}</div>`
        + `<div style="display:flex;gap:4px;flex-shrink:0">${ownerBadge}${bdgHtml}</div>`

--- a/staff/staff.css
+++ b/staff/staff.css
@@ -90,7 +90,6 @@
 .fct-arrow.open { transform:rotate(180deg); }
 .fleet-cat-body { display:none; padding:8px 0 4px; }
 .fleet-cat-body.open { display:block; }
-.fleet-cat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(155px,1fr)); gap:8px; }
 
 /* ── Recent checkouts ── */
 .recent-row { display:flex; align-items:center; gap:10px; padding:7px 0;
@@ -151,7 +150,7 @@
 .fsb-body { padding:6px 0 4px 0; }
 
 /* Compact boat cards in fleet status */
-.fleet-cat-grid { display:flex; flex-wrap:wrap; gap:6px; padding:4px 4px; }
+.fleet-cat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:6px; padding:4px; }
 .bc-boat-card {
   border-radius:var(--radius-sm); padding:7px 10px; min-width:90px; border:1px solid transparent;
   font-size:12px; transition:all .2s;


### PR DESCRIPTION
…category

Fleet-status cards used a flex-wrap layout that sized each card to its content, which looked ragged. Switch .fleet-cat-grid to a CSS grid with auto-fill / minmax(180px, 1fr) in both the member and staff portals. Drop a stale .fleet-cat-grid rule in staff.css that was already shadowed by the later compact-section override.

OOS cards previously dropped the left accent and only dimmed via opacity. Emit an inline border-left in the category color from renderBoatCard when status === 'oos'; the existing .bc-oos opacity mutes it automatically.