### PR TITLE
Handbook rules: single free-text body with formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,14 @@ Content:
   ready for admins to assign people. The seed dedupes by
   `(titleIS|parentId)` so the same sub-role title can coexist under
   every deild and re-running the seed adds only what's missing.
-- **Rules & best practices** — bilingual text blocks. Plain-text content
-  with auto-linkified URLs and paragraph preservation.
+- **Rules & best practices** — single bilingual free-text body (one EN +
+  one IS markdown blob) rather than per-rule cards. Admin edits both
+  textareas inline with a small format toolbar (bold, italic, headings,
+  lists, link, code); rendered as formatted HTML on the read side using
+  a minimal markdown subset. Stored as a single canonical
+  `handbook_info` row with `id='rules_main'`, `kind='rules'`. Pre-existing
+  per-rule rows still surface (first one wins as fallback) until an
+  admin saves once.
 - **Documents** — PDFs and external URLs grouped by category. Admin can
   upload PDFs (or any common doc/image type) directly through the UI;
   uploads land in a dedicated Drive folder via new script property

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -223,3 +223,32 @@
   .hb-member-row > [data-field="labelIS"],
   .hb-member-row > [data-field="representsRoleId"] { grid-column: 1 / -2; }
 }
+
+/* ── Handbook rules editor toolbar ───────────────────────────────────────── */
+.hb-rules-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 4px 0 6px;
+}
+.hb-rules-toolbar .btn-toolbar {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  padding: 3px 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text);
+  cursor: pointer;
+  min-width: 28px;
+}
+.hb-rules-toolbar .btn-toolbar:hover {
+  background: color-mix(in srgb, var(--brass) 10%, var(--surface));
+  border-color: var(--brass);
+}
+.hb-rules-toolbar .btn-toolbar code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-size: 11px;
+}

--- a/admin/handbook.js
+++ b/admin/handbook.js
@@ -104,17 +104,108 @@ function renderHandbookContactsAdmin() {
   card.innerHTML = html || `<div class="empty-state">${s('admin.handbookEmptyInfo')}</div>`;
 }
 
-// Legacy rows without a kind also surface here so pre-migration content edits.
+// Rules is now a single free-text body (markdown) with EN + IS textareas.
+// Loads the canonical 'rules_main' row, falling back to the first existing
+// 'rules' (or legacy 'info') row so pre-existing content surfaces for editing.
 function renderHandbookRulesAdmin() {
-  const card = document.getElementById('hbAdminRulesCard');
-  if (!card) return;
-  const list = (_hbAdmin.info || []).filter(it => {
+  const en = document.getElementById('hbRulesContent');
+  const is = document.getElementById('hbRulesContentIS');
+  if (!en || !is) return;
+  const rows = (_hbAdmin.info || []).filter(it => {
     const k = it.kind || 'info';
     return k === 'rules' || k === 'info';
-  }).sort(_hbBySort);
-  card.innerHTML = list.length
-    ? list.map(_hbInfoRowHtml).join('')
-    : `<div class="empty-state">${s('admin.handbookEmptyInfo')}</div>`;
+  });
+  const main = rows.find(r => r.id === 'rules_main') || rows[0] || null;
+  // Populate from cache only on first mount; avoid clobbering in-progress
+  // edits if a sibling save (contacts modal etc.) re-runs this renderer.
+  if (en.dataset.mounted !== '1') {
+    en.value = main ? (main.content   || '') : '';
+    is.value = main ? (main.contentIS || '') : '';
+    en.dataset.mounted = '1';
+    is.dataset.mounted = '1';
+  }
+  const status = document.getElementById('hbRulesStatus');
+  if (status) status.textContent = '';
+}
+
+async function saveHandbookRulesBody() {
+  const en = document.getElementById('hbRulesContent');
+  const is = document.getElementById('hbRulesContentIS');
+  const status = document.getElementById('hbRulesStatus');
+  try {
+    const payload = {
+      id:        'rules_main',
+      kind:      'rules',
+      title:     'Rules',
+      titleIS:   'Reglur',
+      content:   en.value,
+      contentIS: is.value,
+      sortOrder: 0,
+    };
+    const res = await apiPost('saveHandbookInfo', payload);
+    payload.active = true;
+    payload.id = payload.id || res.id;
+    const arr = _hbAdmin.info;
+    const idx = arr.findIndex(x => x.id === payload.id);
+    if (idx >= 0) arr[idx] = { ...arr[idx], ...payload };
+    else          arr.push(payload);
+    if (status) status.textContent = s('admin.handbook.rules.saved');
+    toast(s('toast.saved'));
+  } catch (e) {
+    toast(s('toast.saveFailed') + ': ' + e.message, 'err');
+  }
+}
+
+// Wraps the current selection in `before`/`after`, or inserts `placeholder`
+// inside the wrappers if there's no selection. For line-prefix tools (lists,
+// headings) pass `before` only with a trailing space; the insertion happens
+// at the start of the current line.
+function hbRulesFormat(targetId, kind) {
+  const ta = document.getElementById(targetId);
+  if (!ta) return;
+  const start = ta.selectionStart;
+  const end   = ta.selectionEnd;
+  const value = ta.value;
+  const sel   = value.slice(start, end);
+
+  const wrap = (before, after, placeholder) => {
+    const inner = sel || placeholder || '';
+    const next  = value.slice(0, start) + before + inner + after + value.slice(end);
+    ta.value = next;
+    const cStart = start + before.length;
+    const cEnd   = cStart + inner.length;
+    ta.setSelectionRange(cStart, cEnd);
+  };
+
+  const linePrefix = (prefix) => {
+    // Find the start of the current line.
+    const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+    // Apply prefix to every line in the selection (or just the current line).
+    const block = value.slice(lineStart, end);
+    const prefixed = block.split('\n').map(l => prefix + l).join('\n');
+    ta.value = value.slice(0, lineStart) + prefixed + value.slice(end);
+    ta.setSelectionRange(lineStart, lineStart + prefixed.length);
+  };
+
+  switch (kind) {
+    case 'bold':    wrap('**', '**', s('admin.handbook.rules.tb.boldPh'));     break;
+    case 'italic':  wrap('*',  '*',  s('admin.handbook.rules.tb.italicPh'));   break;
+    case 'h2':      linePrefix('## ');                                          break;
+    case 'h3':      linePrefix('### ');                                         break;
+    case 'ul':      linePrefix('- ');                                           break;
+    case 'ol':      linePrefix('1. ');                                          break;
+    case 'link': {
+      const url = sel && /^https?:\/\//.test(sel) ? sel : 'https://';
+      const text = sel && !/^https?:\/\//.test(sel) ? sel : s('admin.handbook.rules.tb.linkPh');
+      const next = value.slice(0, start) + '[' + text + '](' + url + ')' + value.slice(end);
+      ta.value = next;
+      const cStart = start + 1;
+      ta.setSelectionRange(cStart, cStart + text.length);
+      break;
+    }
+    case 'code':    wrap('`', '`', s('admin.handbook.rules.tb.codePh'));        break;
+  }
+  ta.focus();
 }
 
 function openHandbookInfoModal(id, kindHint) {

--- a/admin/index.html
+++ b/admin/index.html
@@ -450,17 +450,48 @@
         </div>
       </div>
 
-      <!-- Rules section -->
+      <!-- Rules section: single free-text body (markdown) with a small toolbar -->
       <div class="col-section">
         <div class="col-head" data-admin-toggle-section>
           <div class="col-title" data-s="admin.handbookRulesTitle"></div>
           <span class="col-toggle">▼</span>
         </div>
         <div class="col-body hidden" id="hbAdminRulesCard">
-          <div class="loading-state"><span class="spinner"></span></div>
+          <div class="text-xs text-muted mb-8" data-s="admin.handbook.rules.hint"></div>
+          <div class="grid2 gap-10">
+            <div class="field">
+              <label data-s="admin.handbook.rules.contentEN" for="hbRulesContent"></label>
+              <div class="hb-rules-toolbar">
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="bold"   title="Bold"><b>B</b></button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="italic" title="Italic"><i>I</i></button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="h2"     title="Heading">H2</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="h3"     title="Subheading">H3</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="ul"     title="Bullet list">•</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="ol"     title="Numbered list">1.</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="link"   title="Link">🔗</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContent" data-admin-arg2="code"   title="Code"><code>&lt;/&gt;</code></button>
+              </div>
+              <textarea id="hbRulesContent" rows="10" class="w-full" style="resize:vertical;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px"></textarea>
+            </div>
+            <div class="field">
+              <label data-s="admin.handbook.rules.contentIS" for="hbRulesContentIS"></label>
+              <div class="hb-rules-toolbar">
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="bold"   title="Bold"><b>B</b></button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="italic" title="Italic"><i>I</i></button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="h2"     title="Heading">H2</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="h3"     title="Subheading">H3</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="ul"     title="Bullet list">•</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="ol"     title="Numbered list">1.</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="link"   title="Link">🔗</button>
+                <button type="button" class="btn-toolbar" data-admin-click="hbRulesFormat" data-admin-arg="hbRulesContentIS" data-admin-arg2="code"   title="Code"><code>&lt;/&gt;</code></button>
+              </div>
+              <textarea id="hbRulesContentIS" rows="10" class="w-full" style="resize:vertical;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px"></textarea>
+            </div>
+          </div>
         </div>
-        <div style="padding:8px 0 4px">
-          <button class="btn btn-primary" data-admin-click="openHandbookInfoModal" data-admin-arg="" data-admin-arg2="rules" data-s="admin.handbookAddRule"></button>
+        <div style="padding:8px 0 4px" class="d-flex flex-wrap gap-8 items-center">
+          <button class="btn btn-primary" data-admin-click="saveHandbookRulesBody" data-s="btn.save"></button>
+          <span id="hbRulesStatus" class="text-xs text-muted"></span>
         </div>
       </div>
 

--- a/handbook/handbook.css
+++ b/handbook/handbook.css
@@ -24,6 +24,40 @@
 .hb-info-body a { color: var(--accent); text-decoration: none; }
 .hb-info-body a:hover { text-decoration: underline; }
 
+/* Rules / best-practices: single free-form body with markdown formatting */
+.hb-rules-body {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text);
+}
+.hb-rules-body h3,
+.hb-rules-body h4,
+.hb-rules-body h5 {
+  margin: 14px 0 6px;
+  color: var(--text);
+}
+.hb-rules-body h3:first-child,
+.hb-rules-body h4:first-child,
+.hb-rules-body h5:first-child { margin-top: 0; }
+.hb-rules-body p { margin: 0 0 10px; }
+.hb-rules-body p:last-child { margin-bottom: 0; }
+.hb-rules-body ul,
+.hb-rules-body ol { margin: 0 0 10px; padding-left: 22px; }
+.hb-rules-body li { margin-bottom: 4px; }
+.hb-rules-body code {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-size: 12.5px;
+}
+.hb-rules-body a { color: var(--accent); text-decoration: none; }
+.hb-rules-body a:hover { text-decoration: underline; }
+
 .hb-link {
   color: var(--accent);
   text-decoration: none;

--- a/handbook/handbook.js
+++ b/handbook/handbook.js
@@ -63,6 +63,68 @@ function _renderContent(text) {
   return linked.split(/\n{2,}/).map(p => `<p>${p.replace(/\n/g, '<br>')}</p>`).join('');
 }
 
+// Markdown → safe HTML. Escape first, then transform a small subset:
+// headings (#, ##, ###), **bold**, *italic*, `code`, [text](url),
+// bullet (- ) and numbered (1. ) lists, blank-line paragraph breaks.
+// Bare URLs are linkified. Single newlines inside a paragraph become <br>.
+function _renderMarkdown(text) {
+  if (!text) return '';
+  const inline = (s) => {
+    let out = esc(String(s));
+    out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+      '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    out = out.replace(/(^|[\s(])(https?:\/\/[^\s<)]+)/g,
+      '$1<a href="$2" target="_blank" rel="noopener noreferrer">$2</a>');
+    out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+    out = out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    out = out.replace(/(^|[\s(])\*([^\s*][^*]*?)\*(?=[\s).,!?;:]|$)/g, '$1<em>$2</em>');
+    out = out.replace(/(^|[\s(])_([^\s_][^_]*?)_(?=[\s).,!?;:]|$)/g, '$1<em>$2</em>');
+    return out;
+  };
+  const lines = String(text).replace(/\r\n/g, '\n').split('\n');
+  const html = [];
+  let para = [];
+  let list = null; // {tag:'ul'|'ol', items:[]}
+  const flushPara = () => {
+    if (para.length) {
+      html.push('<p>' + para.map(inline).join('<br>') + '</p>');
+      para = [];
+    }
+  };
+  const flushList = () => {
+    if (list) {
+      html.push(`<${list.tag}>` + list.items.map(li => `<li>${inline(li)}</li>`).join('') + `</${list.tag}>`);
+      list = null;
+    }
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    if (!ln.trim()) { flushPara(); flushList(); continue; }
+    let m;
+    if ((m = ln.match(/^(#{1,3})\s+(.+)$/))) {
+      flushPara(); flushList();
+      html.push(`<h${m[1].length + 2}>${inline(m[2])}</h${m[1].length + 2}>`);
+      continue;
+    }
+    if ((m = ln.match(/^\s*[-*]\s+(.+)$/))) {
+      flushPara();
+      if (!list || list.tag !== 'ul') { flushList(); list = { tag: 'ul', items: [] }; }
+      list.items.push(m[1]);
+      continue;
+    }
+    if ((m = ln.match(/^\s*\d+\.\s+(.+)$/))) {
+      flushPara();
+      if (!list || list.tag !== 'ol') { flushList(); list = { tag: 'ol', items: [] }; }
+      list.items.push(m[1]);
+      continue;
+    }
+    flushList();
+    para.push(ln);
+  }
+  flushPara(); flushList();
+  return html.join('');
+}
+
 function renderContactsSection() {
   const people = (_hb.contacts || []).filter(c =>
     _matchesFilter(_t(c, 'label')) ||
@@ -204,24 +266,21 @@ function _renderOrgNodeMembers(members, byId) {
 }
 
 function renderRulesSection() {
-  // Includes legacy rows where `kind` is unset so pre-migration content
-  // still renders here.
-  const list = _hb.info
-    .filter(it => {
-      const k = it.kind || 'info';
-      return k === 'rules' || k === 'info';
-    })
-    .filter(it => _matchesFilter(_t(it, 'title')) || _matchesFilter(_t(it, 'content')));
+  // Single free-form body. Prefer the canonical `rules_main` row; fall back
+  // to the first 'rules' or legacy 'info' row so pre-migration content still
+  // renders until an admin edits it.
+  const rulesRows = _hb.info.filter(it => (it.kind || 'info') === 'rules' || (it.kind || 'info') === 'info');
+  const main = rulesRows.find(it => it.id === 'rules_main') || rulesRows[0];
+  const body = main ? _t(main, 'content') : '';
   const wrap = document.getElementById('hbRulesSection');
   const target = document.getElementById('hbRulesList');
-  if (!list.length) { wrap.classList.add('hidden'); target.innerHTML = ''; return; }
+  if (!body || !_matchesFilter(body)) {
+    wrap.classList.add('hidden');
+    target.innerHTML = '';
+    return;
+  }
   wrap.classList.remove('hidden');
-  target.innerHTML = list.map(it => `
-    <div class="hb-info-card">
-      <div class="hb-info-title">${esc(_t(it, 'title'))}</div>
-      <div class="hb-info-body">${_renderContent(_t(it, 'content'))}</div>
-    </div>
-  `).join('');
+  target.innerHTML = `<div class="hb-rules-body">${_renderMarkdown(body)}</div>`;
 }
 
 function renderDocsList() {

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1862,4 +1862,13 @@ var _STRINGS_FLAT = {
   "admin.handbook.info.sortOrder":"Sort order",
   "admin.handbook.info.modalAdd": "Add entry",
   "admin.handbook.info.modalEdit":"Edit entry",
+
+  "admin.handbook.rules.hint":       "One free-form body for the whole club. Markdown formatting supported (use the toolbar or write plain markdown).",
+  "admin.handbook.rules.contentEN":  "Body (EN)",
+  "admin.handbook.rules.contentIS":  "Body (IS)",
+  "admin.handbook.rules.saved":      "Saved.",
+  "admin.handbook.rules.tb.boldPh":  "bold text",
+  "admin.handbook.rules.tb.italicPh":"italic text",
+  "admin.handbook.rules.tb.linkPh":  "link text",
+  "admin.handbook.rules.tb.codePh":  "code",
 };

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1862,4 +1862,13 @@ var _STRINGS_FLAT = {
   "admin.handbook.info.sortOrder":"Röðun",
   "admin.handbook.info.modalAdd": "Bæta við færslu",
   "admin.handbook.info.modalEdit":"Breyta færslu",
+
+  "admin.handbook.rules.hint":       "Einn frjáls texti fyrir allan klúbbinn. Markdown-snið styðjast (notaðu tækjastikuna eða skrifaðu hreint markdown).",
+  "admin.handbook.rules.contentEN":  "Texti (EN)",
+  "admin.handbook.rules.contentIS":  "Texti (IS)",
+  "admin.handbook.rules.saved":      "Vistað.",
+  "admin.handbook.rules.tb.boldPh":  "feitletraður texti",
+  "admin.handbook.rules.tb.italicPh":"skáletraður texti",
+  "admin.handbook.rules.tb.linkPh":  "tengill texti",
+  "admin.handbook.rules.tb.codePh":  "kóði",
 };


### PR DESCRIPTION
Replace the rule-by-rule card list with one bilingual markdown body (EN + IS) edited via inline textareas plus a small format toolbar (bold, italic, headings, lists, link, code). The public handbook renders the canonical 'rules_main' row as formatted HTML using a minimal markdown subset; legacy per-rule rows fall back as the first visible row until an admin saves once.

https://claude.ai/code/session_01AAn7CmEW6UEXTbfnpRvBX6