### PR TITLE
Validation/verify wrappers: become the card, eliminate the seam

### DIFF
--- a/captain/captain.css
+++ b/captain/captain.css
@@ -30,16 +30,28 @@
 .cq-card .btn-confirm:hover { background:var(--green)33; }
 .cq-card .btn-reject { background:var(--red)18; color:var(--red); border-color:var(--red)55; }
 .cq-card .btn-reject:hover { background:var(--red)33; }
-/* Validation list wraps a shared tripCard with the confirm/reject row */
-.cq-validation { margin-bottom:14px; }
-.cq-validation .trip-card { margin-bottom:0; border-bottom-left-radius:0; border-bottom-right-radius:0; }
+/* Validation list — the wrapper IS the card. The trip-card inside renders
+   without its own outer border/shadow/radius; the wrapper provides those so
+   trip-card body + footer share one continuous surface (no seam). */
+.cq-validation {
+  margin-bottom:14px;
+  border:1px solid var(--border);
+  border-radius:var(--radius-md);
+  overflow:hidden;
+  box-shadow:var(--shadow-sm);
+}
+.cq-validation .trip-card {
+  margin-bottom:0;
+  border:0;
+  border-radius:0;
+  box-shadow:none;
+}
 .cq-validation-actions {
   display:flex; gap:8px; justify-content:flex-end; align-items:center;
   padding:10px 14px;
   /* Mirror .trip-card's body so the footer reads as the same surface */
   background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface));
-  border:1px solid var(--border); border-top:0;
-  border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md);
+  border-top:1px solid var(--border);
 }
 .cq-validation-actions .btn { min-width:96px; }
 

--- a/staff/staff_logbook-review.css
+++ b/staff/staff_logbook-review.css
@@ -1,10 +1,21 @@
 .filter-bar { display:flex; gap:8px; margin-bottom:16px; flex-wrap:wrap; align-items:center; }
     .filter-bar input, .filter-bar select { flex:1; min-width:140px; }
     /* Wrap the shared tripCard with the staff verify row so the two visually fuse. */
-    .slr-trip { margin-bottom:10px; }
-    .slr-trip .trip-card { margin-bottom:0; border-bottom-left-radius:0; border-bottom-right-radius:0; }
-    .slr-trip.is-verified .trip-card { border-left-color:var(--green); }
-    .slr-verify-row { display:flex; flex-direction:column; gap:4px; padding:10px 14px; background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface)); border:1px solid var(--border); border-top:0; border-bottom-left-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md); }
+    .slr-trip {
+      margin-bottom:12px;
+      border:1px solid var(--border);
+      border-radius:var(--radius-md);
+      overflow:hidden;
+      box-shadow:var(--shadow-sm);
+    }
+    .slr-trip .trip-card {
+      margin-bottom:0;
+      border:0;
+      border-radius:0;
+      box-shadow:none;
+    }
+    .slr-trip.is-verified { border-left:3px solid var(--green); }
+    .slr-verify-row { display:flex; flex-direction:column; gap:4px; padding:10px 14px; background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface)); border-top:1px solid var(--border); }
     .slr-reviewer { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
     .slr-reviewer input[type="text"] { min-width:160px; }
     .slr-verified-by { padding-left:2px; }


### PR DESCRIPTION
The previous version stacked two bordered/rounded boxes — trip-card + action footer — connected by a thin border line at the seam. Even with matching --tc-cat tints the seam still read as a divider.

Promote the wrapper to the actual card: border, rounded corners, overflow:hidden, box-shadow on .cq-validation / .slr-trip. Strip those from the inner trip-card so it renders as a flush content panel inside the wrapper. Footer keeps just a single top border for the section divider, sharing the wrapper's surface tint via --tc-cat.

Trip-card's inline border-left:3px (boat-category accent) survives the border:0 reset because inline styles win on the left-side properties, so the boat-color stripe still reads inside the wrapper.

https://claude.ai/code/session_011fncyzSn1Uo3RF8s9RbgSP