### PR TITLE
Captain validation actions: site-standard buttons + polished action row

### DIFF
--- a/captain/captain.css
+++ b/captain/captain.css
@@ -31,9 +31,16 @@
 .cq-card .btn-reject { background:var(--red)18; color:var(--red); border-color:var(--red)55; }
 .cq-card .btn-reject:hover { background:var(--red)33; }
 /* Validation list wraps a shared tripCard with the confirm/reject row */
-.cq-validation { margin-bottom:10px; }
+.cq-validation { margin-bottom:12px; }
 .cq-validation .trip-card { margin-bottom:0; border-bottom-left-radius:0; border-bottom-right-radius:0; }
-.cq-validation-actions { padding:8px 14px; background:var(--card); border:1px solid var(--border); border-top:0; border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md); }
+.cq-validation-actions {
+  display:flex; gap:8px; justify-content:flex-end;
+  padding:10px 14px;
+  background:var(--card);
+  border:1px solid var(--border); border-top:1px solid var(--border)55;
+  border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md);
+}
+.cq-validation-actions .btn { min-width:96px; }
 
 /* ── Maintenance severity ── */
 .sev-dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:6px; }

--- a/captain/captain.js
+++ b/captain/captain.js
@@ -182,9 +182,9 @@ function renderValidation() {
     var trip = _allTrips.find(t => t.id === r.tripId) || _verifyReqAsTrip(r);
     return '<div class="cq-validation" id="vr-' + esc(r.id) + '">'
       + tripCard(trip)
-      + '<div class="conf-actions cq-validation-actions">'
-        + '<button class="btn-confirm" data-cq-click="respondValidation" data-cq-arg="' + esc(r.id) + '" data-cq-arg2="confirmed">' + s('btn.confirm') + '</button>'
-        + '<button class="btn-reject" data-cq-click="rejectValidation" data-cq-arg="' + esc(r.id) + '">' + s('cq.reject') + '</button>'
+      + '<div class="cq-validation-actions">'
+        + '<button class="btn btn-primary btn-sm" data-cq-click="respondValidation" data-cq-arg="' + esc(r.id) + '" data-cq-arg2="confirmed">✓ ' + s('btn.confirm') + '</button>'
+        + '<button class="btn btn-secondary btn-sm" data-cq-click="rejectValidation" data-cq-arg="' + esc(r.id) + '">✗ ' + s('cq.reject') + '</button>'
       + '</div>'
     + '</div>';
   }).join('');


### PR DESCRIPTION
The confirm/reject buttons rendered unstyled because their tinted .btn-confirm / .btn-reject classes are scoped to .cq-card and the validation row sits outside it. Swap to the canonical .btn .btn-primary / .btn-secondary pair (with .btn-sm and check/cross glyphs) and give .cq-validation-actions a proper flex-end layout, gap, padding, and a subtle top divider so the row visually fuses with the card above.

https://claude.ai/code/session_011fncyzSn1Uo3RF8s9RbgSP