### PR TITLE
Captain: reconcile slot state with backend after book/unbook

### DIFF
--- a/captain/captain.js
+++ b/captain/captain.js
@@ -782,6 +782,9 @@ async function bookCqSlot(slotId) {
       slot.virtual = false;
     }
     toast(s('slot.booked'));
+    // Reconcile with backend truth — cheap defensive refresh in case the
+    // optimistic update missed a field (e.g. tentative flag for forming crews).
+    loadCqSlots();
   } catch(e) {
     toast(e.message || 'Error', 'err');
     loadCqSlots();
@@ -811,6 +814,10 @@ async function unbookCqSlot(slotId) {
   try {
     await apiPost('unbookSlot', { slotId: slotId, kennitala: user.kennitala });
     toast(s('slot.unbooked'));
+    // Reconcile with backend truth — guarantees the rendered state matches
+    // even if the optimistic update missed something (e.g. dematerialized
+    // class slot needs the freshly-projected vslot back).
+    loadCqSlots();
   } catch(e) {
     if (prevSlot && slot) { Object.assign(slot, prevSlot); renderCqSlots(); }
     toast(e.message || 'Error', 'err');


### PR DESCRIPTION
Optimistic local updates can drift from the backend's truth (missed fields, race conditions, or — as just observed — a successful unbook where the rendered slot remained styled as booked until a manual refresh). Re-fetch slots after a successful book or unbook so the rendered state always matches the source of truth. The optimistic update still gives instant feedback during the round-trip.