### PR TITLE
Activity modal polish: tag presets, collapsible boats, remove stray URL

### DIFF
--- a/admin/act-types.js
+++ b/admin/act-types.js
@@ -142,14 +142,28 @@ async function saveActType() {
   }
 }
 
+// Stable preset tag values, always available in the dropdown. Admins can
+// still type a custom value (the field is text + datalist), but these cover
+// the typical sailing-club taxonomy and keep tags consistent across classes.
+var CLASS_TAG_PRESETS = [
+  'Lesson', 'Race', 'Training', 'Club event',
+  'Maintenance', 'Meeting', 'Social', 'Other',
+];
+
 function refreshClassTagOptions() {
   var dl = document.getElementById('atClassTagOptions');
   if (!dl) return;
   var seen = {};
-  var tags = (actTypes || []).map(function(a) { return (a && a.classTag) || ''; })
-    .filter(function(t) { if (!t || seen[t]) return false; seen[t] = true; return true; })
-    .sort();
-  dl.innerHTML = tags.map(function(t) { return '<option value="' + esc(t) + '">'; }).join('');
+  var tags = CLASS_TAG_PRESETS.slice();
+  // Include any legacy/custom tags already in use so they show up in the
+  // dropdown too — avoids losing unusual values an admin added freehand.
+  (actTypes || []).forEach(function(a) {
+    if (a && a.classTag) tags.push(a.classTag);
+  });
+  var out = tags.filter(function(t) {
+    if (!t || seen[t]) return false; seen[t] = true; return true;
+  }).sort();
+  dl.innerHTML = out.map(function(t) { return '<option value="' + esc(t) + '">'; }).join('');
 }
 
 function renderAtDayBtns() {
@@ -175,6 +189,10 @@ function renderAtBoatPicker() {
   var wrap = document.getElementById('atBoatPicker');
   if (!wrap) return;
   var sel = new Set((window._atReservedBoatIds || []).map(String));
+  // Count badge on the <summary> so admins see the selection at a glance
+  // without expanding the (default-collapsed) section.
+  var countEl = document.getElementById('atBoatCount');
+  if (countEl) countEl.textContent = sel.size ? ' (' + sel.size + ')' : '';
   var list = (typeof boats !== 'undefined' && Array.isArray(boats)) ? boats : [];
   if (!list.length) {
     wrap.innerHTML = '<div class="text-10 text-muted" data-s="admin.noBoatsConfigured"></div>';

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -73,6 +73,13 @@
     .boat-chip.on { background:color-mix(in srgb, var(--accent) 14%, transparent);
       color:var(--accent-fg); border-color:var(--accent); }
 
+    /* Collapsible <details> sections in admin modals (reserved boats etc.) */
+    details > summary { cursor:pointer; list-style:none; }
+    details > summary::-webkit-details-marker { display:none; }
+    details > summary::before { content:"\25B8"; color:var(--muted); margin-right:6px;
+      display:inline-block; transition:transform .15s; }
+    details[open] > summary::before { transform:rotate(90deg); }
+
     /* ── Checklist rows ── */
     .cl-row { display:flex; align-items:center; gap:8px; padding:7px 0;
       border-bottom:1px solid var(--border)44; font-size:12px; }

--- a/admin/index.html
+++ b/admin/index.html
@@ -744,15 +744,18 @@
       </div>
       <div id="atDayBtns" class="d-flex gap-6 flex-wrap mt-6"></div>
     </div>
+    <details class="border-muted rounded-6 mb-10" style="padding:10px 12px">
+      <summary class="d-flex items-center justify-between" style="cursor:pointer;list-style:none">
+        <span class="text-9 text-muted" style="letter-spacing:1px">
+          <span data-s="admin.reservedBoats"></span>
+          <span id="atBoatCount" class="text-muted" style="letter-spacing:0;text-transform:none"></span>
+        </span>
+        <span class="text-10 text-muted" data-s="admin.reservedBoatsHint" style="text-transform:none;letter-spacing:0"></span>
+      </summary>
+      <div id="atBoatPicker" class="d-flex gap-6 flex-wrap mt-8"></div>
+    </details>
     <div class="border-muted rounded-6 mb-10" style="padding:10px 12px">
-      <div class="d-flex items-center justify-between mb-6">
-        <div class="text-9 text-muted" style="letter-spacing:1px" data-s="admin.reservedBoats"></div>
-        <div class="text-10 text-muted" data-s="admin.reservedBoatsHint"></div>
-      </div>
-      <div id="atBoatPicker" class="d-flex gap-6 flex-wrap"></div>
-    </div>
-    <div class="border-muted rounded-6 mb-10" style="padding:10px 12px">
-     https://github.com/skarfur/ymir/pull/734/conflict?name=admin%252Findex.html&ancestor_oid=9608ca82547e1b9c7218d668bb41df37453a5c63&base_oid=89a0e640123ce225f6662601d445c61a3fcf1f86&head_oid=96604788d94aea37faa838885f3a47633ccae291 <div class="text-9 text-muted mb-8" style="letter-spacing:1px" data-s="admin.gcalSyncHdr"></div>
+      <div class="text-9 text-muted mb-8" style="letter-spacing:1px" data-s="admin.gcalSyncHdr"></div>
       <div class="field">
         <label data-s="admin.calendarId"></label>
         <input type="text" id="atCalendarId" placeholder="e.g. abc123@group.calendar.google.com">


### PR DESCRIPTION
- admin/index.html: delete a GitHub PR conflict-resolution URL that was pasted into the calendar-sync block. It was rendering as raw text right before the "SYNC TO CALENDAR" header
- admin/act-types.js: seed the class-tag datalist with a preset taxonomy (Lesson, Race, Training, Club event, Maintenance, Meeting, Social, Other) merged with any legacy custom tags already in use. Admins still get a free-text field if they need something custom; most picks now come from the dropdown
- admin/index.html: wrap the Reserved Boats section in <details> so it's collapsed by default. A "(N)" count next to the heading shows the selection at a glance without expanding
- admin/act-types.js: renderAtBoatPicker refreshes the count badge whenever the selection changes
- admin/admin.css: generic <details>/<summary> styling (cursor, a rotating chevron) so the collapsed section reads as interactive