### PR TITLE
style(btn-primary): hover darkens instead of lightens in light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — `.btn-primary` hover darkens instead of lightens
+
+`.btn-primary:hover` now uses `--navy-d` (darker) instead of `--navy-l`
+(lighter). In light mode the rest state is already the brand blue
+(`--navy` = `#163274` = header blue), and every other primary-style
+action button (`#groupCheckOutBtn`, etc.) already darkens on hover —
+so the outlier lightening introduced a bonus blue shade whenever you
+hovered a primary button. With every light-mode action button now
+staying inside the dark-brand-blue family at rest and on hover,
+interactions no longer flash an extra pastel blue that competes with
+the header and the `.act-btn` borders (also `--accent` = `#163274`).
+
 ## Unreleased — no-orphan utility for CSS grids
 
 Shared utility classes `.no-orphans-<N>` / `.no-orphans-sm-2` in

--- a/shared/style.css
+++ b/shared/style.css
@@ -528,7 +528,7 @@ textarea { min-height: 70px; }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
 
 .btn-primary  { background: var(--navy);   color: #ffffff; }
-.btn-primary:hover:not(:disabled)  { background: var(--navy-l); box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 40%, transparent); transform: translateY(-1px); }
+.btn-primary:hover:not(:disabled)  { background: var(--navy-d); box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 40%, transparent); transform: translateY(-1px); }
 
 .btn-secondary { background: var(--faint);  color: var(--text); }
 .btn-secondary:hover:not(:disabled) { background: var(--border); box-shadow: var(--shadow-sm); }


### PR DESCRIPTION
In light mode --navy (#163274) already equals --accent and --header-bg, so .btn-primary at rest already renders as the brand blue the user sees on the header. The hover state was the outlier — it swapped to --navy-l (a lighter 78%-white mix), introducing a pastel blue shade during interactions that didn't appear anywhere else in the palette.

Every other primary-tone action button (#groupCheckOutBtn, etc.) already darkens on hover via --navy-d, so switching .btn-primary to --navy-d unifies the "press" feel and keeps every light-mode action button inside the dark-brand-blue family, at rest and on hover. The .act-btn quick- action borders (--accent = #163274) stay matched to the header blue, which was the other half of the issue.

Fixes #711

https://claude.ai/code/session_01DPcShzavjLRwkKUNzhvrYE