### PR TITLE
Collapse weather flag override into expandable header

### DIFF
--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1377,7 +1377,6 @@ var _STRINGS_FLAT = {
   "staff.noSupportBoat": "No support boat on the water",
   "staff.updatedShort": "Upd.",
   "staff.flagOverrideLabel": "WEATHER FLAG OVERRIDE",
-  "staff.flagOverrideSet": "Set override",
   "staff.flagOverrideClear": "Clear override",
   "staff.flagOverrideNotes": "Public note (English)",
   "staff.flagOverrideNotesIS": "Public note (Icelandic)",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1377,7 +1377,6 @@ var _STRINGS_FLAT = {
   "staff.noSupportBoat": "Enginn Gæslubátur á sjó",
   "staff.updatedShort": "Uppf.",
   "staff.flagOverrideLabel": "VEÐURFÁNA YFIRTAKA",
-  "staff.flagOverrideSet": "Setja yfirtöku",
   "staff.flagOverrideClear": "Hreinsa yfirtöku",
   "staff.flagOverrideNotes": "Skýring (birtist félögum)",
   "staff.flagOverrideNotesIS": "Skýring (á íslensku)",

--- a/staff/index.html
+++ b/staff/index.html
@@ -54,15 +54,15 @@
 
   <!-- ══ WEATHER FLAG OVERRIDE ══════════════════════════════════════════════ -->
   <div id="flagOverrideCard" class="mb-12 border-muted" style="background:var(--card);border-radius:10px;padding:12px 14px">
-    <div class="section-label mb-8" data-s="staff.flagOverrideLabel">WEATHER FLAG OVERRIDE</div>
+    <button type="button" id="foToggle" class="section-label mb-8 d-flex items-center gap-6 cursor-pointer w-full" data-staff-click="toggleFlagOverrideForm" aria-expanded="false" aria-controls="foForm" style="background:none;border:0;color:var(--muted);font:inherit;text-align:left;padding:0;letter-spacing:.8px;text-transform:uppercase;font-size:10px">
+      <span data-s="staff.flagOverrideLabel">WEATHER FLAG OVERRIDE</span>
+      <span id="foCaret" aria-hidden="true">▸</span>
+    </button>
     <div id="foActiveRow" class="hidden d-flex flex-wrap items-center gap-10">
       <span id="foActiveBadge" class="items-center gap-6 text-md fw-500" style="display:inline-flex;padding:4px 10px;border-radius:20px;border:1px solid"></span>
       <span id="foActiveNotes" class="text-md flex-1 text-pre-wrap" style="color:var(--text);min-width:160px"></span>
       <span id="foActiveMeta" class="text-xs text-muted"></span>
       <button class="btn btn-secondary btn-sm" data-staff-click="clearFlagOverride"><span data-s="staff.flagOverrideClear">Clear override</span></button>
-    </div>
-    <div id="foInactiveRow" class="d-flex flex-wrap items-center gap-10">
-      <button class="btn btn-secondary btn-sm ml-auto" data-staff-click="toggleFlagOverrideForm" data-staff-arg="true"><span data-s="staff.flagOverrideSet">Set override</span></button>
     </div>
     <div id="foForm" class="hidden mt-10" style="border-top:1px solid var(--border);padding-top:10px">
       <div class="flex-center flex-wrap gap-6 mb-8" id="foFlagBtns"></div>

--- a/staff/staff.js
+++ b/staff/staff.js
@@ -1068,15 +1068,13 @@ let _flagOverride = null;  // { active, flagKey, notes, notesIS, setAt, setByNam
 let _foDraftFlag = 'yellow';
 
 function renderFlagOverrideCard() {
-  const activeRow   = document.getElementById('foActiveRow');
-  const inactiveRow = document.getElementById('foInactiveRow');
-  const form        = document.getElementById('foForm');
+  const activeRow = document.getElementById('foActiveRow');
+  const form      = document.getElementById('foForm');
   const ov = _flagOverride;
-  if (ov && ov.active) {
+  const formOpen = form && !form.classList.contains('hidden');
+  if (ov && ov.active && !formOpen) {
     activeRow.classList.remove('hidden');
     activeRow.style.display = 'flex';
-    inactiveRow.style.display = 'none';
-    form.classList.add('hidden');
     const flag = (typeof SCORE_CONFIG !== 'undefined' && SCORE_CONFIG.flags[ov.flagKey]) || { icon:'⚑', color:'var(--text)', border:'var(--border)', bg:'var(--surface)', advice:ov.flagKey };
     const IS  = (typeof getLang === 'function' && getLang() === 'IS');
     const badge = document.getElementById('foActiveBadge');
@@ -1092,7 +1090,6 @@ function renderFlagOverrideCard() {
   } else {
     activeRow.classList.add('hidden');
     activeRow.style.display = 'none';
-    inactiveRow.style.display = 'flex';
   }
 }
 
@@ -1111,8 +1108,11 @@ function renderFoFlagBtns() {
 function pickFoFlag(key) { _foDraftFlag = key; renderFoFlagBtns(); }
 
 function toggleFlagOverrideForm(show) {
-  const form = document.getElementById('foForm');
-  if (show) {
+  const form   = document.getElementById('foForm');
+  const toggle = document.getElementById('foToggle');
+  const caret  = document.getElementById('foCaret');
+  const wantShow = (typeof show === 'boolean') ? show : form.classList.contains('hidden');
+  if (wantShow) {
     _foDraftFlag = (_flagOverride?.flagKey) || 'yellow';
     document.getElementById('foNotes').value   = _flagOverride?.notes   || '';
     document.getElementById('foNotesIS').value = _flagOverride?.notesIS || '';
@@ -1121,6 +1121,9 @@ function toggleFlagOverrideForm(show) {
   } else {
     form.classList.add('hidden');
   }
+  if (toggle) toggle.setAttribute('aria-expanded', String(wantShow));
+  if (caret)  caret.textContent = wantShow ? '▾' : '▸';
+  renderFlagOverrideCard();
 }
 
 async function saveFlagOverride() {
@@ -1137,7 +1140,7 @@ async function saveFlagOverride() {
   const prev = _flagOverride;
   _flagOverride = ov;
   wxLoadFlagOverride(ov);
-  renderFlagOverrideCard();
+  toggleFlagOverrideForm(false);
   document.getElementById('wxWidget')?._wxRefresh?.();
   try { await apiPost('saveFlagOverride', { flagOverride: ov }); }
   catch(e) {


### PR DESCRIPTION
Replace the "Set override" button with a clickable section header that toggles the form open/closed, with a caret indicator. Saving closes the form automatically; clicking the header when an override is active opens the form prefilled for editing.

https://claude.ai/code/session_01L97ePbhNXHyZwaaFRrb8MT