### PR TITLE
Captain: persist class-slot unbookings + restore held pattern

### DIFF
--- a/captain/captain.js
+++ b/captain/captain.js
@@ -772,7 +772,15 @@ async function bookCqSlot(slotId) {
     renderCqSlots();
   }
   try {
-    await apiPost('bookSlot', { slotId: slotId, kennitala: user.kennitala, memberName: user.name, bookingColor: bookingColor });
+    var res = await apiPost('bookSlot', { slotId: slotId, kennitala: user.kennitala, memberName: user.name, bookingColor: bookingColor });
+    // Booking a virtual class-slot materializes a real reservationSlots row
+    // on the backend; capture the new id (and drop the `virtual` flag) so a
+    // subsequent unbook in the same session targets the materialized row
+    // instead of being rejected as "virtual class slot — nothing to unbook".
+    if (slot && res && res.slotId && res.slotId !== slotId) {
+      slot.id = res.slotId;
+      slot.virtual = false;
+    }
     toast(s('slot.booked'));
   } catch(e) {
     toast(e.message || 'Error', 'err');
@@ -787,6 +795,17 @@ async function unbookCqSlot(slotId) {
   if (slot) {
     slot.bookedByKennitala = '';
     slot.bookedByName = '';
+    slot.bookedByCrewId = '';
+    slot.bookingColor = '';
+    // Class-slot bookings are dematerialized on the backend (the row is
+    // deleted so the projection re-emits the virtual). Mirror that locally:
+    // restore the virtual flag + vslot-* id so the renderer paints the held
+    // pattern instead of plain "open", and a follow-up click books cleanly
+    // against the projected id.
+    if (slot.sourceActivityClassId) {
+      slot.virtual = true;
+      slot.id = 'vslot-' + slot.sourceActivityClassId + '-' + slot.boatId + '-' + slot.date;
+    }
     renderCqSlots();
   }
   try {


### PR DESCRIPTION
Two coupled bugs around virtual class-slot lifecycle:

bookCqSlot didn't read back the materialized id that bookSlot_ returns when a virtual slot is booked. The in-memory slot kept its vslot-* id, so a same-session unbook sent that virtual id back and unbookSlot_ rejected it ("Virtual class slot — nothing to unbook"). The error handler restored the booking and the materialized row on the backend was never deleted — refresh showed the slot as still booked. Capture the returned slotId on success and clear the virtual flag so subsequent operations target the real row.

unbookCqSlot's optimistic local update only cleared the booker fields, leaving virtual=false and the materialized id in place. The SlotCalendar renderer fell through to sc-slot--open (plain white) instead of the striped sc-slot--held pattern that should follow dematerialization. Mirror the backend's dematerialize: when the slot carries sourceActivityClassId, set virtual=true and rebuild the vslot-* id so the renderer paints held and a follow-up click books cleanly against the projected id.

Also clear bookedByCrewId and bookingColor in the optimistic update so crew/color leftovers don't leak into the next render.