### PR TITLE
Split captain reservations toolbar into two rows

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -79,17 +79,9 @@
   <!-- ══ RESERVATIONS ══ -->
   <div class="cq-section" id="sectReservations">
     <div class="cq-section-hdr" data-s="cq.reservationsTitle">RESERVATIONS</div>
-    <div class="d-flex items-center gap-8 mb-10 flex-wrap">
+    <div class="d-flex items-center gap-8 mb-8 flex-wrap">
       <label data-s="slot.filterBoat" class="text-10 text-muted" style="text-transform:uppercase;letter-spacing:.5px" for="cqResBoat">Boat</label>
       <select id="cqResBoat" data-cq-change="loadCqSlots" class="filter-select"></select>
-      <div class="slot-week-nav">
-        <button class="btn btn-secondary btn-sm" data-cq-click="shiftCqWeek" data-cq-arg="-1">&larr;</button>
-        <span id="cqWeekLabel" class="week-label"></span>
-        <button class="btn btn-secondary btn-sm" data-cq-click="shiftCqWeek" data-cq-arg="1">&rarr;</button>
-        <button class="btn btn-secondary btn-sm" data-cq-click="cqWeekToday" data-s="slot.today">Today</button>
-        <button class="btn btn-primary btn-sm" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" data-cq-click="openCreateSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
-        <button class="btn btn-primary btn-sm" data-s="slot.bulkBook" data-s-attr="title" data-cq-click="openBulkSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
-      </div>
       <div class="d-flex items-center gap-6 ml-auto pos-relative">
         <label class="text-10 text-muted" style="text-transform:uppercase;letter-spacing:.5px" data-s="cq.bookingColor">My booking color</label>
         <button type="button" id="cqBookingColorBtn" data-cq-click="toggleCqBookingColorPop" aria-haspopup="dialog" aria-expanded="false" class="border-muted rounded-4 cursor-pointer" style="width:36px;height:26px;padding:0;border:1px solid var(--border);background:#2e7d32"></button>
@@ -100,6 +92,16 @@
           </div>
           <div id="cqBookingColorSwatches"></div>
         </div>
+      </div>
+    </div>
+    <div class="d-flex items-center gap-8 mb-10 flex-wrap">
+      <div class="slot-week-nav">
+        <button class="btn btn-secondary btn-sm" data-cq-click="shiftCqWeek" data-cq-arg="-1">&larr;</button>
+        <span id="cqWeekLabel" class="week-label"></span>
+        <button class="btn btn-secondary btn-sm" data-cq-click="shiftCqWeek" data-cq-arg="1">&rarr;</button>
+        <button class="btn btn-secondary btn-sm" data-cq-click="cqWeekToday" data-s="slot.today">Today</button>
+        <button class="btn btn-primary btn-sm" id="cqCreateSlotBtn" data-s="slot.createAndBook" data-s-attr="title" data-cq-click="openCreateSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="12" cy="15.5" r="1.8" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.createAndBook">+ New Booking</span></button>
+        <button class="btn btn-primary btn-sm" data-s="slot.bulkBook" data-s-attr="title" data-cq-click="openBulkSlotModal"><svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 3v4M16 3v4"/><circle cx="8" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="14" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="18" r="1" fill="currentColor" stroke="none"/><circle cx="16" cy="18" r="1" fill="currentColor" stroke="none"/></svg><span class="btn-label" data-s="slot.bulkBook">Bulk Book</span></button>
       </div>
     </div>
     <div id="cqSlotGrid" style="overflow-x:auto"></div>


### PR DESCRIPTION
Boat selector + booking-color picker sit on one line; week navigation and booking action buttons wrap to a second line. Improves layout on small screens where the single-row flex was overcrowding.

https://claude.ai/code/session_011p9d8ecrTMoJFoLdS1QpSG