### PR TITLE
Activity types: send nested fields native so the in-memory row stays …

### DIFF
--- a/admin/act-types.js
+++ b/admin/act-types.js
@@ -157,10 +157,15 @@ async function saveActType() {
     calendarSyncActive: document.getElementById("atCalendarSyncActive").checked,
     defaultStart: document.getElementById("atDefaultStart").value.trim(),
     defaultEnd:   document.getElementById("atDefaultEnd").value.trim(),
-    bulkSchedule: hasSchedule ? JSON.stringify(bs) : null,
-    reservedBoatIds: JSON.stringify(window._atReservedBoatIds || []),
+    // Send nested fields as native object/array. _call JSON-stringifies the
+    // whole payload once, and the backend accepts both shapes — but saveEntity
+    // stuffs `payload` straight into the in-memory list after a successful
+    // save, so a stringified bulkSchedule here breaks renderActTypes'
+    // "X days/week" label until the next page load.
+    bulkSchedule: hasSchedule ? bs : null,
+    reservedBoatIds: (window._atReservedBoatIds || []).slice(),
     scheduleSource: schedSrc,
-    roles: isVol ? JSON.stringify(window._atRoles || []) : JSON.stringify([]),
+    roles: isVol ? (window._atRoles || []).slice() : [],
     leaderMemberId: atLeaderMemberId,
     leaderName: atLeaderName,
     leaderPhone: document.getElementById("atLeaderPhone").value.trim(),


### PR DESCRIPTION
…usable

saveActType stringified bulkSchedule, reservedBoatIds, and roles before posting. The backend accepts both shapes, but saveEntity replays the literal payload into the local actTypes array after a successful save — so the row carried a string where renderActTypes expected an object, and the "X days/week" label silently dropped out until a page reload re-fetched the parsed shape from getConfig. _call already JSON.stringifies the whole envelope, so the inner stringify was redundant; remove it.