### PR TITLE
admin: fix chevron tiling on checklist boat-category filter

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -195,7 +195,7 @@
         <div class="flex-center gap-8 mb-8">
           <label class="text-sm text-muted" data-s="admin.categoryColon"></label>
           <select id="launchCLCatFilter" data-admin-change="renderLaunchCLSections"
-            class="text-xs bg-surface border-muted rounded-4" style="padding:3px 8px;color:var(--text)">
+            class="text-xs" style="padding:3px 28px 3px 8px;width:auto">
           </select>
         </div>
         <div id="launchCLCard">


### PR DESCRIPTION
Same bug as ea7d6ca (settings tab dropdown). The launchCLCatFilter <select> had `bg-surface` (and friends) layered on top of the shared `select` rule. `.bg-surface { background: var(--surface) }` is the shorthand form, so it resets `background-repeat` to `repeat` and `background-position` to `0 0` — tiling the chevron SVG into a zigzag wave across the pill.

Drop the redundant background/border/radius/color utilities and let the shared `select` rule provide them (so the chevron longhands stay intact). Keep the smaller `.text-xs` font + tight padding, but reserve 28px on the right for the caret. `width:auto` keeps the filter inline next to its label rather than stretching to 100%.

https://claude.ai/code/session_01SSXtyC5ZgigJMAXLBBuvfB