### PR TITLE
Fix hidden slot calendar on coxswain page

### DIFF
--- a/coxswain/coxswain.js
+++ b/coxswain/coxswain.js
@@ -507,8 +507,8 @@ function initCxSlots() {
   });
   var sect = document.getElementById('sectSlots');
   // Show section if there are slot-scheduled boats (no longer requires active crews)
-  if (!_cxSlotBoats.length) { sect.style.display = 'none'; return; }
-  sect.style.display = '';
+  sect.classList.toggle('d-none', !_cxSlotBoats.length);
+  if (!_cxSlotBoats.length) return;
   // Populate boat filter
   var boatSel = document.getElementById('cxSlotBoat');
   boatSel.innerHTML = '';


### PR DESCRIPTION
initCxSlots toggled inline display, but the section was hidden by the .d-none utility class — clearing inline style never beats the class, so the slot-reservation calendar stayed hidden for rowers with slot-scheduled shells. Toggle the class instead.