### PR TITLE
Trip-card: scope student badge, fix captain actions, persist verify-p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — trip-card fixes: student badge scope, captain-page actions, verify-pending persistence
+
+Three independent bugs surfaced on the same trip card:
+
+- **Student badge in collapsed view leaked across users.** `tripCard()`
+  flagged `isStudent` from `t.student` alone, which is correct on the
+  member's own logbook (one row per user) but wrong on the captain
+  portal (`myTrips` is fleet-wide, so `t` may belong to another
+  member). Now gated by `isOwner` so the collapsed-view STUDENT badge
+  reflects "I was the student on this trip", not "a student was
+  aboard". The expanded crew list still labels each individual
+  student.
+- **Captain trip cards: "Edit trip" / "Add photos" silently no-op'd.**
+  `openModal('editTripModal')` returns silently when the element is
+  missing, and the two modals + their `data-lb-*` delegated listener
+  only existed in `/logbook/index.html`. `shared/logbook-edit.js` now
+  injects both modals (idempotent — the logbook portal still ships
+  its own copy) and registers the `data-lb-*` listener with the same
+  `document._lbListeners` guard so nothing double-fires. Captain
+  portal also now loads `shared/trip-form.js` so the injected
+  weather-fields container has a generator.
+- **"Verification pending" badge disappeared after refresh.**
+  `requestVerification_` only created the handshake row; it never set
+  `validationRequested` on the trip itself, so after reload the badge
+  depended on `_confirmations.outgoing`, which the captain portal
+  doesn't load (no `#confBadge`). Backend now mirrors the flag onto
+  the trip on request, clears it on `applyRejectionCleanup_` for
+  `verify`, and `requestVerification` / `requestValidation` invalidate
+  `getTrips` in addition to `getConfirmations`.
+
 ## Unreleased — Handbook portal (`/handbook/`)
 
 New members- and staff-facing reference page at `/handbook/`, four

--- a/captain/index.html
+++ b/captain/index.html
@@ -22,6 +22,7 @@
 <script src="../shared/maintenance.js" defer></script>
 <script src="../shared/boat-modal.js"></script>
 <script src="../shared/slot-modal.js"></script>
+<script src="../shared/trip-form.js"></script>
 <script src="../shared/tripcard.js" defer></script>
 <!-- captain.js must run before shared/logbook.js so its top-level
      `window._logbookSkipInit = true` is set before logbook.js's auto-init IIFE

--- a/shared/api.js
+++ b/shared/api.js
@@ -120,8 +120,8 @@ var _INVALIDATES = {
   // respondConfirmation can mint a new crew-trip row AND clear a notification.
   respondConfirmation:     ['getTrips', 'getNotifications', 'getConfirmations'],
   createConfirmation:      ['getConfirmations', 'getNotifications'],
-  requestVerification:     ['getConfirmations', 'getNotifications'],
-  requestValidation:       ['getConfirmations', 'getNotifications'],
+  requestVerification:     ['getConfirmations', 'getNotifications', 'getTrips'],
+  requestValidation:       ['getConfirmations', 'getNotifications', 'getTrips'],
   // Maintenance — most also change notification counts (follower pings, etc.).
   saveMaintenance:         ['getMaintenance', 'getNotifications'],
   resolveMaintenance:      ['getMaintenance', 'getNotifications'],

--- a/shared/logbook-edit.js
+++ b/shared/logbook-edit.js
@@ -3,6 +3,11 @@
 // Extracted from shared/logbook.js. All functions stay global via the existing
 // non-module script pattern. Callers (captain/index.html, logbook/index.html)
 // must include this file alongside shared/logbook.js.
+//
+// The two modals (#editTripModal, #photoUploadModal) and their delegated
+// data-lb-* click listener are auto-injected at script load if missing — so
+// host portals don't need to hand-copy the markup. The logbook portal already
+// ships its own copy in HTML; the inject is idempotent so it's a no-op there.
 // ═══════════════════════════════════════════════════════════════════════════════
 
 function openEditTrip(tripId) {
@@ -270,3 +275,137 @@ async function submitInlinePhotos() {
   }
   btn.disabled = false; btn.textContent = s('logbook.uploadPhotos');
 }
+
+// ── Modal HTML + delegated lb-* listener (auto-injected) ────────────────────
+;(function () {
+  if (typeof document === 'undefined') return;
+
+  function editModalHtml() {
+    return ''
+      + '<div class="modal-overlay hidden" id="editTripModal" data-lb-close-self="closeEditTrip">'
+      +   '<div class="modal modal--md">'
+      +     '<div class="modal-title">'
+      +       '<span id="editTripTitle" data-s="lb.editTrip"></span>'
+      +       '<button class="modal-close" data-lb-click="closeEditTrip">&#10005;</button>'
+      +     '</div>'
+      +     '<input type="hidden" id="etId">'
+      +     '<div class="form-row">'
+      +       '<div class="form-field"><label for="etDate" data-s="lbl.date"></label><input type="date" id="etDate"></div>'
+      +       '<div class="form-field"><label for="etBoat" data-s="lbl.boat"></label>'
+      +         '<select id="etBoat"><option value="" data-s="lb.selectBoat"></option></select>'
+      +       '</div>'
+      +     '</div>'
+      +     '<div class="form-field"><label for="etLocation" data-s="lbl.location"></label>'
+      +       '<select id="etLocation"><option value="" data-s="lb.selectLocation"></option></select>'
+      +     '</div>'
+      +     '<div class="form-row">'
+      +       '<div class="form-field"><label for="etTimeOut" data-s="lb.departed"></label><input type="time" id="etTimeOut"></div>'
+      +       '<div class="form-field"><label for="etTimeIn"  data-s="lb.returned"></label><input type="time" id="etTimeIn" ></div>'
+      +     '</div>'
+      +     '<div class="form-row">'
+      +       '<div class="form-field"><label for="etCrew" data-s="lb.crewAboard"></label><input type="number" id="etCrew" min="1" value="1"></div>'
+      +       '<div class="form-field"><label for="etDistanceNm" data-s="lb.distanceNm"></label><input type="number" id="etDistanceNm" min="0" step="0.1"></div>'
+      +     '</div>'
+      +     '<div class="form-row">'
+      +       '<div class="form-field"><label for="etDeparturePort" data-s="lb.departurePort"></label><input list="portsList" id="etDeparturePort" autocomplete="off"></div>'
+      +       '<div class="form-field"><label for="etArrivalPort" data-s="lb.arrivalPort"></label><input list="portsList" id="etArrivalPort" autocomplete="off"></div>'
+      +     '</div>'
+      +     '<div class="section-label" style="margin:12px 0 8px" data-s="lb.weatherHdr"></div>'
+      +     '<div id="etWxFields"></div>'
+      +     '<div class="form-field mt-8"><label for="etSkipperNote">Skipper\'s comments <span class="text-muted text-9" data-s="lb.parenVisibleToCrew"></span></label>'
+      +       '<textarea id="etSkipperNote" rows="2"></textarea>'
+      +     '</div>'
+      +     '<div id="etErr" class="text-sm text-red mb-8" style="display:none"></div>'
+      +     '<button class="btn-primary" id="etSubmitBtn" data-lb-click="submitEditTrip"><span data-s="lb.saveChanges"></span></button>'
+      +   '</div>'
+      + '</div>';
+  }
+
+  function photoModalHtml() {
+    return ''
+      + '<div class="modal-overlay hidden" id="photoUploadModal" data-lb-close-self="closePhotoUpload">'
+      +   '<div class="modal modal--md">'
+      +     '<div class="modal-title">'
+      +       '<span id="photoUploadTitle" data-s="lb.addPhotos"></span>'
+      +       '<button class="modal-close" data-lb-click="closePhotoUpload">&#10005;</button>'
+      +     '</div>'
+      +     '<input type="hidden" id="puTripId">'
+      +     '<div class="form-field">'
+      +       '<label for="puPhotoFiles" data-s="lb.photosLabel"></label>'
+      +       '<input type="file" id="puPhotoFiles" accept="image/*" multiple data-lb-change-el="handleInlinePhotos" class="text-sm">'
+      +       '<div id="puPhotoPreview" class="flex-center flex-wrap gap-6 mt-6"></div>'
+      +     '</div>'
+      +     '<div class="photo-meta-row mb-8">'
+      +       '<label><input type="checkbox" id="puShared" checked> <span id="puSharedLbl" data-s="lb.shareWithCrew"></span></label>'
+      +       '<label><input type="checkbox" id="puClubUse"> <span id="puClubLbl" data-s="lb.clubMayUse"></span></label>'
+      +     '</div>'
+      +     '<div class="text-xs text-muted mb-12" id="puHint" data-s="lb.photosBlurb"></div>'
+      +     '<div id="puErr" class="text-sm text-red mb-8" style="display:none"></div>'
+      +     '<button class="btn-primary" id="puSubmitBtn" data-lb-click="submitInlinePhotos"><span data-s="lb.uploadPhotos"></span></button>'
+      +   '</div>'
+      + '</div>';
+  }
+
+  function injectIfMissing() {
+    if (!document.getElementById('editTripModal')) {
+      var w = document.createElement('div');
+      w.innerHTML = editModalHtml();
+      document.body.appendChild(w.firstElementChild);
+    }
+    if (!document.getElementById('photoUploadModal')) {
+      var w2 = document.createElement('div');
+      w2.innerHTML = photoModalHtml();
+      document.body.appendChild(w2.firstElementChild);
+    }
+    // Populate the weather sub-fields once the container exists.
+    var etWx = document.getElementById('etWxFields');
+    if (etWx && !etWx.firstElementChild && typeof tripFormWeatherFieldsHtml === 'function') {
+      etWx.innerHTML = tripFormWeatherFieldsHtml('et', { extraStep: '0.1' });
+    }
+    if (typeof applyStrings === 'function') applyStrings();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectIfMissing, { once: true });
+  } else {
+    injectIfMissing();
+  }
+
+  // Delegated data-lb-* listener — same vocabulary as the logbook portal's
+  // local listener. Guarded so the two don't double-fire when both load.
+  if (!document._lbListeners) {
+    document._lbListeners = true;
+    document.addEventListener('click', function (e) {
+      if (e.target.closest('[data-lb-nobubble]')) { e.stopPropagation(); return; }
+      var cs = e.target.closest('[data-lb-close-self]');
+      if (cs && e.target === cs) { window[cs.dataset.lbCloseSelf](); return; }
+      var c = e.target.closest('[data-lb-click]');
+      if (c && typeof window[c.dataset.lbClick] === 'function') {
+        var a = [c.dataset.lbArg, c.dataset.lbArg2].filter(function (v) { return v != null; });
+        window[c.dataset.lbClick].apply(null, a);
+      }
+    });
+    document.addEventListener('change', function (e) {
+      var ce = e.target.closest('[data-lb-change-el]');
+      if (ce && typeof window[ce.dataset.lbChangeEl] === 'function') { window[ce.dataset.lbChangeEl](ce); return; }
+      var c = e.target.closest('[data-lb-change]');
+      if (c && typeof window[c.dataset.lbChange] === 'function') window[c.dataset.lbChange]();
+    });
+    document.addEventListener('input', function (e) {
+      var ie = e.target.closest('[data-lb-input-el]');
+      if (ie && typeof window[ie.dataset.lbInputEl] === 'function') { window[ie.dataset.lbInputEl](ie, ie.dataset.lbArg); return; }
+      var i = e.target.closest('[data-lb-input]');
+      if (i && typeof window[i.dataset.lbInput] === 'function') window[i.dataset.lbInput](i.dataset.lbArg);
+    });
+    document.addEventListener('focusout', function (e) {
+      var bh = e.target.closest('[data-lb-blur-hide]');
+      if (bh) {
+        var id = bh.dataset.lbBlurHide;
+        setTimeout(function () {
+          var el = document.getElementById(id);
+          if (el) el.style.display = 'none';
+        }, 200);
+      }
+    });
+  }
+})();

--- a/shared/tripcard.js
+++ b/shared/tripcard.js
@@ -376,7 +376,10 @@ function tripCard(t){
 
   const hasPendingBadge = !isVer && isSki && (pendingCrewConfs.length||pendingHelmConfs.length||pendingStudentConfs.length||pendingCrewIn.length||pendingHelmIn.length||pendingStudentIn.length);
   const hasVerifyPending = (t.validationRequested || _confirmations.outgoing.some(c=>c.type==='verify'&&c.status==='pending'&&c.tripId===t.id)) && !isVer;
-  const isStudent = (t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId)));
+  // Only show STUDENT badge when the *current viewer* was the student on this
+  // trip — t.student is per-row, but on a fleet-wide view (captain portal)
+  // the row may belong to another member, so guard with isOwner.
+  const isStudent = isOwner && ((t.student && t.student!=='false') || _confirmations.incoming.some(c=>c.type==='student'&&c.status==='confirmed'&&String(c.toKennitala)===String(user.kennitala)&&(c.tripId===t.id||(t.linkedCheckoutId&&c.linkedCheckoutId===t.linkedCheckoutId))));
 
   return `<div class="trip-card" style="--tc-cat:${catCol.color};--tc-cat-bg:${catCol.bg};border-left:3px solid var(--tc-cat)">
     <div class="trip-card-main" data-trip-action="open-card">

--- a/trips.gs
+++ b/trips.gs
@@ -412,7 +412,16 @@ function applyRejectionCleanup_(row, ts) {
     return;
   }
 
-  // crew_join / verify rejection: nothing to roll back.
+  if (type === 'verify') {
+    // Staff rejected a verification request — clear the trip-level flag so
+    // the "verification pending" badge stops appearing.
+    if (row.tripId) {
+      updateRow_('trips', 'id', row.tripId, { validationRequested: false, updatedAt: ts });
+    }
+    return;
+  }
+
+  // crew_join rejection: nothing to roll back.
 }
 
 // Shared helper used by crew_assigned rejection cleanup: remove a crew member
@@ -525,6 +534,11 @@ function requestVerification_(b) {
     rejectComment: '',
     createdAt: ts, respondedAt: '',
   });
+  // Mirror onto the trip row so the "verification pending" badge survives a
+  // refresh even when the confirmations list isn't loaded (e.g. captain
+  // portal). Cleared by applyRejectionCleanup_ on reject; superseded by
+  // verified=true on confirm.
+  updateRow_('trips', 'id', b.tripId, { validationRequested: true, updatedAt: ts });
   return okJ({ id: id, created: true, requested: true });
 }
 


### PR DESCRIPTION
…ending

- Student badge in the collapsed view was showing whenever any row had student=true. On the captain portal that meant "any crew on this trip was a student" (since myTrips is fleet-wide). Gate the badge on isOwner so it reflects "I was the student on this trip".
- "Edit trip" and "Add photos" did nothing on the captain page because editTripModal/photoUploadModal only existed in /logbook/index.html. Auto-inject both modals + the data-lb-* delegated listener from shared/logbook-edit.js (idempotent, guarded), and pull shared/trip-form.js into the captain page for the weather generator.
- "Verification pending" badge vanished on refresh because requestVerification_ never set validationRequested on the trip — the badge then depended on _confirmations.outgoing, which the captain portal never loads. Mirror the flag onto the trip on request, clear it on verify rejection, and invalidate getTrips alongside getConfirmations.

https://claude.ai/code/session_01XjqSkjUXJsFibkbvTFnsLC