### PR TITLE
Scheduling: consolidate paired activity + volunteer rows

### DIFF
--- a/admin/scheduling.js
+++ b/admin/scheduling.js
@@ -112,12 +112,21 @@ function _upcomingRowHtml(ev, L) {
   var title = (L === 'IS' && ev.titleIS) ? ev.titleIS : (ev.title || '');
   var subtitle = ev.subtypeName ? ' — ' + esc(ev.subtypeName) : '';
   var signups = '';
-  if (ev.kind === 'volunteer' && ev.capacity) {
-    signups = ' <span class="sched-signup">' + ev.signupCount + '/' + ev.capacity + '</span>';
+  if (ev.capacity) {
+    // Consolidated activity rows carry the volunteer side via
+    // linkedVolunteerEvent — make the chip the click target for the modal so
+    // the row's daily-log link and reschedule/cancel buttons aren't shadowed
+    // by a whole-row click.
+    var volId = ev.linkedVolunteerEvent ? ev.linkedVolunteerEvent.id
+              : (ev.kind === 'volunteer' ? ev.id : '');
+    var chipClick = volId
+      ? ' data-admin-click="openVolEventModal" data-admin-arg="' + esc(volId) + '" style="cursor:pointer"'
+      : '';
+    signups = ' <span class="sched-signup"' + chipClick + '>' + ev.signupCount + '/' + ev.capacity + '</span>';
   }
-  var editAction = ev.kind === 'volunteer' ? 'openVolEventModal' : '';
-  // Activities are authored in the daily log, not in a modal — link to it
-  // with a date-carrying href rather than a JS action.
+  // Standalone volunteer rows stay whole-row-clickable. Activity rows (paired
+  // or not) leave the whole-row click off — they have multiple child actions.
+  var editAction = (ev.kind === 'volunteer') ? 'openVolEventModal' : '';
   var openAttr = editAction
     ? (' data-admin-click="' + editAction + '" data-admin-arg="' + esc(ev.id) + '" style="cursor:pointer"')
     : '';

--- a/shared/scheduled-event.js
+++ b/shared/scheduled-event.js
@@ -171,7 +171,33 @@
         || (a.startTime || '').localeCompare(b.startTime || '')
         || (a.title || '').localeCompare(b.title || '');
     });
-    return out;
+
+    // Pair each volunteer event with its matching activity row (same class +
+    // date) so the timeline shows one row per occurrence. The volunteer side
+    // contributes its signup chip + modal target via `linkedVolunteerEvent`;
+    // the activity side keeps its daily-log link and reschedule/cancel
+    // buttons. Volunteer events without a matching activity (manual one-offs,
+    // or activity-class cancelled but signups remain) still render alone.
+    var volByKey = {};
+    out.forEach(function (ev) {
+      if (ev.kind !== 'volunteer' || !ev.activityTypeId) return;
+      var key = ev.activityTypeId + '|' + ev.date;
+      if (!volByKey[key]) volByKey[key] = ev;
+    });
+    var consumed = {};
+    out.forEach(function (ev) {
+      if (ev.kind !== 'activity' || !ev.activityTypeId) return;
+      var key = ev.activityTypeId + '|' + ev.date;
+      var vol = volByKey[key];
+      if (!vol || consumed[vol.id]) return;
+      ev.linkedVolunteerEvent = vol;
+      ev.signupCount = vol.signupCount;
+      ev.capacity    = vol.capacity;
+      consumed[vol.id] = true;
+    });
+    return out.filter(function (ev) {
+      return !(ev.kind === 'volunteer' && consumed[ev.id]);
+    });
   }
 
   function calendarSourcedActivityTypes(actTypes) {


### PR DESCRIPTION
Activity classes flagged volunteer were producing two rows per occurrence in the admin Upcoming events timeline — one activity row (with "open daily log") and one volunteer row (with a signup chip and a "— Training" subtitle). Pair them by activityTypeId+date in buildUpcomingEvents so a single row carries both affordances: the chip becomes the volunteer modal trigger; the daily-log link, reschedule, and cancel buttons stay put.