### PR TITLE
Move trip-card badges onto the boat headline

### DIFF
--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -9,7 +9,8 @@
 .trip-date-mon{font-size:14px;font-weight:500;color:var(--text);text-transform:uppercase;margin-top:2px}
 .trip-date-yr{font-size:9px;color:var(--muted)}
 .trip-body{padding:10px 12px;min-width:0}
-.trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.trip-headline{display:flex;gap:8px;flex-wrap:wrap;align-items:center;min-width:0}
+.trip-boat{font-size:14px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
 .trip-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:var(--muted);align-items:center;margin-top:4px}
 .trip-badge{font-size:9px;letter-spacing:.6px;padding:2px 6px;border-radius:8px;border:1px solid;text-transform:uppercase;flex-shrink:0}
 .badge-skipper{color:var(--accent-fg);border-color:var(--accent)55;background:var(--accent)11}

--- a/shared/tripcard.js
+++ b/shared/tripcard.js
@@ -386,8 +386,8 @@ function tripCard(t){
         <div class="trip-date-yr">${esc(p.yr)}</div>
       </div>
       <div class="trip-body">
-        <div class="trip-boat">${esc(t.boatName||'—')}</div>
-        <div class="trip-meta">
+        <div class="trip-headline">
+          <span class="trip-boat">${esc(t.boatName||'—')}</span>
           <span class="trip-badge ${isSki?'badge-skipper':'badge-crew'}">${isSki?s('tc.skipper'):s('tc.crew')}</span>
           ${helmPlainNames.length?`<span class="trip-badge badge-helm">⎈ ${(()=>{const _ini=n=>n.split(/\s+/).filter(t=>t&&t!==t.toLowerCase()).map(t=>t.replace(/-/g,'').charAt(0)).join('').toUpperCase();const _memberIni=h=>{const m=allMembers.find(x=>x.kennitala&&String(x.kennitala)===h.kt);return (m&&m.initials)?m.initials:_ini(h.name);};return helmPlainNames.map(h=>h.kt===String(user.kennitala)?s('tc.me'):_memberIni(h)).sort((a,b)=>a===s('tc.me')?-1:b===s('tc.me')?1:a.localeCompare(b,'is')).map(n=>esc(n)).join(', ')})()}</span>`:''}
           ${isVer?'<span class="trip-badge badge-verified">✓</span>':''}
@@ -395,6 +395,8 @@ function tripCard(t){
           ${t.nonClub&&t.nonClub!=='false'?`<span class="trip-badge" style="background:var(--surface);border:1px solid var(--border)">${s('tc.nonClub')}</span>`:''}
           ${hasPendingBadge?'<span class="trip-badge" style="background:var(--yellow)11;border:1px solid var(--yellow)55;color:var(--yellow)">⏳ '+s('tc.pending')+'</span>':''}
           ${hasVerifyPending?'<span class="trip-badge" style="background:color-mix(in srgb, var(--navy-l) 12%, transparent);border:1px solid var(--navy-l);color:var(--navy-l)">⏳ '+s('tc.verificationPending')+'</span>':''}
+        </div>
+        <div class="trip-meta">
           <span>${esc(dur)}</span>
           ${windLine?'<span class="trip-wind">'+windLine+'</span>':''}
         </div>


### PR DESCRIPTION
Boat name and badges share one flex row; duration + wind sit on the meta row below. Keeps the card compact and lets badges wrap next to the boat name they describe.