### PR TITLE
handbook: fold info into config too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,27 +3,32 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
-## Unreleased — Handbook storage: roles/docs/contacts move to config
+## Unreleased — Handbook storage: all four sections move to config
 
-Three of the four handbook tables (`handbook_roles`, `handbook_docs`,
-`handbook_contacts`) collapse into JSON arrays under config keys
-`handbookRoles` / `handbookDocs` / `handbookContacts` — same pattern as
-`boats`, `locations`, `activity_types`, etc. Save/delete now go through
-the existing `saveConfigListItem_` / `deleteConfigListItem_` helpers.
-
-`handbook_info` keeps its own sheet: bilingual rich-text content can run
-long, and packing many sections into one cell risks the 50,000-char
-per-cell limit.
+All four handbook tables (`handbook_roles`, `handbook_docs`,
+`handbook_contacts`, `handbook_info`) collapse into JSON arrays under
+config keys `handbookRoles` / `handbookDocs` / `handbookContacts` /
+`handbookInfo` — same pattern as `boats`, `locations`, `activity_types`,
+etc. Save/delete now go through the existing `saveConfigListItem_` /
+`deleteConfigListItem_` helpers; no handbook-specific sheets remain.
 
 `getHandbook` stays a separate endpoint (storage ≠ delivery): every page
 calls `getConfig`, but only the handbook page needs handbook content.
 
+Cell-size note: Sheets caps cells at 50,000 chars. Long-form info
+content (rules, harbor briefings) could plausibly approach that if a
+club accumulates many bilingual sections. If that ever happens, split
+per-section into `handbookInfo_<id>` keys instead of one mega-blob.
+
 Migration: `getHandbook_` auto-runs a one-shot copy from the legacy
 sheets to the new config keys on first read after deploy. It's
 idempotent (skips keys that already have data) and also exposed
-manually as the `migrateHandbookSheetsToConfig` action. After it runs,
-the old `handbook_roles` / `handbook_docs` / `handbook_contacts` tabs
-sit unused and can be deleted from the spreadsheet.
+manually as the `migrateHandbookSheetsToConfig` action, which returns a
+per-target `{counts, notes}` payload so admins can see *why* a target
+was skipped (`skip:no-tab` / `skip:no-rows` / `skip:already-populated`
+/ `error:…`). After it runs, the old `handbook_roles` /
+`handbook_docs` / `handbook_contacts` / `handbook_info` tabs sit
+unused and can be deleted from the spreadsheet.
 ## Unreleased — trip-card fixes: student badge scope, captain-page actions, verify-pending persistence
 
 Three independent bugs surfaced on the same trip card:

--- a/_setup.gs
+++ b/_setup.gs
@@ -167,15 +167,9 @@ var SCHEMA_ = {
     'createdAt','updatedAt','updatedBy',
   ],
   // Handbook (members- and staff-facing reference). See handbook.gs.
-  // Roles, docs, and contacts now live as JSON arrays under config keys
-  // 'handbookRoles' / 'handbookDocs' / 'handbookContacts' (seeded below).
-  // Only `info` keeps a dedicated tab — its content cells can hold long-form
-  // rich text that risks the 50,000-char per-cell limit when packed into a
-  // JSON blob.
-  handbook_info: [
-    'id','kind','title','titleIS','content','contentIS',
-    'sortOrder','active','createdAt','updatedAt',
-  ],
+  // All four sections (roles, docs, contacts, info) now live as JSON arrays
+  // under config keys 'handbookRoles' / 'handbookDocs' / 'handbookContacts' /
+  // 'handbookInfo' (seeded below).
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -218,7 +212,7 @@ function setupSpreadsheet() {
   var cfgKeys = cfgSheet.getLastRow() >= 2
     ? cfgSheet.getRange(2, 1, cfgSheet.getLastRow()-1, 1).getValues().map(function(r){ return String(r[0]).trim(); })
     : [];
-  var defaultCfgKeys = ['activity_types','overdueAlerts','flagConfig','staffStatus','boats','locations','launchChecklists','boatCategories','certDefs','certCategories','dailyChecklist','handbookRoles','handbookDocs','handbookContacts'];
+  var defaultCfgKeys = ['activity_types','overdueAlerts','flagConfig','staffStatus','boats','locations','launchChecklists','boatCategories','certDefs','certCategories','dailyChecklist','handbookRoles','handbookDocs','handbookContacts','handbookInfo'];
   defaultCfgKeys.forEach(function(k) {
     if (!cfgKeys.includes(k)) {
       cfgSheet.appendRow([k, '']);

--- a/code.gs
+++ b/code.gs
@@ -30,11 +30,9 @@ const TABS_ = {
   scheduledEvents: 'scheduled_events',
   sessions: 'sessions',
   loginAttempts: 'login_attempts',
-  // Handbook roles/docs/contacts now live as JSON arrays under the config
-  // keys 'handbookRoles' / 'handbookDocs' / 'handbookContacts'. Only `info`
-  // keeps a dedicated tab — its content cells can hold long-form rich text
-  // that risks the 50,000-char per-cell limit when packed into a JSON blob.
-  handbookInfo:     'handbook_info',
+  // All four handbook sections (roles/docs/contacts/info) now live as JSON
+  // arrays under the config keys 'handbookRoles' / 'handbookDocs' /
+  // 'handbookContacts' / 'handbookInfo'. No dedicated handbook tabs anymore.
 };
 
 const CLUB_LANG_ = 'IS';

--- a/handbook.gs
+++ b/handbook.gs
@@ -4,14 +4,16 @@
 //   - roles    → JSON array under config key 'handbookRoles'
 //   - docs     → JSON array under config key 'handbookDocs'
 //   - contacts → JSON array under config key 'handbookContacts'
-//   - info     → its own sheet ('handbook_info'), because bilingual rich-text
-//                content can blow the 50,000-char per-cell limit when packed
-//                into one JSON blob.
+//   - info     → JSON array under config key 'handbookInfo'
 //
-// The first three pieces are tiny taxonomies that fit naturally alongside
-// boats/locations/activity_types in the config sheet. getHandbook_ stays a
-// dedicated endpoint (separate from getConfig) so non-handbook pages don't
-// pay the bytes.
+// All four live alongside boats/locations/activity_types in the config sheet.
+// getHandbook_ stays a dedicated endpoint (separate from getConfig) so
+// non-handbook pages don't pay the bytes.
+//
+// Cell-size note: Sheets caps cells at 50,000 chars. Long-form info content
+// (rules, harbor briefings) could plausibly approach that if a club
+// accumulates many bilingual sections. If you hit it, split per-section into
+// `handbookInfo_<id>` keys instead of one mega-blob.
 
 function getHandbook_() {
   // One-shot migration from the legacy per-handbook tabs. Runs at most once
@@ -21,13 +23,13 @@ function getHandbook_() {
   try { migration = _hbAutoMigrateSheetsToConfig_(); }
   catch (e) {
     Logger.log('handbook auto-migrate: ' + e);
-    migration = { counts: { roles: 0, docs: 0, contacts: 0 }, notes: { error: String(e) } };
+    migration = { counts: { roles: 0, docs: 0, contacts: 0, info: 0 }, notes: { error: String(e) } };
   }
 
   const rolesRaw    = readConfigList_('handbookRoles').filter(_hbActive_);
   const contactsRaw = readConfigList_('handbookContacts').filter(_hbActive_);
   const docs        = readConfigList_('handbookDocs').filter(_hbActive_);
-  const info        = (data_.readAll('handbookInfo') || []).filter(_hbActive_);
+  const info        = readConfigList_('handbookInfo').filter(_hbActive_);
 
   const memberByKt = getMemberMap_();
   const needsCatMap = rolesRaw.some(function (r) { return r.boatCategoryKey && !r.color; });
@@ -474,21 +476,15 @@ function uploadHandbookDoc_(b) {
 }
 
 // ── Info (free-form bilingual text sections) ─────────────────────────────────
-// Stays on its own sheet because the bilingual `content`/`contentIS` columns
-// can hold long-form rich text; packing many of them into one config cell
-// risks the 50,000-char per-cell limit.
 
 function saveHandbookInfo_(b) {
   if (!b.title && !b.titleIS) return failJ('title required');
-  addColIfMissing_('handbookInfo', 'kind');
   // 'info' is the legacy fallback bucket so old rows without an explicit
   // kind still round-trip through the editor; admin UI only writes
   // 'contacts' or 'rules'.
   const allowedKinds = { contacts: 1, rules: 1, info: 1 };
-  const id = b.id || ('info_' + uid_());
-  const existing = findOne_('handbookInfo', 'id', id);
-  const row = {
-    id:        id,
+  const res = saveConfigListItem_('handbookInfo', {
+    id:        b.id || '',
     kind:      allowedKinds[b.kind] ? b.kind : 'info',
     title:     b.title || '',
     titleIS:   b.titleIS || '',
@@ -496,19 +492,14 @@ function saveHandbookInfo_(b) {
     contentIS: b.contentIS || '',
     sortOrder: Number(b.sortOrder || 0),
     active:    b.active === false ? false : true,
-    createdAt: existing ? (existing.createdAt || now_()) : now_(),
-    updatedAt: now_(),
-  };
-  if (existing) updateRow_('handbookInfo', 'id', id, row);
-  else          insertRow_('handbookInfo', row);
-  return okJ({ id: id, saved: true });
+  });
+  return okJ({ id: res.id, saved: true });
 }
 
 function deleteHandbookInfo_(b) {
   if (!b.id) return failJ('id required');
-  const existing = findOne_('handbookInfo', 'id', b.id);
-  if (!existing) return failJ('Info section not found', 404);
-  updateRow_('handbookInfo', 'id', b.id, { active: false, updatedAt: now_() });
+  const res = deleteConfigListItem_('handbookInfo', b.id, { soft: true });
+  if (!res.deactivated) return failJ('Info section not found', 404);
   return okJ({ ok: true });
 }
 
@@ -524,10 +515,11 @@ function _hbAutoMigrateSheetsToConfig_() {
     { tab: 'handbook_roles',    key: 'handbookRoles',    type: 'roles'    },
     { tab: 'handbook_docs',     key: 'handbookDocs',     type: 'docs'     },
     { tab: 'handbook_contacts', key: 'handbookContacts', type: 'contacts' },
+    { tab: 'handbook_info',     key: 'handbookInfo',     type: 'info'     },
   ];
   var ss = null;
-  var migrated = { roles: 0, docs: 0, contacts: 0 };
-  var notes    = { roles: '', docs: '', contacts: '' };
+  var migrated = { roles: 0, docs: 0, contacts: 0, info: 0 };
+  var notes    = { roles: '', docs: '', contacts: '', info: '' };
   targets.forEach(function (t) {
     try {
       // Already migrated? Skip.
@@ -578,7 +570,7 @@ function _hbAutoMigrateSheetsToConfig_() {
       notes[t.type] = 'error:' + (err && err.message ? err.message : String(err));
     }
   });
-  if (migrated.roles || migrated.docs || migrated.contacts) {
+  if (migrated.roles || migrated.docs || migrated.contacts || migrated.info) {
     cDel_('config');
   }
   Logger.log('handbook auto-migrate: counts=' + JSON.stringify(migrated) + ' notes=' + JSON.stringify(notes));


### PR DESCRIPTION
Collapses the last handbook table (handbook_info) into the same JSON-in-config-row pattern as roles/docs/contacts. saveHandbookInfo_ / deleteHandbookInfo_ now go through saveConfigListItem_ / deleteConfigListItem_; getHandbook_ reads via readConfigList_; the auto migration gains info as a fourth target.

Cell-size caveat documented in the file header and CHANGELOG: if a club ever accumulates enough bilingual rich-text sections to crowd the 50,000-char per-cell limit, the fallback is splitting per-section into handbookInfo_<id> keys.

https://claude.ai/code/session_01EjDZbRsVX1jS4pwAzGmy3C