### PR TITLE
Surface bulk-scheduled activities in daily log + tighten trip cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — bulk-scheduled activities flow into the daily log
+
+Activities defined per-subtype as `bulkSchedule` entries in `activity_types`
+config now surface automatically on the daily log for any matching date,
+without writing to the `dailyLog` sheet until the day is actually saved by
+staff or frozen by the midnight trigger.
+
+- Added `projectActivitiesForDate_(dateISO)` in `config.gs`: expands each
+  active subtype's `bulkSchedule` (fromDate/toDate/daysOfWeek/startTime/
+  endTime) into activity items of the same shape `dailyLog.activities`
+  stores. Each projected item carries `scheduled: true`.
+- `getDailyLog_` in `members.gs` returns `{ log, date, scheduledActivities }`.
+  The frontend uses `scheduledActivities` when no sheet row exists yet —
+  today pre-populates with the projection (user can edit/delete before
+  saving); future days render read-only so users can browse ahead.
+- Removed the forward-date guard in `dailylog/dailylog.js` so the `▶` button
+  no longer dead-ends at today. `isFuture()` added; future days skip the
+  trips + incidents fetch and show the projected activities.
+- New `materializeYesterday_` + `setupDailyLogMidnightTrigger()` installer
+  in `members.gs`. Time-driven trigger runs at local midnight, inserts a
+  `dailyLog` row for the day that just ended (if none exists) with the
+  projected activities snapshotted in. This prevents subsequent bulk-schedule
+  edits from silently rewriting historical days. Run
+  `setupDailyLogMidnightTrigger()` once from the Apps Script editor.
+- "Scheduled" badge (`daily.scheduled` string) on pre-populated activities
+  in both editable + read-only views so users can tell projected items apart
+  from manually-added ones.
+
+## Unreleased — incidents filter by event date, not filing time
+
+`getIncidents_({ date })` in `incidents.gs` was bucketing incidents by
+`filedAt`/`createdAt` — the *filing* timestamp — so an incident that
+happened Monday but was filed Tuesday would appear on the wrong day of the
+daily log. Now filters on `i.date` (the user-entered event date) with a
+fallback to `filedAt`/`createdAt` for legacy rows that predate the split.
+
+## Unreleased — trip cards condensed to 2-column + boat-category tint
+
+`shared/tripcard.js` collapsed card is now a 2-col label/value grid:
+boat/crew · out/in · location/duration. Status badges (skipper/crew,
+verified, student, non-club, pending) moved to a compact row below the
+grid. All data is preserved; the expanded card is unchanged.
+
+Boat-category color now tints the whole card, not just the left border.
+`--tc-cat` / `--tc-cat-bg` CSS custom properties are set inline from
+`boatCatColors()` and drive the card background, the date column, and the
+expanded boat/logistics sections via `color-mix()` at 5–10% alpha.
+
 ## Unreleased — no-orphan utility for CSS grids
 
 Shared utility classes `.no-orphans-<N>` / `.no-orphans-sm-2` in

--- a/config.gs
+++ b/config.gs
@@ -75,6 +75,51 @@ function getConfig_() {
   return okJ(config);
 }
 
+// ── Bulk-schedule projection ──────────────────────────────────────────────────
+// Expand per-subtype bulkSchedule blobs (fromDate/toDate/daysOfWeek/startTime/
+// endTime) into activity items for a given local date. Used by getDailyLog_ to
+// pre-populate today's/future days' activities without writing to the sheet
+// until the row is actually saved or materialized at midnight.
+//
+// Each returned item mirrors the shape stored under dailyLog.activities so the
+// frontend can treat scheduled + user-added activities uniformly:
+//   { id, activityTypeId, subtypeId, subtypeName, type, name,
+//     start, end, participants, notes, scheduled: true }
+function projectActivitiesForDate_(dateISO) {
+  if (!dateISO) return [];
+  var types = [];
+  try { types = JSON.parse(getConfigValue_('activity_types', getConfigMap_()) || '[]'); } catch (e) { return []; }
+  if (!Array.isArray(types) || !types.length) return [];
+  var dow = String(new Date(dateISO + 'T12:00:00').getDay()); // '0'..'6'
+  var out = [];
+  types.forEach(function(at) {
+    if (!at || at.active === false) return;
+    var subs = Array.isArray(at.subtypes) ? at.subtypes : [];
+    subs.forEach(function(st) {
+      if (!st || !st.bulkSchedule) return;
+      var bs = st.bulkSchedule;
+      if (bs.fromDate && dateISO < bs.fromDate) return;
+      if (bs.toDate   && dateISO > bs.toDate)   return;
+      var days = Array.isArray(bs.daysOfWeek) ? bs.daysOfWeek.map(String) : [];
+      if (!days.length || days.indexOf(dow) === -1) return;
+      out.push({
+        id:             'sched-' + at.id + '-' + st.id + '-' + dateISO,
+        activityTypeId: at.id,
+        subtypeId:      st.id,
+        subtypeName:    st.name || '',
+        type:           at.name || '',
+        name:           st.name || at.name || '',
+        start:          bs.startTime || st.defaultStart || '',
+        end:            bs.endTime   || st.defaultEnd   || '',
+        participants:   '',
+        notes:          '',
+        scheduled:      true,
+      });
+    });
+  });
+  return out;
+}
+
 function saveConfig_(b) {
   let saved = {};
 

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -184,9 +184,10 @@ function renderActivities() {
     const info = document.createElement('div'); info.className = 'activity-info';
     const meta = [act.type, act.subtypeName||'', act.start && act.end ? act.start+'\u2013'+act.end : act.start, act.participants].filter(Boolean).join(' \u00b7 ');
     const ablerBadge  = act.ablerRegistered ? '<span style="font-size:9px;background:color-mix(in srgb, var(--moss) 12%, transparent);border:1px solid color-mix(in srgb, var(--moss) 40%, transparent);color:var(--moss);border-radius:10px;padding:1px 7px;margin-left:6px;letter-spacing:.3px">Abler ✓</span>' : '';
+    const scheduledBadge = act.scheduled ? '<span style="font-size:9px;background:color-mix(in srgb, var(--navy) 10%, transparent);border:1px solid color-mix(in srgb, var(--navy) 40%, transparent);color:var(--navy);border-radius:10px;padding:1px 7px;margin-left:6px;letter-spacing:.3px">' + s('daily.scheduled') + '</span>' : '';
     const linkedCount = act.linkedGroupCheckoutIds && act.linkedGroupCheckoutIds.length
       ? '<span style="font-size:9px;background:var(--card);border:1px solid color-mix(in srgb, var(--navy) 33%, transparent);border-left:2px solid var(--navy);border-radius:4px;padding:1px 7px;margin-left:4px">⛵ ' + act.linkedGroupCheckoutIds.length + ' ' + (act.linkedGroupCheckoutIds.length>1?s('daily.groups'):s('daily.group')) + '</span>' : '';
-    info.innerHTML = `<div class="activity-name">${esc(act.name)}${ablerBadge}${linkedCount}</div>
+    info.innerHTML = `<div class="activity-name">${esc(act.name)}${scheduledBadge}${ablerBadge}${linkedCount}</div>
       <div class="activity-meta">${esc(meta)}</div>
       ${act.notes ? `<div class="activity-nity-note">${esc(act.notes)}</div>` : ''}`;
     const del = document.createElement('button');
@@ -203,7 +204,8 @@ function renderActivitiesReadonly() {
     row.className = 'activity-row';
     const info = document.createElement('div'); info.className = 'activity-info';
     const meta = [act.type, act.start && act.end ? act.start+'–'+act.end : act.start, act.participants].filter(Boolean).join(' · ');
-    info.innerHTML = `<div class="activity-name">${esc(act.name)}</div>
+    const scheduledBadge = act.scheduled ? '<span style="font-size:9px;background:color-mix(in srgb, var(--navy) 10%, transparent);border:1px solid color-mix(in srgb, var(--navy) 40%, transparent);color:var(--navy);border-radius:10px;padding:1px 7px;margin-left:6px;letter-spacing:.3px">' + s('daily.scheduled') + '</span>' : '';
+    info.innerHTML = `<div class="activity-name">${esc(act.name)}${scheduledBadge}</div>
       <div class="activity-meta">${esc(meta)}</div>
       ${act.notes ? `<div class="activity-note">${esc(act.notes)}</div>` : ''}`;
     row.appendChild(info);
@@ -505,10 +507,11 @@ document.addEventListener('DOMContentLoaded', () => {
 // ════════════════════════════════════════════════════════════════════════════
 // SECTION 7 — DATE NAVIGATION
 // ════════════════════════════════════════════════════════════════════════════
-function isToday() { return viewDate === TODAY; }
+function isToday()  { return viewDate === TODAY; }
+function isFuture() { return viewDate >  TODAY; }
 
 function updateDateNav() {
-  dom.nextBtn.disabled = isToday();
+  dom.nextBtn.disabled = false;
   dom.todayBtn.disabled = isToday();
   dom.mainWrap.classList.toggle('readonly', !isToday());
   const isEditable = isToday();
@@ -523,9 +526,7 @@ function updateDateNav() {
 function navigateDay(d) {
   const dt = new Date(viewDate + 'T12:00:00');
   dt.setDate(dt.getDate() + d);
-  const next = dt.toISOString().slice(0, 10);
-  if (next > TODAY) return;
-  viewDate = next;
+  viewDate = dt.toISOString().slice(0, 10);
   loadDay();
 }
 
@@ -724,8 +725,11 @@ async function loadDay() {
 
   if (isToday()) {
     await Promise.all([loadTodayLog(), loadTodayTrips()]);
+  } else if (isFuture()) {
+    await loadOtherLog();
+    tripsData = []; renderTrips();
   } else {
-    await Promise.all([loadPastLog(), loadPastTrips()]);
+    await Promise.all([loadOtherLog(), loadPastTrips()]);
   }
 }
 
@@ -737,7 +741,7 @@ async function loadTodayLog() {
       apiGet('getConfig'),
       loadIncidentsForDate(TODAY),
     ]);
-    applyLogData(logRes.log, cfgRes);
+    applyLogData(logRes, cfgRes);
     renderIncidentSection(incidents);
   } catch(e) {
     console.warn('loadTodayLog failed:', e.message);
@@ -751,17 +755,19 @@ async function loadTodayLog() {
   renderActTypeBtns();
 }
 
-async function loadPastLog() {
+// Loads a non-today day (past or future). No sheet row is written until the
+// user edits + saves, or the midnight trigger materializes it.
+async function loadOtherLog() {
   try {
     const [logRes, cfgRes, incidents] = await Promise.all([
       apiGet('getDailyLog', { date: viewDate }),
       apiGet('getConfig'),
-      loadIncidentsForDate(viewDate),
+      isFuture() ? Promise.resolve([]) : loadIncidentsForDate(viewDate),
     ]);
-    applyLogData(logRes.log, cfgRes);
+    applyLogData(logRes, cfgRes);
     renderIncidentSection(incidents);
   } catch(e) {
-    console.warn('loadPastLog failed:', e.message);
+    console.warn('loadOtherLog failed:', e.message);
     renderIncidentSection([]);
   }
   renderChecklistsReadonly();
@@ -793,7 +799,7 @@ async function loadIncidentsForDate(date) {
   } catch(e) { return []; }
 }
 
-function applyLogData(log, cfgRes) {
+function applyLogData(logRes, cfgRes) {
   const cfg = cfgRes || {};
   if (cfg.flagConfig && typeof wxLoadFlagConfig === 'function') wxLoadFlagConfig(cfg.flagConfig);
   amItems       = cfg.dailyChecklist?.opening || DEFAULT_AM;
@@ -801,6 +807,9 @@ function applyLogData(log, cfgRes) {
   activityTypes = cfg.activityTypes       || DEFAULT_TYPES;
   // Always auto-fill tides from harmonic prediction for the viewed date
   _autoFillTide();
+
+  const log = logRes && logRes.log ? logRes.log : null;
+  const scheduled = (logRes && Array.isArray(logRes.scheduledActivities)) ? logRes.scheduledActivities : [];
 
   if (log) {
     logId    = log.id;
@@ -815,6 +824,12 @@ function applyLogData(log, cfgRes) {
         ? ' at ' + fmtTime(log.signedOffAt) : '';
       dom.signoffBadge.textContent = s('daily.signedOffBy') + (log.signedOffBy||'') + at;
     }
+  } else {
+    // No sheet row yet — pre-populate from the bulk schedule so today's user
+    // sees the planned lessons/events, and forward-browsing shows what's coming.
+    // Nothing is written to the sheet until the user edits + saves (isToday)
+    // or the midnight trigger materializes the day.
+    activities = scheduled;
   }
 }
 

--- a/incidents.gs
+++ b/incidents.gs
@@ -8,7 +8,12 @@ function getIncidents_(b) {
   const all = c || readAll_('incidents');
   if (!c) cPut_('incidents', all);
   if (b.date) {
-    const incidents = all.filter(function(i) { return (i.filedAt || i.createdAt || '').slice(0, 10) === b.date; });
+    // Filter by the actual event date (i.date), not the filing timestamp.
+    // Legacy rows without an event date fall back to filedAt/createdAt.
+    const incidents = all.filter(function(i) {
+      var ev = i.date || (i.filedAt || i.createdAt || '').slice(0, 10);
+      return ev === b.date;
+    });
     return okJ({ incidents });
   }
   return okJ({ incidents: all });

--- a/members.gs
+++ b/members.gs
@@ -739,7 +739,13 @@ function getDailyLog_(date) {
   // anywhere else. nowLocalDate_() matches the format saveDailyLog_ writes.
   const d = date || nowLocalDate_();
   const log = findOne_('dailyLog', 'date', d);
-  return okJ({ log: log || null, date: d });
+  // Projected activities from bulk schedules (see projectActivitiesForDate_
+  // in config.gs). The frontend uses these when no row exists yet — browsing
+  // forward past today doesn't materialize a sheet row until the day is
+  // either saved by staff or materialized by the midnight trigger below.
+  var scheduledActivities = [];
+  try { scheduledActivities = projectActivitiesForDate_(d); } catch (e) {}
+  return okJ({ log: log || null, date: d, scheduledActivities: scheduledActivities });
 }
 
 function saveDailyLog_(b) {
@@ -779,6 +785,42 @@ function saveDailyLog_(b) {
     });
     return okJ({ date, created: true });
   }
+}
+
+// ── Midnight materialization ─────────────────────────────────────────────────
+// Time-driven trigger: at local midnight, insert a dailyLog row for the day
+// that just ended if none exists. Snapshots the bulk-scheduled activities so
+// subsequent edits to a bulk schedule don't silently rewrite historical days.
+// No-op when a row already exists (manually saved or signed off).
+//
+// Install once from the Apps Script editor:
+//   setupDailyLogMidnightTrigger()
+function materializeYesterday_() {
+  var d = new Date();
+  d.setDate(d.getDate() - 1);
+  var dateISO = Utilities.formatDate(d, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  if (findOne_('dailyLog', 'date', dateISO)) return; // already there
+  var scheduled = [];
+  try { scheduled = projectActivitiesForDate_(dateISO); } catch (e) { scheduled = []; }
+  if (!scheduled.length) return; // nothing to freeze
+  var ts = now_();
+  insertRow_('dailyLog', {
+    id: uid_(), date: dateISO,
+    openingChecks: '{}', closingChecks: '{}',
+    activities: JSON.stringify(scheduled),
+    weatherLog: '[]', narrative: '',
+    tideData: '{}',
+    signedOffBy: '', signedOffAt: '',
+    updatedBy: 'auto:midnight', createdAt: ts, updatedAt: ts,
+  });
+}
+
+function setupDailyLogMidnightTrigger() {
+  ScriptApp.getProjectTriggers().forEach(function(t) {
+    if (t.getHandlerFunction() === 'materializeYesterday_') ScriptApp.deleteTrigger(t);
+  });
+  ScriptApp.newTrigger('materializeYesterday_').timeBased().atHour(0).everyDays(1).create();
+  Logger.log('Daily-log midnight materializer registered.');
 }
 
 

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -379,6 +379,7 @@ var _STRINGS_FLAT = {
   "daily.readOnly": "Read-only",
   "daily.noActivities": "No activities recorded yet.",
   "daily.noTrips": "No trips recorded today.",
+  "daily.scheduled": "Scheduled",
   "daily.activityModal": "Add Activity",
   "daily.actType": "Type",
   "daily.actNameLabel": "Name / description",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -379,6 +379,7 @@ var _STRINGS_FLAT = {
   "daily.readOnly": "Lesaðgangur",
   "daily.noActivities": "Engin starfsemi skráð enn.",
   "daily.noTrips": "Engar ferðir skráðar í dag.",
+  "daily.scheduled": "Áætlað",
   "daily.activityModal": "Bæta við starfsemi",
   "daily.actType": "Tegund",
   "daily.actNameLabel": "Nafn / lýsing",

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -1,13 +1,24 @@
 /* ── Trip card (shared between logbook & captain) ── */
-.trip-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
+/* --tc-cat / --tc-cat-bg are set inline from boatCatColors() so the card and
+   its expanded sections tint with the boat category. */
+.trip-card{background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface));border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
 .trip-card:hover{border-color:var(--moss-l)}
 .trip-card-main{display:grid;grid-template-columns:52px 1fr auto;align-items:stretch;cursor:pointer}
-.trip-date-col{background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}
+.trip-date-col{background:color-mix(in srgb, var(--tc-cat, transparent) 10%, var(--card));border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}
 .trip-date-day{font-size:16px;font-weight:500;color:var(--text);line-height:1}
 .trip-date-mon{font-size:14px;font-weight:500;color:var(--text);text-transform:uppercase;margin-top:2px}
 .trip-date-yr{font-size:9px;color:var(--muted)}
 .trip-body{padding:10px 12px;min-width:0}
-.trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:4px}
+/* 2-col collapsed layout: boat/crew · out/in · location/duration */
+.trip-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:6px 14px}
+.trip-cell{display:flex;flex-direction:column;gap:1px;min-width:0}
+.trip-lbl{font-size:9px;color:var(--muted);letter-spacing:.6px;text-transform:uppercase}
+.trip-val{color:var(--text);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.trip-val.trip-boat{font-weight:500;font-size:14px}
+.trip-badges{display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-top:8px;font-size:11px;color:var(--muted)}
+.trip-port{font-size:11px;color:var(--muted)}
+/* Legacy .trip-boat / .trip-meta kept for any non-card callers */
+.trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center}
 .trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
 .badge-skipper{color:var(--accent-fg);border-color:var(--accent)55;background:var(--accent)11}
@@ -30,8 +41,8 @@
 .exp-section{margin:0 -12px;padding:6px 12px 10px;border-top:1px solid var(--border)}
 .exp-section:first-child{padding-top:10px}
 .exp-section .trip-expand-grid{border-top:none;padding-top:2px;margin-top:0}
-.exp-boat{background:var(--card)}
-.exp-logistics{background:var(--card)}
+.exp-boat{background:color-mix(in srgb, var(--tc-cat, transparent) 10%, var(--card))}
+.exp-logistics{background:color-mix(in srgb, var(--tc-cat, transparent) 7%, var(--card))}
 .exp-weather{background:color-mix(in srgb, var(--navy) 8%, transparent)}
 .exp-weather .trip-expand-grid{padding-top:4px}
 .exp-notes{background:var(--faint)}

--- a/shared/tripcard.js
+++ b/shared/tripcard.js
@@ -374,7 +374,19 @@ function tripCard(t){
   const hasDetailWx = !!(eDir||eGust||eAir||eFeel||eSst||eWv||ePres||eFlag);
 
 
-  return `<div class="trip-card" style="border-left:3px solid ${catCol.color}">
+  // Helm initials for the collapsed "crew" cell
+  const helmInitials = helmPlainNames.length ? (()=>{
+    const _ini = n => n.split(/\s+/).filter(t=>t&&t!==t.toLowerCase()).map(t=>t.replace(/-/g,'').charAt(0)).join('').toUpperCase();
+    const _memberIni = h => { const m = allMembers.find(x=>x.kennitala&&String(x.kennitala)===h.kt); return (m&&m.initials)?m.initials:_ini(h.name); };
+    return helmPlainNames.map(h => h.kt===String(user.kennitala) ? s('tc.me') : _memberIni(h))
+      .sort((a,b)=> a===s('tc.me') ? -1 : b===s('tc.me') ? 1 : a.localeCompare(b,'is'))
+      .map(n=>esc(n)).join(', ');
+  })() : '';
+  const hasPendingBadge = !isVer && isSki && (pendingCrewConfs.length||pendingHelmConfs.length||pendingStudentConfs.length||pendingCrewIn.length||pendingHelmIn.length||pendingStudentIn.length);
+  const hasVerifyPending = (t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer;
+  const isStudent = (t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)));
+
+  return `<div class="trip-card" style="--tc-cat:${catCol.color};--tc-cat-bg:${catCol.bg};border-left:3px solid var(--tc-cat)">
     <div class="trip-card-main" data-trip-action="open-card">
       <div class="trip-date-col">
         <div class="trip-date-day">${esc(p.day)}</div>
@@ -382,19 +394,40 @@ function tripCard(t){
         <div class="trip-date-yr">${esc(p.yr)}</div>
       </div>
       <div class="trip-body">
-        <div class="trip-boat">${esc(t.boatName||'—')}</div>
-        <div class="trip-meta">
+        <div class="trip-grid">
+          <div class="trip-cell">
+            <span class="trip-lbl">${s('lbl.boat')}</span>
+            <span class="trip-val trip-boat">${esc(t.boatName||'—')}</span>
+          </div>
+          <div class="trip-cell">
+            <span class="trip-lbl">${s('lbl.crew')}</span>
+            <span class="trip-val">${aboardCount}${helmInitials?` · <span class="text-accent">⎈ ${helmInitials}</span>`:''}</span>
+          </div>
+          <div class="trip-cell">
+            <span class="trip-lbl">${s('tc.departed')}</span>
+            <span class="trip-val">${_timeOut?esc(_timeOut):'—'}</span>
+          </div>
+          <div class="trip-cell">
+            <span class="trip-lbl">${s('tc.returned')}</span>
+            <span class="trip-val">${_timeIn?esc(_timeIn):'—'}</span>
+          </div>
+          <div class="trip-cell">
+            <span class="trip-lbl">${s('lbl.location')}</span>
+            <span class="trip-val">${esc(_locationName||'—')}</span>
+          </div>
+          <div class="trip-cell">
+            <span class="trip-lbl">${s('tc.duration')}</span>
+            <span class="trip-val">${esc(dur)}${_distNm?` · ${esc(_distNm)} nm`:''}${windLine?` · <span class="trip-wind">${windLine}</span>`:''}</span>
+          </div>
+        </div>
+        <div class="trip-badges">
           <span class="trip-badge ${isSki?'badge-skipper':'badge-crew'}">${isSki?s('tc.skipper'):s('tc.crew')}</span>
-          ${helmPlainNames.length?`<span class="trip-badge badge-helm">⎈ ${(()=>{const _ini=n=>n.split(/\s+/).filter(t=>t&&t!==t.toLowerCase()).map(t=>t.replace(/-/g,'').charAt(0)).join('').toUpperCase();const _memberIni=h=>{const m=allMembers.find(x=>x.kennitala&&String(x.kennitala)===h.kt);return (m&&m.initials)?m.initials:_ini(h.name);};return helmPlainNames.map(h=>h.kt===String(user.kennitala)?s('tc.me'):_memberIni(h)).sort((a,b)=>a===s('tc.me')?-1:b===s('tc.me')?1:a.localeCompare(b,'is')).map(n=>esc(n)).join(', ')})()}</span>`:''}
-          ${t.nonClub&&t.nonClub!=='false'?`<span class="trip-badge" style="background:var(--surface);border:1px solid var(--border);font-size:9px">${s('tc.nonClub')}</span>`:''}
-          ${(t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)))?`<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 8%, transparent);border:1px solid color-mix(in srgb, var(--navy-l) 33%, transparent);color:var(--navy-l);font-size:9px">${s('tc.student')}</span>`:''}
-          ${isVer?'<span class="trip-badge badge-verified">✓</span>':'' }
-          ${!isVer && isSki && (pendingCrewConfs.length||pendingHelmConfs.length||pendingStudentConfs.length||pendingCrewIn.length||pendingHelmIn.length||pendingStudentIn.length) ? '<span class="trip-badge" style="background:var(--yellow)11;border:1px solid var(--yellow)55;color:var(--yellow);font-size:9px">⏳ '+s('tc.pending')+'</span>' : ''}
-          ${(t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer ? '<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 12%, transparent);border:1px solid var(--navy-l);color:var(--navy-l);font-size:9px">⏳ '+s('tc.verificationPending')+'</span>' : ''}
-          <span>${esc(dur)}</span>
-          ${_distNm?`<span>${esc(_distNm)} nm</span>`:''}
-          ${windLine?'<span class="trip-wind">'+windLine+'</span>':''}
-          ${isKeelboat&&portLine?portLine:''}
+          ${isVer?'<span class="trip-badge badge-verified">✓</span>':''}
+          ${isStudent?`<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 8%, transparent);border:1px solid color-mix(in srgb, var(--navy-l) 33%, transparent);color:var(--navy-l)">${s('tc.student')}</span>`:''}
+          ${t.nonClub&&t.nonClub!=='false'?`<span class="trip-badge" style="background:var(--surface);border:1px solid var(--border)">${s('tc.nonClub')}</span>`:''}
+          ${hasPendingBadge?'<span class="trip-badge" style="background:var(--yellow)11;border:1px solid var(--yellow)55;color:var(--yellow)">⏳ '+s('tc.pending')+'</span>':''}
+          ${hasVerifyPending?'<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 12%, transparent);border:1px solid var(--navy-l);color:var(--navy-l)">⏳ '+s('tc.verificationPending')+'</span>':''}
+          ${isKeelboat&&portLine?'<span class="trip-port">'+portLine+'</span>':''}
         </div>
       </div>
       <div class="trip-arrow">▾</div>


### PR DESCRIPTION
- Project per-subtype bulkSchedule entries into daily-log activities without materializing the sheet row; user sees scheduled items on today and can browse ahead read-only
- Midnight trigger (setupDailyLogMidnightTrigger) freezes yesterday's projection into a dailyLog row so later schedule edits don't silently rewrite history
- Filter getIncidents by event date (i.date), falling back to filedAt only for legacy rows, so incidents appear on the day they happened
- Collapse trip card to a 2-col grid (boat/crew, out/in, location/duration) and extend boat-category color across the card and expanded sections via --tc-cat / --tc-cat-bg