### PR TITLE
Daily log date picker + defensive incident date filter

### DIFF
--- a/dailylog/dailylog.css
+++ b/dailylog/dailylog.css
@@ -11,6 +11,9 @@
 .readonly-badge { display:inline-flex; align-items:center;
   background:var(--surface); border:1px solid var(--border); color:var(--muted);
   border-radius:var(--radius-sm); padding:4px 10px; font-size:11px; }
+.date-picker-sm { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-sm);
+  color:var(--text); font-family:inherit; font-size:12px; padding:4px 8px; cursor:pointer; }
+.date-picker-sm:hover { border-color:var(--accent); }
 
 /* ── Section headings ── */
 .section-heading { font-size:9px; color:var(--muted); letter-spacing:1px;

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -64,6 +64,7 @@ const dom = domRefs({
   prevBtn:           'prevBtn',
   nextBtn:           'nextBtn',
   todayBtn:          'todayBtn',
+  datePicker:        'datePicker',
   signoffBadge:      'signoffBadge',
   readonlyBadge:     'readonlyBadge',
   logWxBtn:          'logWxBtn',
@@ -452,6 +453,12 @@ document.addEventListener('DOMContentLoaded', () => {
   dom.prevBtn.addEventListener('click',  () => debouncedNav(-1));
   dom.nextBtn.addEventListener('click',  () => debouncedNav(1));
   dom.todayBtn.addEventListener('click', () => navigateToToday());
+  dom.datePicker.addEventListener('change', () => {
+    const v = dom.datePicker.value;
+    if (!v) return;
+    viewDate = v;
+    loadDay();
+  });
 
   dom.addActivityBtn.addEventListener('click', openActivityModal);
   document.getElementById('actCancelBtn').addEventListener('click', closeActivityModal);
@@ -709,6 +716,7 @@ async function loadDay() {
   const d = new Date(viewDate + 'T12:00:00');
   dom.dateBig.textContent = d.toLocaleDateString(L === 'IS' ? 'is-IS' : 'en-GB', { weekday:'long' }).toUpperCase();
   dom.dateHero.textContent = String(d.getDate()).padStart(2,'0') + ' ' + d.toLocaleDateString(L === 'IS' ? 'is-IS' : 'en-GB', { month:'long' }) + ' ' + d.getFullYear();
+  if (dom.datePicker) dom.datePicker.value = viewDate;
   dom.signoffBadge.classList.add('hidden');
   dom.signoffBadge.textContent = s('daily.signedOff');
   dom.narrativeInput.value = '';

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -33,7 +33,11 @@
     </div>
     <button id="nextBtn">▶</button>
   </div>
-  <div class="flex-center mb-8"><button id="todayBtn" class="btn-ghost-sm text-xs" data-s="daily.today"></button></div>
+  <div class="flex-center flex-wrap gap-8 mb-8">
+    <button id="todayBtn" class="btn-ghost-sm text-xs" data-s="daily.today"></button>
+    <label for="datePicker" class="text-xs text-muted" data-s="daily.jumpTo"></label>
+    <input type="date" id="datePicker" class="date-picker-sm">
+  </div>
 
   <div class="flex-center flex-wrap gap-8 mb-16">
     <div class="signoff-badge hidden" id="signoffBadge"></div>

--- a/incidents.gs
+++ b/incidents.gs
@@ -9,10 +9,15 @@ function getIncidents_(b) {
   if (!c) cPut_('incidents', all);
   if (b.date) {
     // Filter by the actual event date (i.date), not the filing timestamp.
-    // Legacy rows without an event date fall back to filedAt/createdAt.
+    // Slice both sides to 10 chars so a Date-object cell that round-tripped
+    // through sanitizeCell_ (yyyy-MM-dd) matches cleanly, and also tolerates
+    // rows where the cell held extra trailing content. Legacy rows without
+    // an event date fall back to filedAt/createdAt.
+    const target = String(b.date).slice(0, 10);
     const incidents = all.filter(function(i) {
-      var ev = i.date || (i.filedAt || i.createdAt || '').slice(0, 10);
-      return ev === b.date;
+      var ev = String(i.date || '').slice(0, 10)
+            || String(i.filedAt || i.createdAt || '').slice(0, 10);
+      return ev === target;
     });
     return okJ({ incidents });
   }

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -380,6 +380,7 @@ var _STRINGS_FLAT = {
   "daily.noActivities": "No activities recorded yet.",
   "daily.noTrips": "No trips recorded today.",
   "daily.scheduled": "Scheduled",
+  "daily.jumpTo": "Jump to:",
   "daily.activityModal": "Add Activity",
   "daily.actType": "Type",
   "daily.actNameLabel": "Name / description",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -380,6 +380,7 @@ var _STRINGS_FLAT = {
   "daily.noActivities": "Engin starfsemi skráð enn.",
   "daily.noTrips": "Engar ferðir skráðar í dag.",
   "daily.scheduled": "Áætlað",
+  "daily.jumpTo": "Fara á:",
   "daily.activityModal": "Bæta við starfsemi",
   "daily.actType": "Tegund",
   "daily.actNameLabel": "Nafn / lýsing",


### PR DESCRIPTION
- Add <input type=date> "jump to" control next to Today, synced with viewDate on every loadDay, so picking any date navigates directly
- Robustify getIncidents_ filter: slice both i.date and b.date to 10 chars before comparing, guarding against sanitizeCell_ edge cases