### PR TITLE
Activity types: fix id loss + block half-filled bulk schedules

### DIFF
--- a/admin/act-types.js
+++ b/admin/act-types.js
@@ -136,8 +136,16 @@ async function saveActType() {
   bs.toDate   = document.getElementById("atBsToDate").value   || '';
   // Empty schedule (no fromDate/toDate AND no days) is normalized to null so
   // projection skips this class cleanly.
-  var hasSchedule = (bs.fromDate || bs.toDate || (Array.isArray(bs.daysOfWeek) && bs.daysOfWeek.length));
+  var dayCount = Array.isArray(bs.daysOfWeek) ? bs.daysOfWeek.length : 0;
+  var hasSchedule = (bs.fromDate || bs.toDate || dayCount);
   const schedSrc = document.getElementById("atSchedSrcCalendar").checked ? 'calendar' : 'bulk';
+  // Bulk-schedule guard: a half-filled schedule (date range without days, or
+  // days without a range) silently emits zero virtual slots from the
+  // projector. Block it at save so the admin sees the missing piece.
+  if (schedSrc === 'bulk' && hasSchedule && (!bs.fromDate || !bs.toDate || !dayCount)) {
+    toast(s("slot.selectDays"), "err");
+    return;
+  }
   const payload = {
     id: editingId, name,
     nameIS:   document.getElementById("atNameIS").value.trim(),

--- a/alerts.gs
+++ b/alerts.gs
@@ -132,7 +132,9 @@ function saveConfigListItem_(key, patch) {
     item = Object.assign(arr[idx], patch, { updatedAt: ts });
     arr[idx] = item;
   } else {
-    item = Object.assign({ id: (patch && patch.id) || uid_() }, patch || {}, { createdAt: ts, updatedAt: ts });
+    // id last so an empty-string `patch.id` can't clobber the freshly-minted uid.
+    var newId = (patch && patch.id) || uid_();
+    item = Object.assign({}, patch || {}, { id: newId, createdAt: ts, updatedAt: ts });
     arr.push(item);
     created = true;
   }


### PR DESCRIPTION
saveConfigListItem_ generated a fresh uid_ for new items but then let Object.assign clobber it with patch.id when patch carried an empty string, leaving rows persisted with id=''. Reorder the merge so the freshly-minted id wins.

The activity-type form computed hasSchedule from any of fromDate/ toDate/daysOfWeek, which let admins save a 'bulk' class with a date range but zero days — the slot projector then silently emits nothing because daysOfWeek.indexOf(dow) === -1. Reject the half-filled state at save with the existing slot.selectDays string.