### PR TITLE
Handbook: explicit selected on role-member placeholder options

### DIFF
--- a/admin/handbook.js
+++ b/admin/handbook.js
@@ -394,10 +394,15 @@ function renderHbRoleMembers() {
   }
   const memberOpts = _hbMemberOptions();
   const repOpts    = _hbRepresentsOptions();
-  list.innerHTML = _hbRoleMembers.map((m, i) => `
+  list.innerHTML = _hbRoleMembers.map((m, i) => {
+    // Without an explicit `selected` on the placeholder, an unmatched value
+    // makes the browser fall back to the first concrete option.
+    const ktMatch  = !!m.kennitala && memberOpts.some(o => o.kt === m.kennitala);
+    const repMatch = !!m.representsRoleId && repOpts.some(o => o.id === m.representsRoleId);
+    return `
     <div class="hb-member-row">
       <select data-field="kennitala">
-        <option value="">${esc(s('admin.handbook.role.kennitalaNone'))}</option>
+        <option value=""${ktMatch ? '' : ' selected'}>${esc(s('admin.handbook.role.kennitalaNone'))}</option>
         ${memberOpts.map(o =>
           `<option value="${esc(o.kt)}"${o.kt === m.kennitala ? ' selected' : ''}>${esc(o.label)}</option>`
         ).join('')}
@@ -407,13 +412,14 @@ function renderHbRoleMembers() {
       <input type="text" data-field="labelIS"
              placeholder="${esc(s('admin.handbook.role.memberLabelISPh'))}" value="${esc(m.labelIS || '')}">
       <select data-field="representsRoleId">
-        <option value="">${esc(s('admin.handbook.role.representsNone'))}</option>
+        <option value=""${repMatch ? '' : ' selected'}>${esc(s('admin.handbook.role.representsNone'))}</option>
         ${repOpts.map(o =>
           `<option value="${esc(o.id)}"${o.id === m.representsRoleId ? ' selected' : ''}>${esc(o.label)}</option>`
         ).join('')}
       </select>
       <button type="button" class="row-del" data-admin-click="removeHbRoleMember" data-admin-arg="${i}" aria-label="${esc(s('btn.delete'))}">×</button>
-    </div>`).join('');
+    </div>`;
+  }).join('');
 }
 
 function _hbMemberOptions() {


### PR DESCRIPTION
New rows in the role-members fieldset have empty kennitala/representsRoleId, which never matches a concrete option. Without an explicit `selected` on the placeholder `<option>`, the browser was rendering the first member/role instead of the placeholder, making the dropdown look like it auto-picked.

https://claude.ai/code/session_012HAxsiEjSk3SpxmQmR1UDc