### PR TITLE
fix(dailylog): actually show activity subtypes when type is selected

### DIFF
--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -889,8 +889,8 @@ function populateActSubtypes() {
   const subs = typeObj && typeObj.subtypes
     ? (Array.isArray(typeObj.subtypes) ? typeObj.subtypes : JSON.parse(typeObj.subtypes || '[]'))
     : [];
-  if (!subs.length) { field.style.display = 'none'; grid.innerHTML = ''; return; }
-  field.style.display = '';
+  if (!subs.length) { field.classList.add('d-none'); grid.innerHTML = ''; return; }
+  field.classList.remove('d-none');
   grid.innerHTML = '';
   subs.forEach(function(st) {
     const btn = document.createElement('button');


### PR DESCRIPTION
Since c9c77e1 moved actSubtypeField from inline style="display:none" to class="d-none", populateActSubtypes()'s field.style.display = '' no longer un-hides it — clearing the inline style just lets the .d-none class cascade back. Subtype buttons rendered into the grid but stayed invisible, so users lost the ability to pick a standard subtype (name + default times) from config when adding an activity.

Switch the show/hide to classList.add/remove('d-none') so the field actually reveals once a type with subtypes is selected.

https://claude.ai/code/session_015qnWid45bHTipmi7db8N1G