### PR TITLE
Simplify handbook code per review

### DIFF
--- a/admin/handbook.js
+++ b/admin/handbook.js
@@ -1,30 +1,17 @@
-// ═══════════════════════════════════════════════════════════════════════════════
-// admin/handbook.js — Handbook tab (info sections, org chart, documents)
-// ═══════════════════════════════════════════════════════════════════════════════
-// Mirrors the locations.js / certs.js pattern: render functions read from a
-// module-local state object, mutations call apiPost and re-render. All entries
-// are soft-deleted (active=false) on the backend.
+// Handbook admin: contacts (people + free text), rules, org chart, docs.
 
 var _hbAdmin = {
-  info: [],
-  roles: [],
-  docs: [],
-  contacts: [],
-  editingInfoId:    null,
-  editingRoleId:    null,
-  editingDocId:     null,
-  editingContactId: null,
+  info: [], roles: [], docs: [], contacts: [],
+  editingInfoId: null, editingRoleId: null, editingDocId: null, editingContactId: null,
 };
 
 async function loadHandbookAdmin(force) {
-  if (_hbAdmin._loaded && !force) return;
   try {
     const res = await apiGet('getHandbook', force ? { _fresh: 1 } : {});
     _hbAdmin.info     = res.info     || [];
     _hbAdmin.roles    = res.roles    || [];
     _hbAdmin.docs     = res.docs     || [];
     _hbAdmin.contacts = res.contacts || [];
-    _hbAdmin._loaded = true;
   } catch (e) {
     console.warn('loadHandbookAdmin failed:', e.message);
   }
@@ -38,24 +25,59 @@ async function renderHandbookAdmin() {
   renderHandbookDocsList();
 }
 
-function _hbLocalized(row, key) {
-  return getLang() === 'IS'
-    ? (row[key + 'IS'] || row[key] || '')
-    : (row[key] || row[key + 'IS'] || '');
+const _hbT = (row, key) => localizedField(row, key);
+
+function _hbBySort(a, b) {
+  return (Number(a.sortOrder || 0) - Number(b.sortOrder || 0)) ||
+    String(a.title || a.label || '').localeCompare(String(b.title || b.label || ''));
 }
 
-// ── Info sections ────────────────────────────────────────────────────────────
+function _hbAdminMemberName(kt) {
+  if (typeof members === 'undefined' || !members) return '';
+  const m = members.find(x => String(x.kennitala) === String(kt));
+  return m ? (m.name || '') : '';
+}
+
+// Generic save: posts the payload, splices the result into the local array,
+// closes the modal, re-renders, toasts. `render` may be a single fn or array.
+async function _hbSave(action, payload, listKey, modalId, render) {
+  try {
+    const res = await apiPost(action, payload);
+    payload.id = payload.id || res.id;
+    payload.active = true;
+    const arr = _hbAdmin[listKey];
+    const idx = arr.findIndex(x => x.id === payload.id);
+    if (idx >= 0) arr[idx] = { ...arr[idx], ...payload };
+    else          arr.push(payload);
+    closeModal(modalId, true);
+    [].concat(render).forEach(fn => fn());
+    toast(s('toast.saved'));
+  } catch (e) { toast(s('toast.saveFailed') + ': ' + e.message, 'err'); }
+}
+
+async function _hbDelete(action, listKey, editingKey, modalId, render) {
+  const id = _hbAdmin[editingKey];
+  if (!id) return;
+  if (!await ymConfirm(s('admin.handbookConfirmDelete'))) return;
+  try {
+    await apiPost(action, { id: id });
+    _hbAdmin[listKey] = _hbAdmin[listKey].filter(x => x.id !== id);
+    closeModal(modalId, true);
+    [].concat(render).forEach(fn => fn());
+    toast(s('toast.deleted'));
+  } catch (e) { toast(s('toast.error') + ': ' + e.message, 'err'); }
+}
+
+// ── Contacts col-section: people + free-text ────────────────────────────────
 
 function _hbInfoRowHtml(it) {
   return `
     <div class="list-row">
-      <span class="list-name">${esc(_hbLocalized(it, 'title'))}</span>
+      <span class="list-name">${esc(_hbT(it, 'title'))}</span>
       <button class="row-edit" data-admin-click="openHandbookInfoModal" data-admin-arg="${it.id}">${s('btn.edit')}</button>
     </div>`;
 }
 
-// Contacts col-section in admin = (member-linked contacts) + (free-text
-// entries with kind='contacts'). Two distinct lists, two add buttons.
 function renderHandbookContactsAdmin() {
   const card = document.getElementById('hbAdminContactsCard');
   if (!card) return;
@@ -66,7 +88,7 @@ function renderHandbookContactsAdmin() {
   if (ppl.length) {
     html += `<div class="text-xs text-muted mb-4" style="text-transform:uppercase;letter-spacing:1px">${esc(s('admin.handbookContactsPeople'))}</div>`;
     html += ppl.map(c => {
-      const lbl  = _hbLocalized(c, 'label');
+      const lbl  = _hbT(c, 'label');
       const name = c.name || (c.memberId ? _hbAdminMemberName(c.memberId) : '');
       return `
         <div class="list-row">
@@ -82,9 +104,7 @@ function renderHandbookContactsAdmin() {
   card.innerHTML = html || `<div class="empty-state">${s('admin.handbookEmptyInfo')}</div>`;
 }
 
-// Rules col-section in admin = free-text entries with kind='rules'. Legacy
-// rows without a kind also surface here so existing content keeps editing
-// cleanly after the schema migration.
+// Legacy rows without a kind also surface here so pre-migration content edits.
 function renderHandbookRulesAdmin() {
   const card = document.getElementById('hbAdminRulesCard');
   if (!card) return;
@@ -97,29 +117,16 @@ function renderHandbookRulesAdmin() {
     : `<div class="empty-state">${s('admin.handbookEmptyInfo')}</div>`;
 }
 
-function _hbBySort(a, b) {
-  return (Number(a.sortOrder || 0) - Number(b.sortOrder || 0)) ||
-    String(a.title || a.label || '').localeCompare(String(b.title || b.label || ''));
-}
-
-function _hbAdminMemberName(kt) {
-  if (typeof members === 'undefined' || !members) return '';
-  const m = members.find(x => String(x.kennitala) === String(kt));
-  return m ? (m.name || '') : '';
-}
-
 function openHandbookInfoModal(id, kindHint) {
   _hbAdmin.editingInfoId = id || null;
   const row = id ? _hbAdmin.info.find(x => x.id === id) : null;
   document.getElementById('hbInfoModalTitle').textContent = row
     ? s('admin.handbook.info.modalEdit')
     : s('admin.handbook.info.modalAdd');
-  // Default new entries to the kind hint (passed by the section's add
-  // button) and fall back to 'contacts' since the user opened the modal
-  // from somewhere — legacy rows without a kind map to 'rules'.
-  const kind = row
-    ? (row.kind === 'contacts' ? 'contacts' : 'rules')
-    : (kindHint === 'rules' ? 'rules' : 'contacts');
+  let kind;
+  if (row)            kind = row.kind === 'contacts' ? 'contacts' : 'rules';
+  else if (kindHint)  kind = kindHint;
+  else                kind = 'contacts';
   document.getElementById('hbInfoKind').value      = kind;
   document.getElementById('hbInfoTitle').value     = row ? (row.title || '')     : '';
   document.getElementById('hbInfoTitleIS').value   = row ? (row.titleIS || '')   : '';
@@ -135,43 +142,23 @@ async function saveHandbookInfo() {
   const title   = document.getElementById('hbInfoTitle').value.trim();
   const titleIS = document.getElementById('hbInfoTitleIS').value.trim();
   if (!title && !titleIS) { toast(s('admin.nameRequired') || 'Title required', 'err'); return; }
-  const payload = {
+  return _hbSave('saveHandbookInfo', {
     id:        _hbAdmin.editingInfoId || undefined,
-    kind:      document.getElementById('hbInfoKind').value || 'rules',
+    kind:      document.getElementById('hbInfoKind').value,
     title:     title,
     titleIS:   titleIS,
     content:   document.getElementById('hbInfoContent').value,
     contentIS: document.getElementById('hbInfoContentIS').value,
     sortOrder: Number(document.getElementById('hbInfoSort').value) || 0,
-  };
-  try {
-    const res = await apiPost('saveHandbookInfo', payload);
-    payload.id = payload.id || res.id;
-    payload.active = true;
-    const idx = _hbAdmin.info.findIndex(x => x.id === payload.id);
-    if (idx >= 0) _hbAdmin.info[idx] = { ..._hbAdmin.info[idx], ...payload };
-    else          _hbAdmin.info.push(payload);
-    closeModal('hbInfoModal', true);
-    renderHandbookContactsAdmin();
-    renderHandbookRulesAdmin();
-    toast(s('toast.saved'));
-  } catch (e) { toast(s('toast.saveFailed') + ': ' + e.message, 'err'); }
+  }, 'info', 'hbInfoModal', [renderHandbookContactsAdmin, renderHandbookRulesAdmin]);
 }
 
 async function deleteHandbookInfo() {
-  if (!_hbAdmin.editingInfoId) return;
-  if (!await ymConfirm(s('admin.handbookConfirmDelete'))) return;
-  try {
-    await apiPost('deleteHandbookInfo', { id: _hbAdmin.editingInfoId });
-    _hbAdmin.info = _hbAdmin.info.filter(x => x.id !== _hbAdmin.editingInfoId);
-    closeModal('hbInfoModal', true);
-    renderHandbookContactsAdmin();
-    renderHandbookRulesAdmin();
-    toast(s('toast.deleted'));
-  } catch (e) { toast(s('toast.error') + ': ' + e.message, 'err'); }
+  return _hbDelete('deleteHandbookInfo', 'info', 'editingInfoId', 'hbInfoModal',
+    [renderHandbookContactsAdmin, renderHandbookRulesAdmin]);
 }
 
-// ── Contacts (member-linked phone book) ─────────────────────────────────────
+// ── Member-linked contacts ──────────────────────────────────────────────────
 
 function openHandbookContactModal(id) {
   _hbAdmin.editingContactId = id || null;
@@ -180,8 +167,6 @@ function openHandbookContactModal(id) {
     ? s('admin.handbook.contact.modalEdit')
     : s('admin.handbook.contact.modalAdd');
 
-  // Member dropdown — sorted by name. Falls back gracefully if the global
-  // members array hasn't been populated yet.
   const sel = document.getElementById('hbContactMember');
   const opts = ['<option value="">' + esc(s('admin.handbook.contact.memberNone')) + '</option>'];
   if (typeof members !== 'undefined' && Array.isArray(members)) {
@@ -205,8 +190,6 @@ function openHandbookContactModal(id) {
   document.getElementById('hbContactNotesIS').value   = row ? (row.notesIS || '')   : '';
   document.getElementById('hbContactSort').value      = row ? (row.sortOrder || 0)  : 0;
 
-  // Datalist autocomplete: previously-used labels make consistency easy
-  // without forcing a hard preset list.
   const usedEN = {}, usedIS = {};
   (_hbAdmin.contacts || []).forEach(c => {
     if (c.label) usedEN[c.label] = true;
@@ -217,8 +200,8 @@ function openHandbookContactModal(id) {
   document.getElementById('hbContactLabelListIS').innerHTML =
     Object.keys(usedIS).sort().map(l => `<option value="${esc(l)}">`).join('');
 
-  // Default the placeholders to the linked member's data so the admin
-  // sees what'll show up if they don't override.
+  // Surface the linked member's values as placeholders so the admin sees what
+  // will render on the public page if they don't override.
   hbContactMemberPicked();
 
   document.getElementById('hbContactDeleteBtn').classList.toggle('hidden', !row);
@@ -226,10 +209,6 @@ function openHandbookContactModal(id) {
   openModal('hbContactModal');
 }
 
-// Fired when the member dropdown changes — refresh the placeholder text
-// in name/phone/email so the admin can see what'll be shown if they don't
-// override. The actual save still sends the override (or empty) and the
-// read endpoint hydrates missing fields from the member record.
 function hbContactMemberPicked() {
   const kt = document.getElementById('hbContactMember').value;
   const m = (typeof members !== 'undefined' && Array.isArray(members))
@@ -244,7 +223,7 @@ async function saveHandbookContact() {
   const label   = document.getElementById('hbContactLabel').value.trim();
   const labelIS = document.getElementById('hbContactLabelIS').value.trim();
   if (!label && !labelIS) { toast(s('admin.handbookLabelRequired'), 'err'); return; }
-  const payload = {
+  return _hbSave('saveHandbookContact', {
     id:        _hbAdmin.editingContactId || undefined,
     memberId:  document.getElementById('hbContactMember').value || '',
     label:     label,
@@ -255,33 +234,15 @@ async function saveHandbookContact() {
     notes:     document.getElementById('hbContactNotes').value,
     notesIS:   document.getElementById('hbContactNotesIS').value,
     sortOrder: Number(document.getElementById('hbContactSort').value) || 0,
-  };
-  try {
-    const res = await apiPost('saveHandbookContact', payload);
-    payload.id = payload.id || res.id;
-    payload.active = true;
-    const idx = _hbAdmin.contacts.findIndex(x => x.id === payload.id);
-    if (idx >= 0) _hbAdmin.contacts[idx] = { ..._hbAdmin.contacts[idx], ...payload };
-    else          _hbAdmin.contacts.push(payload);
-    closeModal('hbContactModal', true);
-    renderHandbookContactsAdmin();
-    toast(s('toast.saved'));
-  } catch (e) { toast(s('toast.saveFailed') + ': ' + e.message, 'err'); }
+  }, 'contacts', 'hbContactModal', renderHandbookContactsAdmin);
 }
 
 async function deleteHandbookContact() {
-  if (!_hbAdmin.editingContactId) return;
-  if (!await ymConfirm(s('admin.handbookConfirmDelete'))) return;
-  try {
-    await apiPost('deleteHandbookContact', { id: _hbAdmin.editingContactId });
-    _hbAdmin.contacts = _hbAdmin.contacts.filter(x => x.id !== _hbAdmin.editingContactId);
-    closeModal('hbContactModal', true);
-    renderHandbookContactsAdmin();
-    toast(s('toast.deleted'));
-  } catch (e) { toast(s('toast.error') + ': ' + e.message, 'err'); }
+  return _hbDelete('deleteHandbookContact', 'contacts', 'editingContactId',
+    'hbContactModal', renderHandbookContactsAdmin);
 }
 
-// ── Roles (org chart) ────────────────────────────────────────────────────────
+// ── Roles (org chart) ───────────────────────────────────────────────────────
 
 function renderHandbookRolesList() {
   const card = document.getElementById('hbAdminRolesCard');
@@ -290,22 +251,20 @@ function renderHandbookRolesList() {
     card.innerHTML = `<div class="empty-state">${s('admin.handbookEmptyRoles')}</div>`;
     return;
   }
-  // Render as a flat sorted list with parent indent indicator. The read-side
-  // /handbook/ portal renders the actual nested tree; admin only needs to
-  // identify each row.
+  // Flat list (the read portal handles the tree).
   const byId = {};
   _hbAdmin.roles.forEach(r => { byId[r.id] = r; });
-  const rows = _hbAdmin.roles.slice().sort((a, b) => {
-    return (Number(a.sortOrder || 0) - Number(b.sortOrder || 0)) ||
-      String(_hbLocalized(a, 'title')).localeCompare(_hbLocalized(b, 'title'));
-  });
+  const rows = _hbAdmin.roles.slice().sort((a, b) =>
+    (Number(a.sortOrder || 0) - Number(b.sortOrder || 0)) ||
+    String(_hbT(a, 'title')).localeCompare(_hbT(b, 'title'))
+  );
   card.innerHTML = rows.map(r => {
-    const parent = r.parentId && byId[r.parentId] ? _hbLocalized(byId[r.parentId], 'title') : '';
+    const parent = r.parentId && byId[r.parentId] ? _hbT(byId[r.parentId], 'title') : '';
     const sub = parent ? `<span class="text-xs text-muted"> ↳ ${esc(parent)}</span>` : '';
     const who = r.name ? ` — <span class="text-muted">${esc(r.name)}</span>` : '';
     return `
       <div class="list-row">
-        <span class="list-name">${esc(_hbLocalized(r, 'title'))}${who}${sub}</span>
+        <span class="list-name">${esc(_hbT(r, 'title'))}${who}${sub}</span>
         <button class="row-edit" data-admin-click="openHandbookRoleModal" data-admin-arg="${r.id}">${s('btn.edit')}</button>
       </div>`;
   }).join('');
@@ -326,14 +285,11 @@ function openHandbookRoleModal(id) {
   document.getElementById('hbRoleNotes').value   = row ? (row.notes || '')   : '';
   document.getElementById('hbRoleNotesIS').value = row ? (row.notesIS || '') : '';
   document.getElementById('hbRoleColor').value   = (row && row.color) ? row.color : '#d4af37';
-  // Track whether the admin actually picked / kept a color so we can save
-  // an empty string when they want the default rather than a hex value.
+  // userSet flag distinguishes "admin picked this color" from "default
+  // shown in the swatch but not chosen" so save can persist '' for default.
   document.getElementById('hbRoleColor').dataset.userSet = (row && row.color) ? '1' : '';
   document.getElementById('hbRoleSort').value    = row ? (row.sortOrder || 0): 0;
 
-  // Boat-category dropdown — uses the global boatCats array loaded by
-  // admin.js. The selected key, if any, lets the read endpoint resolve
-  // this role's color from the matching boat category at request time.
   const catSel = document.getElementById('hbRoleBoatCat');
   const catOpts = ['<option value="">' + esc(s('admin.handbook.role.boatCatNone')) + '</option>'];
   if (typeof boatCats !== 'undefined' && Array.isArray(boatCats)) {
@@ -347,15 +303,15 @@ function openHandbookRoleModal(id) {
   }
   catSel.innerHTML = catOpts.join('');
 
-  // Populate parent dropdown — exclude self to avoid loops.
+  // Exclude self from parent options to avoid loops.
   const sel = document.getElementById('hbRoleParent');
   const opts = ['<option value="">' + esc(s('admin.handbook.role.parentNone')) + '</option>'];
   _hbAdmin.roles
     .filter(r => !id || r.id !== id)
-    .sort((a, b) => String(_hbLocalized(a, 'title')).localeCompare(_hbLocalized(b, 'title')))
+    .sort((a, b) => String(_hbT(a, 'title')).localeCompare(_hbT(b, 'title')))
     .forEach(r => {
       const sel2 = (row && row.parentId === r.id) ? ' selected' : '';
-      opts.push(`<option value="${esc(r.id)}"${sel2}>${esc(_hbLocalized(r, 'title'))}</option>`);
+      opts.push(`<option value="${esc(r.id)}"${sel2}>${esc(_hbT(r, 'title'))}</option>`);
     });
   sel.innerHTML = opts.join('');
 
@@ -368,48 +324,52 @@ async function saveHandbookRole() {
   const title   = document.getElementById('hbRoleTitle').value.trim();
   const titleIS = document.getElementById('hbRoleTitleIS').value.trim();
   if (!title && !titleIS) { toast(s('admin.nameRequired') || 'Title required', 'err'); return; }
-  const payload = {
-    id:        _hbAdmin.editingRoleId || undefined,
-    parentId:  document.getElementById('hbRoleParent').value || '',
-    title:     title,
-    titleIS:   titleIS,
-    name:      document.getElementById('hbRoleName').value.trim(),
-    kennitala: document.getElementById('hbRoleKt').value.trim(),
-    phone:     document.getElementById('hbRolePhone').value.trim(),
-    email:     document.getElementById('hbRoleEmail').value.trim(),
+  return _hbSave('saveHandbookRole', {
+    id:              _hbAdmin.editingRoleId || undefined,
+    parentId:        document.getElementById('hbRoleParent').value || '',
+    title:           title,
+    titleIS:         titleIS,
+    name:            document.getElementById('hbRoleName').value.trim(),
+    kennitala:       document.getElementById('hbRoleKt').value.trim(),
+    phone:           document.getElementById('hbRolePhone').value.trim(),
+    email:           document.getElementById('hbRoleEmail').value.trim(),
     notes:           document.getElementById('hbRoleNotes').value,
     notesIS:         document.getElementById('hbRoleNotesIS').value,
     color:           document.getElementById('hbRoleColor').dataset.userSet
                        ? document.getElementById('hbRoleColor').value : '',
     boatCategoryKey: document.getElementById('hbRoleBoatCat').value || '',
     sortOrder:       Number(document.getElementById('hbRoleSort').value) || 0,
-  };
-  try {
-    const res = await apiPost('saveHandbookRole', payload);
-    payload.id = payload.id || res.id;
-    payload.active = true;
-    const idx = _hbAdmin.roles.findIndex(x => x.id === payload.id);
-    if (idx >= 0) _hbAdmin.roles[idx] = { ..._hbAdmin.roles[idx], ...payload };
-    else          _hbAdmin.roles.push(payload);
-    closeModal('hbRoleModal', true);
-    renderHandbookRolesList();
-    toast(s('toast.saved'));
-  } catch (e) { toast(s('toast.saveFailed') + ': ' + e.message, 'err'); }
+  }, 'roles', 'hbRoleModal', renderHandbookRolesList);
 }
 
 async function deleteHandbookRole() {
-  if (!_hbAdmin.editingRoleId) return;
-  if (!await ymConfirm(s('admin.handbookConfirmDelete'))) return;
+  return _hbDelete('deleteHandbookRole', 'roles', 'editingRoleId',
+    'hbRoleModal', renderHandbookRolesList);
+}
+
+function hbRoleColorPicked() {
+  document.getElementById('hbRoleColor').dataset.userSet = '1';
+}
+
+function clearHandbookRoleColor() {
+  // Empty userSet flag tells save to persist '' so the read-side falls back
+  // to the boat-category color (or --brass if none).
+  const el = document.getElementById('hbRoleColor');
+  el.value = '#d4af37';
+  el.dataset.userSet = '';
+}
+
+async function seedHandbookOrgChart() {
+  if (!await ymConfirm(s('admin.handbookSeedConfirm'))) return;
   try {
-    await apiPost('deleteHandbookRole', { id: _hbAdmin.editingRoleId });
-    _hbAdmin.roles = _hbAdmin.roles.filter(x => x.id !== _hbAdmin.editingRoleId);
-    closeModal('hbRoleModal', true);
+    const res = await apiPost('seedHandbookOrgChart', {});
+    await loadHandbookAdmin(true);
     renderHandbookRolesList();
-    toast(s('toast.deleted'));
+    toast(s('toast.saved') + (res.added ? ' (+' + res.added + ')' : ''));
   } catch (e) { toast(s('toast.error') + ': ' + e.message, 'err'); }
 }
 
-// ── Documents ────────────────────────────────────────────────────────────────
+// ── Documents ───────────────────────────────────────────────────────────────
 
 function renderHandbookDocsList() {
   const card = document.getElementById('hbAdminDocsCard');
@@ -418,16 +378,13 @@ function renderHandbookDocsList() {
     card.innerHTML = `<div class="empty-state">${s('admin.handbookEmptyDocs')}</div>`;
     return;
   }
-  card.innerHTML = _hbAdmin.docs.slice().sort((a, b) => {
-    return (Number(a.sortOrder || 0) - Number(b.sortOrder || 0)) ||
-      String(_hbLocalized(a, 'title')).localeCompare(_hbLocalized(b, 'title'));
-  }).map(d => {
-    const cat = _hbLocalized(d, 'category');
+  card.innerHTML = _hbAdmin.docs.slice().sort(_hbBySort).map(d => {
+    const cat = _hbT(d, 'category');
     const catSpan = cat ? `<span class="text-xs text-muted"> · ${esc(cat)}</span>` : '';
     const icon = d.driveFileId ? '📄' : '🔗';
     return `
       <div class="list-row">
-        <span class="list-name">${icon} ${esc(_hbLocalized(d, 'title'))}${catSpan}</span>
+        <span class="list-name">${icon} ${esc(_hbT(d, 'title'))}${catSpan}</span>
         <button class="row-edit" data-admin-click="openHandbookDocModal" data-admin-arg="${d.id}">${s('btn.edit')}</button>
       </div>`;
   }).join('');
@@ -451,8 +408,6 @@ function openHandbookDocModal(id) {
   document.getElementById('hbDocFile').value       = '';
   document.getElementById('hbDocUploadStatus').textContent = '';
 
-  // Populate category datalist with distinct existing categories so the admin
-  // can reuse them.
   const seen = {};
   const cats = [];
   _hbAdmin.docs.forEach(d => {
@@ -501,7 +456,7 @@ async function saveHandbookDoc() {
   const url   = document.getElementById('hbDocUrl').value.trim();
   if (!title) { toast(s('admin.nameRequired') || 'Title required', 'err'); return; }
   if (!url)   { toast('URL required', 'err'); return; }
-  const payload = {
+  return _hbSave('saveHandbookDoc', {
     id:          _hbAdmin.editingDocId || undefined,
     title:       title,
     titleIS:     document.getElementById('hbDocTitleIS').value.trim(),
@@ -512,56 +467,10 @@ async function saveHandbookDoc() {
     notes:       document.getElementById('hbDocNotes').value,
     notesIS:     document.getElementById('hbDocNotesIS').value,
     sortOrder:   Number(document.getElementById('hbDocSort').value) || 0,
-  };
-  try {
-    const res = await apiPost('saveHandbookDoc', payload);
-    payload.id = payload.id || res.id;
-    payload.active = true;
-    const idx = _hbAdmin.docs.findIndex(x => x.id === payload.id);
-    if (idx >= 0) _hbAdmin.docs[idx] = { ..._hbAdmin.docs[idx], ...payload };
-    else          _hbAdmin.docs.push(payload);
-    closeModal('hbDocModal', true);
-    renderHandbookDocsList();
-    toast(s('toast.saved'));
-  } catch (e) { toast(s('toast.saveFailed') + ': ' + e.message, 'err'); }
+  }, 'docs', 'hbDocModal', renderHandbookDocsList);
 }
 
 async function deleteHandbookDoc() {
-  if (!_hbAdmin.editingDocId) return;
-  if (!await ymConfirm(s('admin.handbookConfirmDelete'))) return;
-  try {
-    await apiPost('deleteHandbookDoc', { id: _hbAdmin.editingDocId });
-    _hbAdmin.docs = _hbAdmin.docs.filter(x => x.id !== _hbAdmin.editingDocId);
-    closeModal('hbDocModal', true);
-    renderHandbookDocsList();
-    toast(s('toast.deleted'));
-  } catch (e) { toast(s('toast.error') + ': ' + e.message, 'err'); }
-}
-
-// ── Role color helpers ──────────────────────────────────────────────────────
-
-function hbRoleColorPicked() {
-  // Native color picker emits 'input' as the user drags the swatch; flag
-  // that we should persist whatever they chose rather than ''-meaning-default.
-  document.getElementById('hbRoleColor').dataset.userSet = '1';
-}
-
-function clearHandbookRoleColor() {
-  // Reset to the brand default and mark the field as not-user-set so save
-  // sends an empty color (the read-side then falls back to --brass).
-  const el = document.getElementById('hbRoleColor');
-  el.value = '#d4af37';
-  el.dataset.userSet = '';
-}
-
-// ── Seed defaults ───────────────────────────────────────────────────────────
-
-async function seedHandbookOrgChart() {
-  if (!await ymConfirm(s('admin.handbookSeedConfirm'))) return;
-  try {
-    const res = await apiPost('seedHandbookOrgChart', {});
-    await loadHandbookAdmin(true);
-    renderHandbookRolesList();
-    toast(s('toast.saved') + (res.added ? ' (+' + res.added + ')' : ''));
-  } catch (e) { toast(s('toast.error') + ': ' + e.message, 'err'); }
+  return _hbDelete('deleteHandbookDoc', 'docs', 'editingDocId',
+    'hbDocModal', renderHandbookDocsList);
 }

--- a/handbook.gs
+++ b/handbook.gs
@@ -1,72 +1,30 @@
-// ═══════════════════════════════════════════════════════════════════════════════
-// HANDBOOK / HANDBÓK
-// ═══════════════════════════════════════════════════════════════════════════════
-//
-// Members- and staff-facing reference: a visual org chart with contact data,
-// quick links to PDFs (hosted on Drive), free-form bilingual info sections
-// for emergency contacts and rules/best practices, plus an auto-populated
-// staff contact list pulled from the members sheet. Editable from the admin
-// portal.
-//
-// Four sheets back this:
-//   handbook_roles    — org-chart entries with optional parentId for hierarchy
-//                       and optional kennitala link to a member record. When
-//                       kennitala is set, the read endpoint hydrates missing
-//                       name / phone / email from the member's record so the
-//                       handbook stays in sync without duplicate data entry.
-//                       `color` is an optional hex string for the box accent.
-//   handbook_contacts — manually curated people in the contact-numbers
-//                       section. Each row has an optional `memberId`
-//                       (kennitala) link plus a free-text `label` /
-//                       `labelIS` (e.g. "Emergency contact",
-//                       "Maintenance lead"). Member-linked rows hydrate
-//                       missing name / phone / email from the member's
-//                       record at read time.
-//   handbook_docs     — PDF / URL entries grouped by category. driveFileId
-//                       is set when the file was uploaded through the admin
-//                       UI so deletes can also trash the Drive file.
-//   handbook_info     — bilingual text sections, distinguished by `kind`:
-//                       'contacts' (free-text emergency / external numbers),
-//                       'rules'    (rules / best practices),
-//                       other      (legacy / free-form).
-//
-// Soft-deletes via `active=false` so audit history survives.
-
-// ── Reads ────────────────────────────────────────────────────────────────────
+// Handbook: org chart, contacts, docs, rules. Read endpoint hydrates
+// kennitala-linked rows from members and resolves deild colors from boat
+// categories so the chart stays in sync with the rest of the app.
 
 function getHandbook_() {
-  const rolesRaw    = (data_.readAll('handbookRoles')    || []).filter(_handbookActive_);
-  const contactsRaw = (data_.readAll('handbookContacts') || []).filter(_handbookActive_);
-  const docs        = (data_.readAll('handbookDocs')     || []).filter(_handbookActive_);
-  const info        = (data_.readAll('handbookInfo')     || []).filter(_handbookActive_);
+  const rolesRaw    = (data_.readAll('handbookRoles')    || []).filter(_hbActive_);
+  const contactsRaw = (data_.readAll('handbookContacts') || []).filter(_hbActive_);
+  const docs        = (data_.readAll('handbookDocs')     || []).filter(_hbActive_);
+  const info        = (data_.readAll('handbookInfo')     || []).filter(_hbActive_);
 
-  const memberByKt   = _handbookMemberMap_();
-  const catColorMap  = _handbookBoatCatColorMap_();
+  const memberByKt = getMemberMap_();
+  const needsCatMap = rolesRaw.some(function (r) { return r.boatCategoryKey && !r.color; });
+  const catColorMap = needsCatMap ? _hbBoatCatColorMap_() : {};
 
-  // Hydrate roles: when a role has a kennitala link, pull missing name /
-  // phone / email from the member record. The role's own values still win
-  // when they're set, so admins can override (e.g. publish a club extension
-  // rather than the member's mobile). Color resolution falls back to the
-  // linked boat category's color so the deildir stay in sync with the
-  // rest of the app — explicit `color` still wins.
   const roles = rolesRaw.map(function (r) {
     const m = r.kennitala ? memberByKt[String(r.kennitala).trim()] : null;
-    const out = m
-      ? Object.assign({}, r, {
-          name:  r.name  || m.name  || '',
-          phone: r.phone || m.phone || '',
-          email: r.email || m.email || '',
-          _linkedMemberRole: m.role || '',
-        })
-      : Object.assign({}, r);
+    const out = m ? Object.assign({}, r, {
+      name:  r.name  || m.name  || '',
+      phone: r.phone || m.phone || '',
+      email: r.email || m.email || '',
+    }) : Object.assign({}, r);
     if (!out.color && out.boatCategoryKey && catColorMap[out.boatCategoryKey]) {
       out.color = catColorMap[out.boatCategoryKey];
     }
     return out;
   });
 
-  // Hydrate contacts the same way; the row's own override wins. memberId
-  // here holds a kennitala (matches the column name on the role rows).
   const contacts = contactsRaw.map(function (c) {
     const m = c.memberId ? memberByKt[String(c.memberId).trim()] : null;
     if (!m) return c;
@@ -78,25 +36,25 @@ function getHandbook_() {
   });
 
   return okJ({
-    roles:    roles.sort(_byOrder_),
-    contacts: contacts.sort(_byOrder_),
-    docs:     docs.sort(_byOrder_),
-    info:     info.sort(_byOrder_),
+    roles:    roles.sort(_hbByOrder_),
+    contacts: contacts.sort(_hbByOrder_),
+    docs:     docs.sort(_hbByOrder_),
+    info:     info.sort(_hbByOrder_),
   });
 }
 
-function _handbookActive_(r) { return r && r.active !== false && r.active !== 'false'; }
-function _byOrder_(a, b) {
+function _hbActive_(r) { return r && bool_(r.active); }
+
+function _hbByOrder_(a, b) {
   var ao = Number(a.sortOrder || 0), bo = Number(b.sortOrder || 0);
   if (ao !== bo) return ao - bo;
   return String(a.title || '').localeCompare(String(b.title || ''));
 }
 
-function _handbookBoatCatColorMap_() {
+function _hbBoatCatColorMap_() {
   const out = {};
   try {
-    const cfg = getConfigMap_();
-    const raw = getConfigValue_('boatCategories', cfg);
+    const raw = getConfigValue_('boatCategories', getConfigMap_());
     const list = raw ? JSON.parse(raw) : [];
     if (Array.isArray(list)) {
       list.forEach(function (c) {
@@ -107,27 +65,35 @@ function _handbookBoatCatColorMap_() {
   return out;
 }
 
-function _handbookMemberMap_() {
-  const map = {};
-  try {
-    (readAll_('members') || []).forEach(function (m) {
-      if (m && m.kennitala) map[String(m.kennitala).trim()] = m;
-    });
-  } catch (e) {}
-  return map;
+// ── Generic upsert / soft-delete helpers ─────────────────────────────────────
+
+function _hbUpsert_(tabKey, idPrefix, b, fields) {
+  const id = b.id || (idPrefix + uid_());
+  const existing = findOne_(tabKey, 'id', id);
+  const row = Object.assign({ id: id }, fields, {
+    active:    b.active === false ? false : true,
+    createdAt: existing ? (existing.createdAt || now_()) : now_(),
+    updatedAt: now_(),
+  });
+  if (existing) updateRow_(tabKey, 'id', id, row);
+  else          insertRow_(tabKey, row);
+  return { id: id, existing: existing };
 }
 
-// ── Contacts (member-linked phone book) ─────────────────────────────────────
-// `memberId` holds a kennitala (mirrors the column name used on roles).
-// Free-text label per entry — bilingual EN + IS. The read endpoint hydrates
-// missing name / phone / email from the linked member record.
+function _hbSoftDelete_(tabKey, id, notFoundMsg) {
+  if (!id) return { error: failJ('id required') };
+  const existing = findOne_(tabKey, 'id', id);
+  if (!existing) return { error: failJ(notFoundMsg, 404) };
+  updateRow_(tabKey, 'id', id, { active: false, updatedAt: now_() });
+  return { existing: existing };
+}
+
+// ── Contacts (member-linked phone book) ──────────────────────────────────────
+// `memberId` holds a kennitala (mirrors the column name on roles).
 
 function saveHandbookContact_(b) {
   if (!b.label && !b.labelIS) return failJ('label required');
-  const id = b.id || ('contact_' + uid_());
-  const existing = findOne_('handbookContacts', 'id', id);
-  const row = {
-    id:         id,
+  const r = _hbUpsert_('handbookContacts', 'contact_', b, {
     memberId:   b.memberId || '',
     label:      b.label || '',
     labelIS:    b.labelIS || '',
@@ -137,31 +103,20 @@ function saveHandbookContact_(b) {
     notes:      b.notes || '',
     notesIS:    b.notesIS || '',
     sortOrder:  Number(b.sortOrder || 0),
-    active:     b.active === false ? false : true,
-    createdAt:  existing ? (existing.createdAt || now_()) : now_(),
-    updatedAt:  now_(),
-  };
-  if (existing) updateRow_('handbookContacts', 'id', id, row);
-  else          insertRow_('handbookContacts', row);
-  return okJ({ id: id, saved: true });
+  });
+  return okJ({ id: r.id, saved: true });
 }
 
 function deleteHandbookContact_(b) {
-  if (!b.id) return failJ('id required');
-  const existing = findOne_('handbookContacts', 'id', b.id);
-  if (!existing) return failJ('Contact not found', 404);
-  updateRow_('handbookContacts', 'id', b.id, { active: false, updatedAt: now_() });
-  return okJ({ ok: true });
+  const r = _hbSoftDelete_('handbookContacts', b.id, 'Contact not found');
+  return r.error || okJ({ ok: true });
 }
 
 // ── Roles (org chart) ────────────────────────────────────────────────────────
 
 function saveHandbookRole_(b) {
   if (!b.title && !b.titleIS) return failJ('title required');
-  const id = b.id || ('role_' + uid_());
-  const existing = findOne_('handbookRoles', 'id', id);
-  const row = {
-    id:              id,
+  const r = _hbUpsert_('handbookRoles', 'role_', b, {
     parentId:        b.parentId || '',
     title:           b.title || '',
     titleIS:         b.titleIS || '',
@@ -174,31 +129,18 @@ function saveHandbookRole_(b) {
     color:           b.color || '',
     boatCategoryKey: b.boatCategoryKey || '',
     sortOrder:       Number(b.sortOrder || 0),
-    active:          b.active === false ? false : true,
-    createdAt:       existing ? (existing.createdAt || now_()) : now_(),
-    updatedAt:       now_(),
-  };
-  if (existing) updateRow_('handbookRoles', 'id', id, row);
-  else          insertRow_('handbookRoles', row);
-  return okJ({ id: id, saved: true });
+  });
+  return okJ({ id: r.id, saved: true });
 }
 
 function deleteHandbookRole_(b) {
-  if (!b.id) return failJ('id required');
-  const existing = findOne_('handbookRoles', 'id', b.id);
-  if (!existing) return failJ('Role not found', 404);
-  // Soft-delete so any sub-roles can be re-parented later if the admin
-  // changes their mind. Children keep their parentId pointing at this row.
-  updateRow_('handbookRoles', 'id', b.id, { active: false, updatedAt: now_() });
-  return okJ({ ok: true });
+  // Soft-delete leaves children's parentId intact so the admin can re-parent.
+  const r = _hbSoftDelete_('handbookRoles', b.id, 'Role not found');
+  return r.error || okJ({ ok: true });
 }
 
-// One-shot scaffolding: seed a Stjórn root + the five deildir if the chart
-// is empty (or if the named entries are missing). Idempotent — never
-// overwrites existing entries, and silently skips deildir whose title
-// already appears.
 function seedHandbookOrgChart_() {
-  const existing = (readAll_('handbookRoles') || []).filter(_handbookActive_);
+  const existing = (readAll_('handbookRoles') || []).filter(_hbActive_);
   const have = {};
   existing.forEach(function (r) {
     have[String(r.titleIS || r.title).toLowerCase()] = r;
@@ -227,16 +169,11 @@ function seedHandbookOrgChart_() {
     return row;
   }
 
+  // Stjórn isn't a boat category, so it carries an explicit color; deildir
+  // resolve theirs from the linked boatCategoryKey at read time.
   const stjorn = ensure({
-    title:     'Board',
-    titleIS:   'Stjórn',
-    sortOrder: 0,
-    // Stjórn isn't a boat category, so it carries an explicit color.
-    color:     '#d4af37',
+    title: 'Board', titleIS: 'Stjórn', sortOrder: 0, color: '#d4af37',
   });
-  // Each deild links to a boat-category key from config; the read endpoint
-  // resolves the deild's color from that category at request time so the
-  // chart stays in sync if an admin retunes a category color elsewhere.
   const deildir = [
     { title: 'Keelboat division',    titleIS: 'Kjölbátadeild',  boatCategoryKey: 'keelboat' },
     { title: 'Dinghy division',      titleIS: 'Kænudeild',      boatCategoryKey: 'dinghy' },
@@ -258,10 +195,7 @@ function seedHandbookOrgChart_() {
 function saveHandbookDoc_(b) {
   if (!b.title) return failJ('title required');
   if (!b.url)   return failJ('url required');
-  const id = b.id || ('doc_' + uid_());
-  const existing = findOne_('handbookDocs', 'id', id);
-  const row = {
-    id:          id,
+  const r = _hbUpsert_('handbookDocs', 'doc_', b, {
     category:    b.category || '',
     categoryIS:  b.categoryIS || '',
     title:       b.title || '',
@@ -271,40 +205,30 @@ function saveHandbookDoc_(b) {
     notes:       b.notes || '',
     notesIS:     b.notesIS || '',
     sortOrder:   Number(b.sortOrder || 0),
-    active:      b.active === false ? false : true,
-    createdAt:   existing ? (existing.createdAt || now_()) : now_(),
-    updatedAt:   now_(),
-  };
-  if (existing) updateRow_('handbookDocs', 'id', id, row);
-  else          insertRow_('handbookDocs', row);
-  return okJ({ id: id, saved: true });
+  });
+  return okJ({ id: r.id, saved: true });
 }
 
 function deleteHandbookDoc_(b) {
-  if (!b.id) return failJ('id required');
-  const existing = findOne_('handbookDocs', 'id', b.id);
-  if (!existing) return failJ('Doc not found', 404);
-  // Trash the Drive file if we own it. Plain external URLs (driveFileId
-  // unset) are left alone.
+  const r = _hbSoftDelete_('handbookDocs', b.id, 'Doc not found');
+  if (r.error) return r.error;
+  // Trash the Drive file if we own it; plain external URLs are left alone.
+  const existing = r.existing;
   if (existing.driveFileId) {
-    try { DriveApp.getFileById(existing.driveFileId).setTrashed(true); }
-    catch (e) { /* file may already be gone */ }
+    try { DriveApp.getFileById(existing.driveFileId).setTrashed(true); } catch (e) {}
   } else if (existing.url) {
-    // Best effort: if the URL points at a Drive file we can extract the id.
     try {
       var m = String(existing.url).match(/\/d\/([a-zA-Z0-9_-]+)/);
       if (m) DriveApp.getFileById(m[1]).setTrashed(true);
     } catch (e) {}
   }
-  updateRow_('handbookDocs', 'id', b.id, { active: false, updatedAt: now_() });
   return okJ({ ok: true });
 }
 
 // Script Property required: DRIVE_FOLDER_ID_HANDBOOK_DOCS
 function uploadHandbookDoc_(b) {
   if (!b.fileData) return failJ('fileData required');
-  const props = PropertiesService.getScriptProperties();
-  const folderId = props.getProperty('DRIVE_FOLDER_ID_HANDBOOK_DOCS');
+  const folderId = PropertiesService.getScriptProperties().getProperty('DRIVE_FOLDER_ID_HANDBOOK_DOCS');
   if (!folderId) return okJ({ ok: false, error: 'Drive folder not configured' });
 
   try {
@@ -321,10 +245,9 @@ function uploadHandbookDoc_(b) {
       jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
       txt: 'text/plain',
     };
-    const mime     = b.mimeType || mimeMap[ext] || 'application/octet-stream';
-    const blob     = Utilities.newBlob(bytes, mime, safeName);
-    const folder   = DriveApp.getFolderById(folderId);
-    const file     = folder.createFile(blob);
+    const mime  = b.mimeType || mimeMap[ext] || 'application/octet-stream';
+    const blob  = Utilities.newBlob(bytes, mime, safeName);
+    const file  = DriveApp.getFolderById(folderId).createFile(blob);
     file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
     return okJ({ ok: true, url: file.getUrl(), driveFileId: file.getId(), fileName: safeName });
   } catch (e) {
@@ -336,34 +259,22 @@ function uploadHandbookDoc_(b) {
 
 function saveHandbookInfo_(b) {
   if (!b.title && !b.titleIS) return failJ('title required');
-  const id = b.id || ('info_' + uid_());
-  const existing = findOne_('handbookInfo', 'id', id);
-  // 'contacts' = important phone numbers (emergency, external orgs, …),
-  // 'rules'    = rules / best practices, anything else falls into the
-  // legacy bucket and renders below the named sections.
+  // 'info' is the legacy fallback bucket so old rows without an explicit
+  // kind still round-trip through the editor; admin UI only writes
+  // 'contacts' or 'rules'.
   const allowedKinds = { contacts: 1, rules: 1, info: 1 };
-  const kind = allowedKinds[b.kind] ? b.kind : 'info';
-  const row = {
-    id:         id,
-    kind:       kind,
+  const r = _hbUpsert_('handbookInfo', 'info_', b, {
+    kind:       allowedKinds[b.kind] ? b.kind : 'info',
     title:      b.title || '',
     titleIS:    b.titleIS || '',
     content:    b.content || '',
     contentIS:  b.contentIS || '',
     sortOrder:  Number(b.sortOrder || 0),
-    active:     b.active === false ? false : true,
-    createdAt:  existing ? (existing.createdAt || now_()) : now_(),
-    updatedAt:  now_(),
-  };
-  if (existing) updateRow_('handbookInfo', 'id', id, row);
-  else          insertRow_('handbookInfo', row);
-  return okJ({ id: id, saved: true });
+  });
+  return okJ({ id: r.id, saved: true });
 }
 
 function deleteHandbookInfo_(b) {
-  if (!b.id) return failJ('id required');
-  const existing = findOne_('handbookInfo', 'id', b.id);
-  if (!existing) return failJ('Info section not found', 404);
-  updateRow_('handbookInfo', 'id', b.id, { active: false, updatedAt: now_() });
-  return okJ({ ok: true });
+  const r = _hbSoftDelete_('handbookInfo', b.id, 'Info section not found');
+  return r.error || okJ({ ok: true });
 }

--- a/handbook/handbook.css
+++ b/handbook/handbook.css
@@ -70,13 +70,8 @@
 .hb-sep { color: var(--muted); }
 
 /* ── Org chart (visual tree) ────────────────────────────────────────────── */
-/* Each node is a vertical stack of (its own box) + (its children row,
-   side-by-side). Connectors are drawn with pseudo-elements per child:
-   each child has a half/full horizontal bar above it (clipped at the
-   ends so first/last children don't overhang) plus a vertical drop. */
 .hb-orgchart {
-  /* Allow horizontal scroll on narrow screens rather than wrapping the
-     tree, which would corrupt the connector lines. */
+  /* Horizontal scroll on narrow screens — wrapping would break connectors. */
   overflow-x: auto;
   padding: 14px 4px 4px;
 }
@@ -136,8 +131,6 @@
   line-height: 1.4;
 }
 
-/* Vertical drop below a node that has children — joins the bar that
-   spans its children row. */
 .hb-orgnode--has-children::after {
   content: '';
   position: absolute;
@@ -149,7 +142,6 @@
   z-index: 0;
 }
 
-/* Add space above each non-root children-row so the connectors fit. */
 .hb-orgnode-wrap > .hb-orgchart-row { margin-top: 20px; }
 
 /* Per-child connectors: a horizontal bar above + a vertical drop into

--- a/handbook/handbook.js
+++ b/handbook/handbook.js
@@ -1,7 +1,6 @@
 prefetch({Handbook:['getHandbook']});
 
-const user = requireAuth();
-const L    = getLang();
+requireAuth();
 
 let _hb = { roles: [], docs: [], info: [], contacts: [] };
 let _hbFilter = '';
@@ -27,10 +26,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   renderHandbook();
 });
 
-function _localized(row, key) {
-  if (L === 'IS') return row[key + 'IS'] || row[key] || '';
-  return row[key] || row[key + 'IS'] || '';
-}
+const _t = (row, key) => localizedField(row, key);
 
 function _matchesFilter(text) {
   if (!_hbFilter) return true;
@@ -56,9 +52,7 @@ function renderHandbook() {
   document.getElementById('hbEmpty').classList.toggle('hidden', anyVisible);
 }
 
-// Plain text → safe HTML. Linkifies URLs, escapes everything else, preserves
-// paragraph breaks. Intentionally narrow so admins can paste raw text without
-// fearing malformed HTML on the read side.
+// Plain text → safe HTML: escape, linkify URLs, preserve paragraph breaks.
 function _renderContent(text) {
   if (!text) return '';
   const escaped = esc(String(text));
@@ -69,25 +63,18 @@ function _renderContent(text) {
   return linked.split(/\n{2,}/).map(p => `<p>${p.replace(/\n/g, '<br>')}</p>`).join('');
 }
 
-// ── 1. Contacts (member-linked + free-text entries) ─────────────────────────
-
 function renderContactsSection() {
-  // People: manually curated member-linked contacts.
-  const people = (_hb.contacts || []).filter(c => {
-    return _matchesFilter(_localized(c, 'label')) ||
-           _matchesFilter(c.name)  ||
-           _matchesFilter(c.phone) ||
-           _matchesFilter(c.email) ||
-           _matchesFilter(_localized(c, 'notes'));
-  });
+  const people = (_hb.contacts || []).filter(c =>
+    _matchesFilter(_t(c, 'label')) ||
+    _matchesFilter(c.name)  ||
+    _matchesFilter(c.phone) ||
+    _matchesFilter(c.email) ||
+    _matchesFilter(_t(c, 'notes'))
+  );
 
-  // Text entries: handbook_info rows where kind === 'contacts'. For things
-  // that aren't tied to a specific person — emergency hotlines, harbor
-  // master, coast guard, etc.
-  const text = _hb.info.filter(it => (it.kind || 'info') === 'contacts').filter(it => {
-    return _matchesFilter(_localized(it, 'title')) ||
-           _matchesFilter(_localized(it, 'content'));
-  });
+  const text = _hb.info
+    .filter(it => (it.kind || 'info') === 'contacts')
+    .filter(it => _matchesFilter(_t(it, 'title')) || _matchesFilter(_t(it, 'content')));
 
   const wrap     = document.getElementById('hbContactsSection');
   const peopleEl = document.getElementById('hbContactsPeople');
@@ -104,11 +91,11 @@ function renderContactsSection() {
   peopleEl.innerHTML = people.length ? `
     <div class="hb-contact-grid">
       ${people.map(c => {
-        const label = esc(_localized(c, 'label'));
+        const label = esc(_t(c, 'label'));
         const name  = esc(c.name || '');
         const phone = c.phone ? `<a href="tel:${esc(c.phone)}" class="hb-link">${esc(c.phone)}</a>` : '';
         const email = c.email ? `<a href="mailto:${esc(c.email)}" class="hb-link">${esc(c.email)}</a>` : '';
-        const notes = esc(_localized(c, 'notes'));
+        const notes = esc(_t(c, 'notes'));
         return `
           <div class="hb-contact-card">
             ${label ? `<div class="hb-contact-label">${label}</div>` : ''}
@@ -123,13 +110,11 @@ function renderContactsSection() {
 
   textEl.innerHTML = text.length ? text.map(it => `
     <div class="hb-info-card">
-      <div class="hb-info-title">${esc(_localized(it, 'title'))}</div>
-      <div class="hb-info-body">${_renderContent(_localized(it, 'content'))}</div>
+      <div class="hb-info-title">${esc(_t(it, 'title'))}</div>
+      <div class="hb-info-body">${_renderContent(_t(it, 'content'))}</div>
     </div>
   `).join('') : '';
 }
-
-// ── 2. Org chart (visual tree) ───────────────────────────────────────────────
 
 function renderOrgChart() {
   const byId = {};
@@ -140,18 +125,20 @@ function renderOrgChart() {
     else roots.push(r);
   });
   const sorter = (a, b) => (Number(a.sortOrder || 0) - Number(b.sortOrder || 0)) ||
-                           String(_localized(a, 'title')).localeCompare(_localized(b, 'title'));
+                           String(_t(a, 'title')).localeCompare(_t(b, 'title'));
   roots.sort(sorter);
   Object.values(byId).forEach(r => r.children.sort(sorter));
 
+  const visCache = {};
   function visible(r) {
+    if (visCache[r.id] !== undefined) return visCache[r.id];
     const childMatches = r.children.some(visible);
-    const self = _matchesFilter(_localized(r, 'title')) ||
+    const self = _matchesFilter(_t(r, 'title')) ||
                  _matchesFilter(r.name) ||
                  _matchesFilter(r.phone) ||
                  _matchesFilter(r.email) ||
-                 _matchesFilter(_localized(r, 'notes'));
-    return self || childMatches;
+                 _matchesFilter(_t(r, 'notes'));
+    return (visCache[r.id] = self || childMatches);
   }
 
   const visibleRoots = roots.filter(visible);
@@ -166,11 +153,11 @@ function renderOrgChart() {
 
 function _renderOrgNode(r, visiblePred) {
   const visibleChildren = (r.children || []).filter(visiblePred);
-  const title = esc(_localized(r, 'title'));
+  const title = esc(_t(r, 'title'));
   const name  = esc(r.name || '');
   const phone = r.phone ? `<a href="tel:${esc(r.phone)}" class="hb-link">${esc(r.phone)}</a>` : '';
   const email = r.email ? `<a href="mailto:${esc(r.email)}" class="hb-link">${esc(r.email)}</a>` : '';
-  const notes = esc(_localized(r, 'notes'));
+  const notes = esc(_t(r, 'notes'));
   const contactRow = (phone || email)
     ? `<div class="hb-orgnode-contact">${phone}${phone && email ? ' · ' : ''}${email}</div>`
     : '';
@@ -192,42 +179,33 @@ function _renderOrgNode(r, visiblePred) {
     </div>`;
 }
 
-// ── 3. Rules / best practices ────────────────────────────────────────────────
-
 function renderRulesSection() {
-  // 'rules' kind explicitly, plus legacy entries with no kind set so existing
-  // content keeps showing up after the schema migration.
+  // Includes legacy rows where `kind` is unset so pre-migration content
+  // still renders here.
   const list = _hb.info
     .filter(it => {
       const k = it.kind || 'info';
       return k === 'rules' || k === 'info';
     })
-    .filter(it => {
-      const title = _localized(it, 'title');
-      const body  = _localized(it, 'content');
-      return _matchesFilter(title) || _matchesFilter(body);
-    });
+    .filter(it => _matchesFilter(_t(it, 'title')) || _matchesFilter(_t(it, 'content')));
   const wrap = document.getElementById('hbRulesSection');
   const target = document.getElementById('hbRulesList');
   if (!list.length) { wrap.classList.add('hidden'); target.innerHTML = ''; return; }
   wrap.classList.remove('hidden');
   target.innerHTML = list.map(it => `
     <div class="hb-info-card">
-      <div class="hb-info-title">${esc(_localized(it, 'title'))}</div>
-      <div class="hb-info-body">${_renderContent(_localized(it, 'content'))}</div>
+      <div class="hb-info-title">${esc(_t(it, 'title'))}</div>
+      <div class="hb-info-body">${_renderContent(_t(it, 'content'))}</div>
     </div>
   `).join('');
 }
 
-// ── 4. Docs (PDFs + URLs) ────────────────────────────────────────────────────
-
 function renderDocsList() {
-  const list = _hb.docs.filter(d => {
-    const title = _localized(d, 'title');
-    const cat   = _localized(d, 'category');
-    const notes = _localized(d, 'notes');
-    return _matchesFilter(title) || _matchesFilter(cat) || _matchesFilter(notes);
-  });
+  const list = _hb.docs.filter(d =>
+    _matchesFilter(_t(d, 'title')) ||
+    _matchesFilter(_t(d, 'category')) ||
+    _matchesFilter(_t(d, 'notes'))
+  );
   const wrap = document.getElementById('hbDocsSection');
   const target = document.getElementById('hbDocsList');
   if (!list.length) { wrap.classList.add('hidden'); target.innerHTML = ''; return; }
@@ -235,7 +213,7 @@ function renderDocsList() {
 
   const groups = {};
   list.forEach(d => {
-    const cat = _localized(d, 'category') || s('handbook.docCatOther');
+    const cat = _t(d, 'category') || s('handbook.docCatOther');
     (groups[cat] = groups[cat] || []).push(d);
   });
   const catNames = Object.keys(groups).sort();
@@ -247,9 +225,9 @@ function renderDocsList() {
           <li>
             <a class="hb-doc-link" href="${esc(d.url)}" target="_blank" rel="noopener noreferrer">
               <span class="hb-doc-icon" aria-hidden="true">${d.driveFileId ? '📄' : '🔗'}</span>
-              <span class="hb-doc-title">${esc(_localized(d, 'title'))}</span>
+              <span class="hb-doc-title">${esc(_t(d, 'title'))}</span>
             </a>
-            ${_localized(d, 'notes') ? `<div class="hb-doc-notes">${esc(_localized(d, 'notes'))}</div>` : ''}
+            ${_t(d, 'notes') ? `<div class="hb-doc-notes">${esc(_t(d, 'notes'))}</div>` : ''}
           </li>
         `).join('')}
       </ul>
@@ -257,9 +235,8 @@ function renderDocsList() {
   `).join('');
 }
 
-// ── Delegated event listeners ────────────────────────────────────────────────
 (function () {
-  if (typeof document === 'undefined' || document._hbListeners) return;
+  if (document._hbListeners) return;
   document._hbListeners = true;
   document.addEventListener('input', function (e) {
     var i = e.target.closest('[data-hb-input]');

--- a/shared/api.js
+++ b/shared/api.js
@@ -31,7 +31,7 @@ try {
 async function apiGet(action, params) {
   params = params || {};
   // Cache getConfig in sessionStorage for 60s — called on every page load
-  var _CACHEABLE = { getConfig: 120000, getWeather: 300000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewBoard: 30000, getCrewInvites: 30000, getNotifications: 30000, getConfirmations: 30000, getHandbook: 120000 };
+  var _CACHEABLE = { getConfig: 120000, getWeather: 300000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewBoard: 30000, getCrewInvites: 30000, getNotifications: 30000, getConfirmations: 30000, getHandbook: 600000 };
   if (_CACHEABLE[action] && !params._fresh) {
     try {
       var _ck = 'ymir_' + action + '_';

--- a/shared/strings.js
+++ b/shared/strings.js
@@ -41,6 +41,16 @@ window.s = function s(key, vars, lang) {
   return str;
 };
 
+// Read a bilingual field from a row: prefer the active-language variant,
+// fall back to the other one when the preferred is blank. Convention:
+// English lives in `key`, Icelandic in `key + 'IS'`.
+window.localizedField = function localizedField(row, key) {
+  if (!row) return '';
+  var lang = (localStorage.getItem('ymirLang') || 'IS').toUpperCase();
+  if (lang === 'IS') return row[key + 'IS'] || row[key] || '';
+  return row[key] || row[key + 'IS'] || '';
+};
+
 window.applyStrings = function applyStrings(root) {
   var scope = root || document;
   scope.querySelectorAll('[data-s]').forEach(function(el) {


### PR DESCRIPTION
Backend (handbook.gs):
- Replace _handbookMemberMap_ with the existing getMemberMap_() from members.gs (CacheService-backed, single source of truth).
- Replace _handbookActive_ with bool_(r.active) — codebase standard.
- Factor save/delete handlers into _hbUpsert_ / _hbSoftDelete_; the four save handlers now build their fields object and delegate.
- Gate _hbBoatCatColorMap_ behind a needs-it check so the config read is skipped when no role uses boatCategoryKey.
- Drop dead _linkedMemberRole field (never read).
- Trim narrating comments per CLAUDE.md guidance; keep only WHY.

Frontend admin (admin/handbook.js):
- Factor save/delete into _hbSave / _hbDelete helpers; the four save and four delete handlers each shrink to ~10 lines.
- Drop redundant _loaded flag — apiGet already memoizes; on invalidation we simply re-fetch.
- Flatten the kind-default ternary in openHandbookInfoModal.
- Drop dead `|| 'rules'` fallback (the select always has a value).
- Trim narrating comments.

Frontend read (handbook/handbook.js):
- Drop unused `const user = requireAuth()` binding.
- Memoize visible() in renderOrgChart by id.
- Simplify the cargo-culted typeof-document guard.
- Trim narrating comments.

Shared:
- Add window.localizedField(row, key) to shared/strings.js; replaces the two near-duplicate _localized / _hbLocalized helpers.
- Bump getHandbook sessionStorage TTL from 120s to 600s — handbook content rarely changes and writes already invalidate the cache.

Net: -201 lines.

https://claude.ai/code/session_01LoN9HvF12huT4s75K5poSJ