### PR TITLE
Standardize staff page section headers

### DIFF
--- a/staff/index.html
+++ b/staff/index.html
@@ -84,7 +84,7 @@
   </div>
 
   <!-- ══ ACTIVE CHECKOUTS ══ -->
-  <div class="divider-label" data-s="staff.activeCheckouts">ACTIVE CHECKOUTS</div>
+  <div class="section-label mt-16" data-s="staff.activeCheckouts">ACTIVE CHECKOUTS</div>
 
   <!-- Stats strip -->
   <div class="stat-row no-orphans-3 no-orphans-sm-2">
@@ -169,7 +169,7 @@
   </div>
 
   <!-- ══ TOOLS ══ -->
-  <div class="divider-label" data-s="staff.toolsLabel">TOOLS</div>
+  <div class="section-label mt-16" data-s="staff.toolsLabel">TOOLS</div>
   <div class="nav-grid">
     <a href="../dailylog/" class="nav-card">
       <span class="nc-icon nc-icon--dailylog" aria-hidden="true"></span>
@@ -195,7 +195,7 @@
   </div>
   
   <!-- ══ PUNCH CLOCK ══ -->
-  <div class="divider-label" data-s="payroll.section"></div>
+  <div class="section-label mt-16" data-s="payroll.section"></div>
   <div id="punchClockCard" class="info-panel mb-16">
     <div id="punchClockWidget">
       <div class="empty-note" data-s="lbl.loading"></div>
@@ -203,7 +203,7 @@
   </div>
 
   <!-- ══ OPEN MAINTENANCE ══ -->
-  <div class="divider-label" data-s="staff.maintenance">OPEN MAINTENANCE</div>
+  <div class="section-label mt-16" data-s="staff.maintenance">OPEN MAINTENANCE</div>
   <div class="info-panel mb-16">
     <div id="maintList"><div class="empty-note" data-s="lbl.loading"></div></div>
     <div class="mt-10" style="padding-top:10px;border-top:1px solid var(--border)44">
@@ -213,14 +213,14 @@
   </div>
 
   <!-- ══ FLEET STATUS ══ -->
-  <div class="divider-label flex-between">
+  <div class="section-label mt-16 flex-between">
     <span data-s="staff.fleet"></span>
-    
+
   </div>
 
   <!-- Fleet status (bars + expandable boat cards) -->
   <div id="fleetStatus"><div class="empty-note" data-s="lbl.loading"></div></div>
-  <div class="divider-label mt-16"><span data-s="staff.recentCheckins"></span></div>
+  <div class="section-label mt-16"><span data-s="staff.recentCheckins"></span></div>
     <div id="recentCheckins"><div class="empty-note" data-s="lbl.loading"></div></div>
   </div>
 


### PR DESCRIPTION
The staff page used a `divider-label` class for its major section headers (ACTIVE CHECKOUTS, TOOLS, PUNCH CLOCK, OPEN MAINTENANCE, FLEET STATUS, RECENT CHECK-INS), but that class was not defined in any CSS file, leaving those headers completely unstyled. Every other portal uses `section-label` — documented in shared/style.css as "the small uppercase heading used throughout" — and the staff page itself already used `section-label` for its sub-headers.

Replaces each `divider-label` with `section-label mt-16` to match the style used on admin, member, dailylog, incidents, and the staff logbook-review pages.

Fixes #713