### PR TITLE
Color boat cards by category, not status

### DIFF
--- a/member/member.css
+++ b/member/member.css
@@ -134,11 +134,11 @@
 .fsb-arrow { font-size:11px;color:var(--muted); }
 .fsb-body { padding:4px 0; }
 .fleet-cat-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:6px; padding:4px; }
+/* Left border is set inline by renderBoatCard() to the category color;
+   status is expressed through badges + opacity, not border color. */
 .bc-card { background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;font-size:12px; }
-.bc-avail { border-left:3px solid var(--moss);cursor:pointer; }
+.bc-avail { cursor:pointer; }
 .bc-avail:hover { background:var(--faint); }
-.bc-out { border-left:3px solid var(--accent); }
-.bc-overdue { border-left:3px solid var(--red); }
 .bc-oos { opacity:.5; }
 
 /* ── Pending confirmations ── */

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -415,10 +415,11 @@ function renderBoatCard(boat, opts) {
   // Muted card style for restricted boats (controlled access without authorization)
   const isMuted = (!opts.staffView && controlled && !userCanAccess);
   const charteredMuted = isMuted ? "opacity:.55;pointer-events:none;" : "";
-  // OOS cards keep a muted left accent in the category color (opacity from .bc-oos)
-  const oosBorder = status === "oos" ? `border-left:3px solid ${boatCatColors(cat).color};` : "";
+  // Left accent always reflects the boat category; oos/restricted cards are
+  // muted via opacity (.bc-oos / charteredMuted) rather than a different color.
+  const catBorder = `border-left:3px solid ${boatCatColors(cat).color};`;
 
-  return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}${oosBorder}">`
+  return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}${catBorder}">`
        + `<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:4px">`
        + `<div style="font-size:14px;font-weight:500;color:var(--text)">${emoji} ${name}</div>`
        + `<div style="display:flex;gap:4px;flex-shrink:0">${ownerBadge}${bdgHtml}</div>`

--- a/shared/style.css
+++ b/shared/style.css
@@ -771,19 +771,19 @@ textarea { min-height: 70px; }
 
 /* ── BOAT CARDS (shared/boats.js) ─────────────────────────────────────────────── */
 
-/* Fleet card — available / out / oos */
+/* Fleet card — available / out / oos.
+   Left border is set inline by renderBoatCard() to the category color.
+   Status is expressed through badges + opacity, not border color. */
 .bc-card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-left: 3px solid var(--moss);
   border-radius: var(--radius-md);
   padding: 12px 14px;
   transition: border-color .2s, box-shadow .2s;
   box-shadow: var(--shadow-sm);
 }
-.bc-card.bc-avail   { }
-.bc-card.bc-out     { border-left: 3px solid var(--accent); }
-.bc-card.bc-overdue { border-left: 3px solid var(--red); }
+.bc-card.bc-avail   { cursor: pointer; }
+.bc-card.bc-avail:hover { background: var(--faint); }
 .bc-card.bc-oos     { opacity: .55; }
 
 /* Checkout card — active checkouts */


### PR DESCRIPTION
The fleet-status grid on the staff hub and the member fleet tab rendered every available card with the same green left border because `.bc-card` defaulted to `var(--moss)` and only oos cards got a category-colored border via inline style. Status was a second signal on top of the badge.

Use the category color for every card's left border and express status with opacity and the existing badge instead, so a glance at the grid immediately groups boats by category.

- Apply category-colored `border-left` inline in renderBoatCard for every status (not just oos).
- Drop the status-based border overrides in shared/style.css and member/member.css; keep the oos/restricted opacity muting.