### PR TITLE
Coxswain: show crew booking color dot in crew board card

### DIFF
--- a/coxswain/coxswain.css
+++ b/coxswain/coxswain.css
@@ -63,7 +63,7 @@
 .cb-seat-name { overflow:hidden; text-overflow:ellipsis; }
 .cb-actions { display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
 .cb-needs { font-size:10px; color:var(--accent-fg); margin-top:6px; }
-.cb-color-dot { width:10px; height:10px; border-radius:50%; flex-shrink:0; }
+.cb-color-dot { width:12px; height:12px; border-radius:50%; flex-shrink:0; box-shadow:inset 0 0 0 1px rgba(0,0,0,.25); }
 
 /* ── Passport ── */
 .pp-cat { margin-bottom:14px; }

--- a/coxswain/coxswain.js
+++ b/coxswain/coxswain.js
@@ -271,8 +271,11 @@ function renderCrewCard(c) {
 
   var descHtml = c.description ? '<div class="cb-desc">' + esc(c.description) + '</div>' : '';
 
+  var colorDot = '<span class="cb-color-dot" style="background:' + esc(crewColor) + '" title="' + esc(s('cox.crewColor')) + '" aria-label="' + esc(s('cox.crewColor')) + '"></span>';
+
   return '<div class="cb-card" style="border-color:' + esc(crewColor) + '">'
     + '<div class="cb-header">'
+      + colorDot
       + '<span class="cb-name">' + esc(c.name) + '</span> ' + badge
       + ' <span class="cb-count">' + filledSeats + '/' + totalSeats + '</span>'
     + '</div>'


### PR DESCRIPTION
Add a small color swatch to each crew board card header so members can visually match the card to its bookings on the slot calendar.

https://claude.ai/code/session_01Ta4BR3ZtK4ToVGz2QEEoU1