### PR TITLE
Captain: load captain.js before shared/logbook.js

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -23,6 +23,11 @@
 <script src="../shared/boat-modal.js"></script>
 <script src="../shared/slot-modal.js"></script>
 <script src="../shared/tripcard.js" defer></script>
+<!-- captain.js must run before shared/logbook.js so its top-level
+     `window._logbookSkipInit = true` is set before logbook.js's auto-init IIFE
+     reads the flag — otherwise the IIFE proceeds, calls renderCerts() (which
+     only exists in /logbook), and the failure briefly flashes as a toast. -->
+<script src="captain.js" defer></script>
 <script src="../shared/logbook.js" defer></script>
 <script src="../shared/logbook-form.js" defer></script>
 <script src="../shared/logbook-share.js" defer></script>
@@ -216,6 +221,5 @@
 
 <!-- Boat modal — markup injected by shared/boat-modal.js (injectBoatModalHtml()). -->
 
-<script src="captain.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
shared/logbook.js's auto-init IIFE checks window._logbookSkipInit, which captain.js sets at the top of its file. Both scripts use defer, so they execute in document order — but logbook.js was listed first, so the IIFE ran before the flag was set, called renderCerts() (only defined in /logbook), and briefly flashed a "renderCerts is not defined" toast on the captain page before the rest of init replaced it.

Move captain.js's <script> tag in front of shared/logbook.js so the flag is in place when the IIFE checks it.