### PR TITLE
Captain booking colour: inline → popover

### DIFF
--- a/captain/captain.js
+++ b/captain/captain.js
@@ -647,6 +647,8 @@ function initCqReservations() {
     var prefs = {};
     try { prefs = typeof user.preferences === 'string' ? JSON.parse(user.preferences || '{}') : (user.preferences || {}); } catch (e) {}
     colorEl.value = prefs.bookingColor || '#2e7d32';
+    var trig = document.getElementById('cqBookingColorBtn');
+    if (trig) trig.style.background = colorEl.value;
     if (typeof renderColorSwatches === 'function') renderColorSwatches('cqBookingColor', 'cqBookingColorSwatches');
   }
   // Set week start
@@ -708,6 +710,8 @@ function _cqGetBookingColor() {
 
 async function saveCqBookingColor() {
   var color = document.getElementById('cqBookingColor').value;
+  var btn = document.getElementById('cqBookingColorBtn');
+  if (btn) btn.style.background = color;
   var prefs = {};
   try { prefs = typeof user.preferences === 'string' ? JSON.parse(user.preferences || '{}') : (user.preferences || {}); } catch (e) {}
   prefs.bookingColor = color;
@@ -717,6 +721,45 @@ async function saveCqBookingColor() {
     toast(s('toast.saved'));
   } catch(e) { toast(e.message || 'Error', 'err'); }
   renderCqSlots();
+}
+
+function toggleCqBookingColorPop() {
+  var pop = document.getElementById('cqBookingColorPop');
+  var btn = document.getElementById('cqBookingColorBtn');
+  if (!pop || !btn) return;
+  var opening = pop.classList.contains('hidden');
+  if (opening) {
+    pop.classList.remove('hidden');
+    btn.setAttribute('aria-expanded', 'true');
+    // Defer binding so the click that opened doesn't immediately close.
+    setTimeout(function () {
+      document.addEventListener('mousedown', _cqBookingColorOutside, true);
+      document.addEventListener('keydown', _cqBookingColorKey, true);
+    }, 0);
+  } else {
+    _cqBookingColorClose();
+  }
+}
+
+function _cqBookingColorClose() {
+  var pop = document.getElementById('cqBookingColorPop');
+  var btn = document.getElementById('cqBookingColorBtn');
+  if (pop) pop.classList.add('hidden');
+  if (btn) btn.setAttribute('aria-expanded', 'false');
+  document.removeEventListener('mousedown', _cqBookingColorOutside, true);
+  document.removeEventListener('keydown', _cqBookingColorKey, true);
+}
+
+function _cqBookingColorOutside(e) {
+  var pop = document.getElementById('cqBookingColorPop');
+  var btn = document.getElementById('cqBookingColorBtn');
+  if (!pop || !btn) return;
+  if (pop.contains(e.target) || btn.contains(e.target)) return;
+  _cqBookingColorClose();
+}
+
+function _cqBookingColorKey(e) {
+  if (e.key === 'Escape') { _cqBookingColorClose(); document.getElementById('cqBookingColorBtn')?.focus(); }
 }
 
 async function bookCqSlot(slotId) {

--- a/captain/index.html
+++ b/captain/index.html
@@ -91,10 +91,16 @@
         <button class="btn btn-primary btn-sm" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" data-cq-click="openCreateSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
         <button class="btn btn-primary btn-sm" data-s="slot.bulkBook" data-s-attr="title" data-cq-click="openBulkSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
       </div>
-      <div class="d-flex items-center gap-6 ml-auto flex-wrap">
-        <label for="cqBookingColor" class="text-10 text-muted" style="text-transform:uppercase;letter-spacing:.5px" data-s="cq.bookingColor">My booking color</label>
-        <input type="color" id="cqBookingColor" data-cq-change="saveCqBookingColor" class="border-muted rounded-4 bg-surface cursor-pointer" style="width:36px;height:26px">
-        <div id="cqBookingColorSwatches"></div>
+      <div class="d-flex items-center gap-6 ml-auto pos-relative">
+        <label class="text-10 text-muted" style="text-transform:uppercase;letter-spacing:.5px" data-s="cq.bookingColor">My booking color</label>
+        <button type="button" id="cqBookingColorBtn" data-cq-click="toggleCqBookingColorPop" aria-haspopup="dialog" aria-expanded="false" class="border-muted rounded-4 cursor-pointer" style="width:36px;height:26px;padding:0;border:1px solid var(--border);background:#2e7d32"></button>
+        <div id="cqBookingColorPop" class="hidden" style="position:absolute;top:calc(100% + 6px);right:0;z-index:500;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px;box-shadow:var(--shadow-md);min-width:200px">
+          <div class="d-flex items-center gap-8 mb-8">
+            <input type="color" id="cqBookingColor" data-cq-change="saveCqBookingColor" class="border-muted rounded-4 bg-surface cursor-pointer" style="width:36px;height:26px;padding:2px">
+            <span class="text-10 text-muted" data-s="lbl.custom">Custom</span>
+          </div>
+          <div id="cqBookingColorSwatches"></div>
+        </div>
       </div>
     </div>
     <div id="cqSlotGrid" style="overflow-x:auto"></div>

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -21,6 +21,7 @@ var _STRINGS_FLAT = {
   "lbl.off": "Off",
   "lbl.noData": "No data",
   "lbl.unknown": "Unknown",
+  "lbl.custom": "Custom",
   "lbl.name": "Name",
   "lbl.date": "Date",
   "lbl.time": "Time",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -21,6 +21,7 @@ var _STRINGS_FLAT = {
   "lbl.off": "Slökkt",
   "lbl.noData": "Engin gögn",
   "lbl.unknown": "Óþekkt",
+  "lbl.custom": "Sérsniðið",
   "lbl.name": "Nafn",
   "lbl.date": "Dagsetning",
   "lbl.time": "Tími",


### PR DESCRIPTION
The booking-colour control sat inline in the slot-grid toolbar next to the boat filter and week nav. Adding the 12 swatches inline made that row visually noisy, so wrap the whole control in a popover anchored to a single colour-chip trigger button. Clicking the chip toggles a floating panel (native input + swatches); clicking outside or pressing Escape closes it. The chip's background mirrors the current booking colour.

The three other colour pickers (crew, boat-category, cert) already live inside modals and stay inline.

Adds lbl.custom string (EN/IS) for the popover's "Custom" label.

https://claude.ai/code/session_01B5A82DxqmAfLk7d2VE8Ryb