### PR TITLE
Reserve chevron room on custom-styled <select> elements

### DIFF
--- a/logbook/logbook.css
+++ b/logbook/logbook.css
@@ -42,6 +42,7 @@
 .form-field{margin-bottom:12px}
 .form-field label{font-size:9px;text-transform:uppercase;margin-bottom:4px}
 .form-field input,.form-field select,.form-field textarea{font-size:12px;padding:8px 10px}
+.form-field select{padding-right:34px}
 .form-row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 .btn-primary{background:var(--accent);color:#000;border:none;border-radius:var(--radius-sm);padding:11px 20px;font-family:inherit;font-size:12px;font-weight:500;cursor:pointer;width:100%;transition:all .2s}
 .btn-primary:hover{opacity:.9;box-shadow:var(--accent-glow-sm);transform:translateY(-1px)}

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -7,7 +7,7 @@
 .settings-row:last-child{margin-bottom:0}
 .settings-row label{font-size:12px;color:var(--text);flex:1;display:flex;align-items:center;gap:6px;text-transform:none;letter-spacing:0;margin:0}
 .settings-row input[type="text"]{width:80px;font-size:14px;font-weight:500;text-align:center;letter-spacing:2px;padding:8px;text-transform:uppercase}
-.settings-row select{width:auto;min-width:140px;font-size:12px;padding:7px 10px}
+.settings-row select{width:auto;min-width:140px;font-size:12px;padding:7px 34px 7px 10px}
 .toggle-group{display:flex;gap:0;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden}
 .toggle-group button{background:none;border:none;border-right:1px solid var(--border);padding:7px 14px;font-size:11px;font-family:inherit;cursor:pointer;color:var(--muted);transition:all .2s;white-space:nowrap}
 .toggle-group button:last-child{border-right:none}

--- a/shared/style.css
+++ b/shared/style.css
@@ -418,6 +418,7 @@ input[type=file]:disabled::-webkit-file-upload-button { cursor: not-allowed; }
 .field--compact input, .field--compact select, .field--compact textarea {
   padding: 9px 10px; font-size: 13px;
 }
+.field--compact select { padding-right: 34px; }
 
 textarea { min-height: 70px; }
 
@@ -441,7 +442,7 @@ textarea { min-height: 70px; }
 }
 .filter-bar select,
 .filter-bar input {
-  background: var(--surface);
+  background-color: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text);
@@ -475,7 +476,7 @@ textarea { min-height: 70px; }
 .filter-select {
   width: auto;
   height: 30px;
-  padding: 5px 9px;
+  padding: 5px 26px 5px 9px;
   font-size: 11px;
 }
 

--- a/staff/staff.css
+++ b/staff/staff.css
@@ -210,7 +210,8 @@
 .gm-drop{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:0 0 var(--radius-sm) var(--radius-sm);z-index:500;max-height:160px;overflow-y:auto;display:none}
 .gm-drop-item{padding:7px 10px;font-size:11px;cursor:pointer;border-bottom:1px solid var(--border)}
 .gm-field label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;display:block;margin-bottom:4px}
-.gm-field input,.gm-field select{width:100%;box-sizing:border-box;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
+.gm-field input,.gm-field select{width:100%;box-sizing:border-box;background-color:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;font-size:12px;padding:7px 10px}
+.gm-field select{padding-right:34px}
 .gm-row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 .gm-activity-link{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 12px;margin-bottom:10px}
 .gm-activity-link .link-label{font-size:9px;color:var(--muted);letter-spacing:.8px;text-transform:uppercase;margin-bottom:6px}


### PR DESCRIPTION
The base `select` rule sets `padding-right: 34px` and paints the chevron via `background-image`. Several class rules later target selects with shorthand `padding:` (resets padding-right) and/or shorthand `background:` (resets background-image), so the chevron either overlaps the text or disappears entirely. Fixed by either using longhand `background-color:` or restoring `padding-right` after the shorthand:

- `.filter-select` (captain/coxswain/admin filter selects) — padding now `5px 26px 5px 9px`; was overlapping with text like "All boats".
- `.filter-bar select` (logbook filter rows) — switched to `background-color:` so the chevron survives.
- `.field--compact select`, `.form-field select`, `.settings-row select`, `.gm-field select` — restored padding-right and (where needed) switched to background-color longhand.

https://claude.ai/code/session_0115fred8NjjdAp7oDimimG2