### PR TITLE
Handbook org chart: scope "represents" by level; visualize board↔divi…

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -207,6 +207,10 @@
   align-items: center;
   margin-bottom: 6px;
 }
+/* Level 3+ roles can't represent anything — drop the column entirely. */
+.hb-member-row--no-rep {
+  grid-template-columns: 1.6fr 1fr 1fr auto;
+}
 .hb-member-row select,
 .hb-member-row input { min-width: 0; }
 .hb-member-row .row-del {
@@ -222,6 +226,8 @@
   .hb-member-row { grid-template-columns: 1fr 1fr auto; }
   .hb-member-row > [data-field="labelIS"],
   .hb-member-row > [data-field="representsRoleId"] { grid-column: 1 / -2; }
+  .hb-member-row--no-rep { grid-template-columns: 1fr 1fr auto; }
+  .hb-member-row--no-rep > [data-field="labelIS"] { grid-column: 1 / -2; }
 }
 
 /* ── Handbook rules editor toolbar ───────────────────────────────────────── */

--- a/admin/handbook.js
+++ b/admin/handbook.js
@@ -491,13 +491,23 @@ function renderHbRoleMembers() {
   }
   const memberOpts = _hbMemberOptions();
   const repOpts    = _hbRepresentsOptions();
+  // Level 3+ roles can't represent anything below them, so the column is
+  // hidden entirely. The CSS variant collapses the grid to four columns.
+  const showRep    = repOpts.length > 0;
   list.innerHTML = _hbRoleMembers.map((m, i) => {
     // Without an explicit `selected` on the placeholder, an unmatched value
     // makes the browser fall back to the first concrete option.
     const ktMatch  = !!m.kennitala && memberOpts.some(o => o.kt === m.kennitala);
     const repMatch = !!m.representsRoleId && repOpts.some(o => o.id === m.representsRoleId);
+    const repCell  = showRep ? `
+      <select data-field="representsRoleId">
+        <option value=""${repMatch ? '' : ' selected'}>${esc(s('admin.handbook.role.representsNone'))}</option>
+        ${repOpts.map(o =>
+          `<option value="${esc(o.id)}"${o.id === m.representsRoleId ? ' selected' : ''}>${esc(o.label)}</option>`
+        ).join('')}
+      </select>` : '';
     return `
-    <div class="hb-member-row">
+    <div class="hb-member-row${showRep ? '' : ' hb-member-row--no-rep'}">
       <select data-field="kennitala">
         <option value=""${ktMatch ? '' : ' selected'}>${esc(s('admin.handbook.role.kennitalaNone'))}</option>
         ${memberOpts.map(o =>
@@ -508,12 +518,7 @@ function renderHbRoleMembers() {
              placeholder="${esc(s('admin.handbook.role.memberLabelPh'))}" value="${esc(m.label || '')}">
       <input type="text" data-field="labelIS"
              placeholder="${esc(s('admin.handbook.role.memberLabelISPh'))}" value="${esc(m.labelIS || '')}">
-      <select data-field="representsRoleId">
-        <option value=""${repMatch ? '' : ' selected'}>${esc(s('admin.handbook.role.representsNone'))}</option>
-        ${repOpts.map(o =>
-          `<option value="${esc(o.id)}"${o.id === m.representsRoleId ? ' selected' : ''}>${esc(o.label)}</option>`
-        ).join('')}
-      </select>
+      ${repCell}
       <button type="button" class="row-del" data-admin-click="removeHbRoleMember" data-admin-arg="${i}" aria-label="${esc(s('btn.delete'))}">×</button>
     </div>`;
   }).join('');
@@ -528,15 +533,52 @@ function _hbMemberOptions() {
     .map(m => ({ kt: String(m.kennitala || ''), label: m.name || m.kennitala }));
 }
 
-// Roles to choose from for "represents". Excludes the role being edited so
-// admins can't link a role to itself.
+// Determine the depth of the role being edited (1 = root/board, 2 = under
+// root/division, 3+ = under division). Reads the parent dropdown so this
+// updates live as the admin changes the parent.
+function _hbEditingLevel() {
+  const sel = document.getElementById('hbRoleParent');
+  const parentId = sel ? sel.value : '';
+  if (!parentId) return 1;
+  const parent = _hbAdmin.roles.find(r => r.id === parentId);
+  if (!parent) return 1;
+  return parent.parentId ? 3 : 2;
+}
+
+// Roles to choose from for "represents". Scope depends on level:
+//   • Level 1 (board)     → any level-2 role (a division)
+//   • Level 2 (division)  → only level-3 children of self (sub-roles in same division)
+//   • Level 3+            → no represents option (returns empty; column is hidden)
+// Always excludes the role being edited so a role can't represent itself.
 function _hbRepresentsOptions() {
   const editingId = _hbAdmin.editingRoleId;
-  return _hbAdmin.roles
-    .filter(r => r.id !== editingId)
-    .slice()
-    .sort((a, b) => String(_hbT(a, 'title')).localeCompare(_hbT(b, 'title')))
-    .map(r => ({ id: r.id, label: _hbT(r, 'title') }));
+  const level     = _hbEditingLevel();
+  const sortMap   = (r) => ({ id: r.id, label: _hbT(r, 'title') });
+  const byTitle   = (a, b) => String(a.label).localeCompare(String(b.label));
+
+  if (level === 1) {
+    const rootIds = new Set(_hbAdmin.roles.filter(r => !r.parentId).map(r => r.id));
+    return _hbAdmin.roles
+      .filter(r => r.id !== editingId && r.parentId && rootIds.has(r.parentId))
+      .map(sortMap)
+      .sort(byTitle);
+  }
+  if (level === 2) {
+    if (!editingId) return []; // new level-2 role has no children yet
+    return _hbAdmin.roles
+      .filter(r => r.id !== editingId && r.parentId === editingId)
+      .map(sortMap)
+      .sort(byTitle);
+  }
+  return [];
+}
+
+// Re-render the members fieldset when the parent dropdown changes — the
+// "represents" column scope depends on the editing role's level, which is
+// derived from the chosen parent.
+function hbRoleParentChanged() {
+  _hbRoleMembers = _hbReadMembersFromDOM();
+  renderHbRoleMembers();
 }
 
 function addHbRoleMember() {
@@ -554,12 +596,16 @@ function removeHbRoleMember(idx) {
 }
 
 function _hbReadMembersFromDOM() {
-  return Array.from(document.querySelectorAll('#hbRoleMembersList .hb-member-row')).map(row => ({
-    kennitala:        row.querySelector('[data-field="kennitala"]').value.trim(),
-    label:            row.querySelector('[data-field="label"]').value.trim(),
-    labelIS:          row.querySelector('[data-field="labelIS"]').value.trim(),
-    representsRoleId: row.querySelector('[data-field="representsRoleId"]').value,
-  }));
+  return Array.from(document.querySelectorAll('#hbRoleMembersList .hb-member-row')).map(row => {
+    // Represents column is omitted at level 3+, so guard the lookup.
+    const repEl = row.querySelector('[data-field="representsRoleId"]');
+    return {
+      kennitala:        row.querySelector('[data-field="kennitala"]').value.trim(),
+      label:            row.querySelector('[data-field="label"]').value.trim(),
+      labelIS:          row.querySelector('[data-field="labelIS"]').value.trim(),
+      representsRoleId: repEl ? repEl.value : '',
+    };
+  });
 }
 
 function hbRoleColorPicked() {

--- a/admin/index.html
+++ b/admin/index.html
@@ -599,7 +599,7 @@
           <div class="field"><label data-s="admin.handbook.role.titleIS" for="hbRoleTitleIS"></label><input type="text" id="hbRoleTitleIS" list="hbRoleTitleListIS"><datalist id="hbRoleTitleListIS"></datalist></div>
         </div>
         <div class="field"><label data-s="admin.handbook.role.parent" for="hbRoleParent"></label>
-          <select id="hbRoleParent"></select>
+          <select id="hbRoleParent" data-admin-change="hbRoleParentChanged"></select>
         </div>
         <fieldset class="hb-members-fieldset">
           <legend data-s="admin.handbook.role.membersHdr"></legend>

--- a/handbook/handbook.css
+++ b/handbook/handbook.css
@@ -108,15 +108,17 @@
   /* `--hb-accent` cascades from each .hb-orgnode-wrap that sets it (deildir
      do, via inline style). Sub-roles without their own color inherit. */
   --hb-accent: var(--brass);
-  /* Horizontal scroll on narrow screens — wrapping would break connectors. */
-  overflow-x: auto;
   padding: 14px 4px 4px;
+  /* No horizontal scroll: rows wrap when there isn't room. Connectors above
+     wrapped items become harmless stubs (cheaper than re-architecting them). */
 }
 .hb-orgchart-row {
   display: flex;
   justify-content: center;
   align-items: flex-start;
   gap: 18px;
+  flex-wrap: wrap;
+  row-gap: 26px;
 }
 /* Top-level row needs no incoming connectors. */
 .hb-orgchart-roots > .hb-orgnode-wrap::before,
@@ -127,7 +129,8 @@
   flex-direction: column;
   align-items: center;
   position: relative;
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 .hb-orgnode {
@@ -137,7 +140,7 @@
   border-radius: var(--radius-md, 8px);
   padding: 10px 14px;
   min-width: 150px;
-  max-width: 220px;
+  max-width: 240px;
   text-align: center;
   box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
   position: relative;
@@ -148,6 +151,13 @@
   font-size: 13px;
   color: var(--text);
   letter-spacing: 0.3px;
+}
+
+/* Board-level node sits "above" its divisions and is wider so each member
+   row can carry a colored stripe pointing at the division they represent. */
+.hb-orgnode--board {
+  min-width: 240px;
+  max-width: 480px;
 }
 
 /* Member list inside an org-chart node */
@@ -182,6 +192,23 @@
   font-size: 11px;
   color: var(--muted);
 }
+
+/* Board-member rows: each gets a left stripe colored to the division they
+   represent (or a neutral stripe if they're general board with no division).
+   This makes the dual-role nature of the board visible in the layout itself
+   instead of relying on a small "represents" chip. */
+.hb-member-list--board { margin-top: 10px; }
+.hb-member-item--board {
+  --hb-rep: color-mix(in srgb, var(--border) 70%, transparent);
+  padding: 6px 8px 6px 10px;
+  margin-top: 4px;
+  border-top: 0;
+  border-left: 4px solid var(--hb-rep);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--hb-rep) 10%, transparent);
+}
+.hb-member-item--board:first-child { margin-top: 0; }
+.hb-member-item--board.hb-member-item--has-rep .hb-member-name { color: var(--text); }
 
 /* "Represents" chip — small badge colored by the represented role's accent. */
 .hb-represents-chip {
@@ -253,11 +280,17 @@
   background: var(--border);
 }
 
-/* On very narrow screens, fall back to a stacked vertical list so the
-   chart stays readable instead of trying to render side-by-side. */
+/* On narrow screens, shrink nodes and let the board node use the full
+   available width. Connectors between siblings become per-card stubs once
+   wrapping kicks in — acceptable; no horizontal scrolling either way. */
 @media (max-width: 600px) {
-  .hb-orgchart-row { flex-wrap: wrap; }
-  .hb-orgnode { min-width: 120px; }
+  .hb-orgchart-row { gap: 12px; row-gap: 24px; }
+  .hb-orgnode { min-width: 130px; max-width: 100%; padding: 8px 10px; }
+  .hb-orgnode--board { min-width: 0; max-width: 100%; width: 100%; }
+  /* Hide the per-sibling horizontal connector bar once wrapping is the norm:
+     it no longer carries useful information, and the parent's vertical drop
+     plus each child's stub stays. */
+  .hb-orgchart-row > .hb-orgnode-wrap::before { display: none; }
 }
 
 /* Docs list */

--- a/handbook/handbook.js
+++ b/handbook/handbook.js
@@ -211,11 +211,11 @@ function renderOrgChart() {
   if (!visibleRoots.length) { wrap.classList.add('hidden'); target.innerHTML = ''; return; }
   wrap.classList.remove('hidden');
   target.innerHTML = `<div class="hb-orgchart-row hb-orgchart-roots">${
-    visibleRoots.map(r => _renderOrgNode(r, visible, byId)).join('')
+    visibleRoots.map(r => _renderOrgNode(r, visible, byId, 1)).join('')
   }</div>`;
 }
 
-function _renderOrgNode(r, visiblePred, byId) {
+function _renderOrgNode(r, visiblePred, byId, level) {
   const visibleChildren = (r.children || []).filter(visiblePred);
   const title = esc(_t(r, 'title'));
   const notes = esc(_t(r, 'notes'));
@@ -224,38 +224,51 @@ function _renderOrgNode(r, visiblePred, byId) {
   // custom-property inheritance; children with their own color override.
   const accent = r.color ? ` style="--hb-accent:${esc(r.color)}"` : '';
   const hasChildren = visibleChildren.length > 0;
-  const membersHtml = _renderOrgNodeMembers(r.members || [], byId);
+  // Board-level (root with children): stripe each member by their represented
+  // division so the link to the cards below is visually obvious.
+  const isBoardLike = level === 1 && hasChildren;
+  const membersHtml = _renderOrgNodeMembers(r.members || [], byId, isBoardLike);
+  const nodeCls = ['hb-orgnode'];
+  if (hasChildren) nodeCls.push('hb-orgnode--has-children');
+  if (isBoardLike) nodeCls.push('hb-orgnode--board');
   return `
     <div class="hb-orgnode-wrap"${accent}>
-      <div class="hb-orgnode${hasChildren ? ' hb-orgnode--has-children' : ''}">
+      <div class="${nodeCls.join(' ')}">
         <div class="hb-orgnode-title">${title}</div>
         ${membersHtml}
         ${notesRow}
       </div>
       ${hasChildren ? `
         <div class="hb-orgchart-row">
-          ${visibleChildren.map(c => _renderOrgNode(c, visiblePred, byId)).join('')}
+          ${visibleChildren.map(c => _renderOrgNode(c, visiblePred, byId, level + 1)).join('')}
         </div>` : ''}
     </div>`;
 }
 
-function _renderOrgNodeMembers(members, byId) {
+function _renderOrgNodeMembers(members, byId, isBoardLike) {
   if (!members.length) return '';
-  return `<ul class="hb-member-list">${
+  return `<ul class="hb-member-list${isBoardLike ? ' hb-member-list--board' : ''}">${
     members.map(m => {
       const name  = esc(m.name || '');
       const label = esc(_t(m, 'label'));
       const phone = m.phone ? `<a href="tel:${esc(m.phone)}" class="hb-link">${esc(m.phone)}</a>` : '';
       const email = m.email ? `<a href="mailto:${esc(m.email)}" class="hb-link">${esc(m.email)}</a>` : '';
       const repRole = m.representsRoleId && byId[m.representsRoleId];
+      const repColor = repRole ? (repRole.color || 'var(--brass)') : '';
       const chip = repRole
-        ? `<span class="hb-represents-chip" style="--hb-chip:${esc(repRole.color || 'var(--brass)')}">${esc(_t(repRole, 'title'))}</span>`
+        ? `<span class="hb-represents-chip" style="--hb-chip:${esc(repColor)}">${esc(_t(repRole, 'title'))}</span>`
         : '';
       const contact = (phone || email)
         ? `<span class="hb-member-contact">${phone}${phone && email ? ' · ' : ''}${email}</span>`
         : '';
+      const itemCls = ['hb-member-item'];
+      if (isBoardLike)        itemCls.push('hb-member-item--board');
+      if (isBoardLike && repColor) itemCls.push('hb-member-item--has-rep');
+      const itemStyle = (isBoardLike && repColor)
+        ? ` style="--hb-rep:${esc(repColor)}"`
+        : '';
       return `
-        <li class="hb-member-item">
+        <li class="${itemCls.join(' ')}"${itemStyle}>
           <span class="hb-member-name">${name || '—'}</span>
           ${label ? `<span class="hb-member-label">${label}</span>` : ''}
           ${chip}


### PR DESCRIPTION
…sion link

- Admin: "Represents" dropdown is now level-aware. Level-1 (board) members pick from level-2 divisions; level-2 division members pick from their own level-3 sub-roles only (Námskeið / Iðkendur / Félagsstarf / Keppnisstarf); level-3+ hides the column entirely. The column re-scopes live as the admin changes the parent dropdown.
- Public: Board-level members render in a wider node with a colored left stripe matching the division they represent (faint background tint plus border), so the dual-role nature shows up in the layout itself instead of relying solely on the small "represents" chip. Chip stays for the textual cue.
- Layout: Org chart no longer scrolls horizontally — rows wrap and the per-sibling connector bar is dropped on small screens, where the parent's vertical drop and per-card stub are enough.