### PR TITLE
Validation/verify action rows: tint with --faint to match trip-card

### DIFF
--- a/captain/captain.css
+++ b/captain/captain.css
@@ -31,13 +31,13 @@
 .cq-card .btn-reject { background:var(--red)18; color:var(--red); border-color:var(--red)55; }
 .cq-card .btn-reject:hover { background:var(--red)33; }
 /* Validation list wraps a shared tripCard with the confirm/reject row */
-.cq-validation { margin-bottom:12px; }
+.cq-validation { margin-bottom:14px; }
 .cq-validation .trip-card { margin-bottom:0; border-bottom-left-radius:0; border-bottom-right-radius:0; }
 .cq-validation-actions {
-  display:flex; gap:8px; justify-content:flex-end;
+  display:flex; gap:8px; justify-content:flex-end; align-items:center;
   padding:10px 14px;
-  background:var(--card);
-  border:1px solid var(--border); border-top:1px solid var(--border)55;
+  background:var(--faint);
+  border:1px solid var(--border); border-top:0;
   border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md);
 }
 .cq-validation-actions .btn { min-width:96px; }

--- a/staff/staff_logbook-review.css
+++ b/staff/staff_logbook-review.css
@@ -4,7 +4,7 @@
     .slr-trip { margin-bottom:10px; }
     .slr-trip .trip-card { margin-bottom:0; border-bottom-left-radius:0; border-bottom-right-radius:0; }
     .slr-trip.is-verified .trip-card { border-left-color:var(--green); }
-    .slr-verify-row { display:flex; flex-direction:column; gap:4px; padding:10px 14px; background:var(--card); border:1px solid var(--border); border-top:0; border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md); }
+    .slr-verify-row { display:flex; flex-direction:column; gap:4px; padding:10px 14px; background:var(--faint); border:1px solid var(--border); border-top:0; border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md); }
     .slr-reviewer { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
     .slr-reviewer input[type="text"] { min-width:160px; }
     .slr-verified-by { padding-left:2px; }


### PR DESCRIPTION
--card resolves to pure white in light mode and to a tint that's *lighter* than the trip-card surface in dark mode, so the action row reads as a stark/jarring block tacked onto the bottom of the card.

Switch to --faint, which is what tripCard's own .exp-notes section uses, so the row reads as a natural continuation of the card. Drop the double top divider (the trip-card's own border already provides the seam) and add align-items:center to the captain row for tidier vertical alignment.

https://claude.ai/code/session_011fncyzSn1Uo3RF8s9RbgSP