### PR TITLE
Validation/verify: stripe on wrapper, fix crew respond API field

### DIFF
--- a/captain/captain.css
+++ b/captain/captain.css
@@ -36,13 +36,16 @@
 .cq-validation {
   margin-bottom:14px;
   border:1px solid var(--border);
+  border-left:3px solid var(--tc-cat, var(--border));
   border-radius:var(--radius-md);
   overflow:hidden;
   box-shadow:var(--shadow-sm);
 }
+/* The inner trip-card sets border-left inline (style attribute) so we need
+   !important to suppress it — the wrapper draws the colored stripe instead. */
 .cq-validation .trip-card {
   margin-bottom:0;
-  border:0;
+  border:0 !important;
   border-radius:0;
   box-shadow:none;
 }

--- a/captain/captain.js
+++ b/captain/captain.js
@@ -263,13 +263,13 @@ function renderCrew() {
   }).join('');
 }
 
-async function respondCrew(id, status) {
+async function respondCrew(id, response) {
   // Optimistic UI — update card immediately
   var prev = _crewConfirmations.slice();
-  _crewConfirmations = _crewConfirmations.map(c => c.id === id ? Object.assign({}, c, { status }) : c);
+  _crewConfirmations = _crewConfirmations.map(c => c.id === id ? Object.assign({}, c, { status: response }) : c);
   renderCrew();
   try {
-    await apiPost('respondConfirmation', { id, status, responderName: user.name });
+    await apiPost('respondConfirmation', { id, response, responderName: user.name });
     showToast(s('toast.saved'), 'ok');
   } catch (e) {
     _crewConfirmations = prev;

--- a/staff/staff_logbook-review.css
+++ b/staff/staff_logbook-review.css
@@ -4,13 +4,16 @@
     .slr-trip {
       margin-bottom:12px;
       border:1px solid var(--border);
+      border-left:3px solid var(--tc-cat, var(--border));
       border-radius:var(--radius-md);
       overflow:hidden;
       box-shadow:var(--shadow-sm);
     }
+    /* The inner trip-card sets border-left inline (style attribute) so we need
+       !important to suppress it — the wrapper draws the colored stripe instead. */
     .slr-trip .trip-card {
       margin-bottom:0;
-      border:0;
+      border:0 !important;
       border-radius:0;
       box-shadow:none;
     }


### PR DESCRIPTION
The seam wasn't going away because tripCard() sets border-left inline on .trip-card — that style-attribute rule beats CSS without !important. Move the boat-category stripe to the outer wrapper (.cq-validation / .slr-trip), and force the inner trip-card border off with !important so the wrapper reads as a single contiguous card.

Separately, captain.js respondCrew() was sending {status} to respondConfirmation, but the backend (trips.gs:154) only accepts {response}. Every confirm/reject on a crew card was failing with "response must be confirmed or rejected" — that's the API error.