### PR TITLE
Slim trip-card collapsed view back to one row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — collapse trip cards back to a single-row summary
+
+The 2-column grid added in `860555b` (boat/crew, departed/returned,
+location/duration) made collapsed cards heavy enough to defeat the
+purpose of collapsing. Reverted to the single boat headline + badges
+row: date, boat, duration, wind, and role/verification/student/
+non-club/pending badges. Times, location, crew count, distance, and
+ports already live in the expanded card.
+
+Dropped now-unused CSS (`.trip-grid`, `.trip-cell`, `.trip-lbl`,
+`.trip-val`, `.trip-badges`, `.trip-port`) and promoted the previously
+legacy `.trip-boat` / `.trip-meta` back to primary.
+
 ## Unreleased — fix 2×16-minute time drift from Sheets auto-converting "HH:MM" strings
 
 Observed: a scheduled event created today appeared 32 minutes later than

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -9,17 +9,8 @@
 .trip-date-mon{font-size:14px;font-weight:500;color:var(--text);text-transform:uppercase;margin-top:2px}
 .trip-date-yr{font-size:9px;color:var(--muted)}
 .trip-body{padding:10px 12px;min-width:0}
-/* 2-col collapsed layout: boat/crew · out/in · location/duration */
-.trip-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:6px 14px}
-.trip-cell{display:flex;flex-direction:column;gap:1px;min-width:0}
-.trip-lbl{font-size:9px;color:var(--muted);letter-spacing:.6px;text-transform:uppercase}
-.trip-val{color:var(--text);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.trip-val.trip-boat{font-weight:500;font-size:14px}
-.trip-badges{display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-top:8px;font-size:11px;color:var(--muted)}
-.trip-port{font-size:11px;color:var(--muted)}
-/* Legacy .trip-boat / .trip-meta kept for any non-card callers */
 .trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center}
+.trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center;margin-top:4px}
 .trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
 .badge-skipper{color:var(--accent-fg);border-color:var(--accent)55;background:var(--accent)11}
 .badge-crew{color:var(--muted);border-color:var(--border);background:var(--surface)}

--- a/shared/tripcard.js
+++ b/shared/tripcard.js
@@ -374,14 +374,6 @@ function tripCard(t){
   const hasDetailWx = !!(eDir||eGust||eAir||eFeel||eSst||eWv||ePres||eFlag);
 
 
-  // Helm initials for the collapsed "crew" cell
-  const helmInitials = helmPlainNames.length ? (()=>{
-    const _ini = n => n.split(/\s+/).filter(t=>t&&t!==t.toLowerCase()).map(t=>t.replace(/-/g,'').charAt(0)).join('').toUpperCase();
-    const _memberIni = h => { const m = allMembers.find(x=>x.kennitala&&String(x.kennitala)===h.kt); return (m&&m.initials)?m.initials:_ini(h.name); };
-    return helmPlainNames.map(h => h.kt===String(user.kennitala) ? s('tc.me') : _memberIni(h))
-      .sort((a,b)=> a===s('tc.me') ? -1 : b===s('tc.me') ? 1 : a.localeCompare(b,'is'))
-      .map(n=>esc(n)).join(', ');
-  })() : '';
   const hasPendingBadge = !isVer && isSki && (pendingCrewConfs.length||pendingHelmConfs.length||pendingStudentConfs.length||pendingCrewIn.length||pendingHelmIn.length||pendingStudentIn.length);
   const hasVerifyPending = (t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer;
   const isStudent = (t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)));
@@ -394,40 +386,17 @@ function tripCard(t){
         <div class="trip-date-yr">${esc(p.yr)}</div>
       </div>
       <div class="trip-body">
-        <div class="trip-grid">
-          <div class="trip-cell">
-            <span class="trip-lbl">${s('lbl.boat')}</span>
-            <span class="trip-val trip-boat">${esc(t.boatName||'—')}</span>
-          </div>
-          <div class="trip-cell">
-            <span class="trip-lbl">${s('lbl.crew')}</span>
-            <span class="trip-val">${aboardCount}${helmInitials?` · <span class="text-accent">⎈ ${helmInitials}</span>`:''}</span>
-          </div>
-          <div class="trip-cell">
-            <span class="trip-lbl">${s('tc.departed')}</span>
-            <span class="trip-val">${_timeOut?esc(_timeOut):'—'}</span>
-          </div>
-          <div class="trip-cell">
-            <span class="trip-lbl">${s('tc.returned')}</span>
-            <span class="trip-val">${_timeIn?esc(_timeIn):'—'}</span>
-          </div>
-          <div class="trip-cell">
-            <span class="trip-lbl">${s('lbl.location')}</span>
-            <span class="trip-val">${esc(_locationName||'—')}</span>
-          </div>
-          <div class="trip-cell">
-            <span class="trip-lbl">${s('tc.duration')}</span>
-            <span class="trip-val">${esc(dur)}${_distNm?` · ${esc(_distNm)} nm`:''}${windLine?` · <span class="trip-wind">${windLine}</span>`:''}</span>
-          </div>
-        </div>
-        <div class="trip-badges">
+        <div class="trip-boat">${esc(t.boatName||'—')}</div>
+        <div class="trip-meta">
           <span class="trip-badge ${isSki?'badge-skipper':'badge-crew'}">${isSki?s('tc.skipper'):s('tc.crew')}</span>
+          ${helmPlainNames.length?`<span class="trip-badge badge-helm">⎈ ${(()=>{const _ini=n=>n.split(/\s+/).filter(t=>t&&t!==t.toLowerCase()).map(t=>t.replace(/-/g,'').charAt(0)).join('').toUpperCase();const _memberIni=h=>{const m=allMembers.find(x=>x.kennitala&&String(x.kennitala)===h.kt);return (m&&m.initials)?m.initials:_ini(h.name);};return helmPlainNames.map(h=>h.kt===String(user.kennitala)?s('tc.me'):_memberIni(h)).sort((a,b)=>a===s('tc.me')?-1:b===s('tc.me')?1:a.localeCompare(b,'is')).map(n=>esc(n)).join(', ')})()}</span>`:''}
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':''}
           ${isStudent?`<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 8%, transparent);border:1px solid color-mix(in srgb, var(--navy-l) 33%, transparent);color:var(--navy-l)">${s('tc.student')}</span>`:''}
           ${t.nonClub&&t.nonClub!=='false'?`<span class="trip-badge" style="background:var(--surface);border:1px solid var(--border)">${s('tc.nonClub')}</span>`:''}
           ${hasPendingBadge?'<span class="trip-badge" style="background:var(--yellow)11;border:1px solid var(--yellow)55;color:var(--yellow)">⏳ '+s('tc.pending')+'</span>':''}
           ${hasVerifyPending?'<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 12%, transparent);border:1px solid var(--navy-l);color:var(--navy-l)">⏳ '+s('tc.verificationPending')+'</span>':''}
-          ${isKeelboat&&portLine?'<span class="trip-port">'+portLine+'</span>':''}
+          <span>${esc(dur)}</span>
+          ${windLine?'<span class="trip-wind">'+windLine+'</span>':''}
         </div>
       </div>
       <div class="trip-arrow">▾</div>


### PR DESCRIPTION
Reverts the 2-col grid from 860555b. Collapsed card now shows just date · boat · duration · wind · badges, matching the pre-tighten layout. Times, location, crew count, distance, and port info stay in the expanded card where they already have labeled rows.

Also drops the now-dead .trip-grid / .trip-cell / .trip-lbl / .trip-val / .trip-badges / .trip-port CSS rules and promotes the previously "legacy" .trip-boat / .trip-meta styles back to primary.