### PR TITLE
Activity types: let the row X button delete id-less orphans

### DIFF
--- a/admin/act-types.js
+++ b/admin/act-types.js
@@ -325,7 +325,10 @@ function toggleAtDay(dayVal) {
 }
 
 async function deleteActType(id) {
-  const _id = id || editingId;
+  // Treat only missing args (modal Delete button) as "fall back to editingId".
+  // An empty string means the row has no id (orphan from the earlier
+  // saveConfigListItem_ bug) and we still want the backend filter to remove it.
+  const _id = (id == null) ? editingId : id;
   if (!await ymConfirm(s("admin.confirmDeleteActType"))) return;
   // Count linked volunteer events and signups so we can warn the admin
   // before cascading through real signup data.


### PR DESCRIPTION
deleteActType used `id || editingId`, which treated an empty-string arg the same as no arg. The X button on a row passes the row's id verbatim, so for orphan rows persisted with id='' (saveConfigListItem_ bug, now fixed) the call collapsed to editingId — null when the modal isn't open — and the backend filter `a.id !== null` kept everything. Distinguish missing args (null/undefined) from a deliberate empty id.