### PR TITLE
Verify cards: shared verifyCard() helper + inline comment on captain

### DIFF
--- a/captain/captain.css
+++ b/captain/captain.css
@@ -30,33 +30,8 @@
 .cq-card .btn-confirm:hover { background:var(--green)33; }
 .cq-card .btn-reject { background:var(--red)18; color:var(--red); border-color:var(--red)55; }
 .cq-card .btn-reject:hover { background:var(--red)33; }
-/* Validation list — the wrapper IS the card. The trip-card inside renders
-   without its own outer border/shadow/radius; the wrapper provides those so
-   trip-card body + footer share one continuous surface (no seam). */
-.cq-validation {
-  margin-bottom:14px;
-  border:1px solid var(--border);
-  border-left:3px solid var(--tc-cat, var(--border));
-  border-radius:var(--radius-md);
-  overflow:hidden;
-  box-shadow:var(--shadow-sm);
-}
-/* The inner trip-card sets border-left inline (style attribute) so we need
-   !important to suppress it — the wrapper draws the colored stripe instead. */
-.cq-validation .trip-card {
-  margin-bottom:0;
-  border:0 !important;
-  border-radius:0;
-  box-shadow:none;
-}
-.cq-validation-actions {
-  display:flex; gap:8px; justify-content:flex-end; align-items:center;
-  padding:10px 14px;
-  /* Mirror .trip-card's body so the footer reads as the same surface */
-  background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface));
-  border-top:1px solid var(--border);
-}
-.cq-validation-actions .btn { min-width:96px; }
+/* Validation list now uses the shared .verify-wrap / .verify-actions
+   classes from shared/tripcard.css — staff review uses the same. */
 
 /* ── Maintenance severity ── */
 .sev-dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:6px; }

--- a/captain/captain.js
+++ b/captain/captain.js
@@ -180,17 +180,17 @@ function renderValidation() {
     // Reuse the canonical trip card. Fall back to the request payload when
     // the trip can't be found locally (e.g. outside the limit window).
     var trip = _allTrips.find(t => t.id === r.tripId) || _verifyReqAsTrip(r);
-    // Match the trip-card's boat-category tint on the wrapper so the action
-    // row reads as the same surface (no seam between card and footer).
-    var cat = (allBoats.find(b => b.id === trip.boatId)?.category) || trip.boatCategory || '';
-    var catCol = boatCatColors(cat);
-    return '<div class="cq-validation" id="vr-' + esc(r.id) + '" style="--tc-cat:' + catCol.color + '">'
-      + tripCard(trip)
-      + '<div class="cq-validation-actions">'
-        + '<button class="btn btn-primary btn-sm" data-cq-click="respondValidation" data-cq-arg="' + esc(r.id) + '" data-cq-arg2="confirmed">✓ ' + s('btn.confirm') + '</button>'
-        + '<button class="btn btn-secondary btn-sm" data-cq-click="rejectValidation" data-cq-arg="' + esc(r.id) + '">✗ ' + s('cq.reject') + '</button>'
-      + '</div>'
-    + '</div>';
+    return verifyCard({
+      trip: trip,
+      prefix: 'cq',
+      wrapperId: 'vr-' + r.id,
+      commentId: 'vrcomment-' + r.id,
+      commentPlaceholder: s('cq.rejectReason'),
+      buttons: [
+        { kind:'primary',   label:'✓ ' + s('btn.confirm'), action:'respondValidation', args:[r.id, 'confirmed'] },
+        { kind:'secondary', label:'✗ ' + s('cq.reject'),   action:'rejectValidation', args:[r.id] },
+      ],
+    });
   }).join('');
 }
 
@@ -225,13 +225,13 @@ async function respondValidation(id, response) {
 }
 
 async function rejectValidation(id) {
-  var rejectComment = await ymPrompt(s('cq.rejectReason'));
-  if (rejectComment === null) return;  // cancelled
+  var commentEl = document.getElementById('vrcomment-' + id);
+  var rejectComment = (commentEl && commentEl.value || '').trim();
   var prev = _verificationRequests.slice();
   _verificationRequests = _verificationRequests.filter(r => r.id !== id);
   renderValidation();
   try {
-    await apiPost('respondConfirmation', { id, response: 'rejected', rejectComment: rejectComment || '', responderName: user.name });
+    await apiPost('respondConfirmation', { id, response: 'rejected', rejectComment, responderName: user.name });
     showToast(s('toast.saved'), 'ok');
   } catch (e) {
     _verificationRequests = prev;

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -96,3 +96,14 @@
   .photo-thumb{width:48px;height:48px}
   .photo-thumb-link{width:48px;height:48px}
 }
+
+/* ── Verify wrapper (shared by staff review + captain validation) ── */
+/* Wrapper IS the card: border + radius + shadow live here so the inner
+   .trip-card body and the action row read as one continuous surface. The
+   inner trip-card sets border-left inline; !important overrides it so the
+   wrapper alone draws the boat-category stripe. */
+.verify-wrap{margin-bottom:12px;border:1px solid var(--border);border-left:3px solid var(--tc-cat,var(--border));border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-sm)}
+.verify-wrap.is-verified{border-left:3px solid var(--green)}
+.verify-wrap .trip-card{margin-bottom:0;border:0 !important;border-radius:0;box-shadow:none}
+.verify-actions{display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:10px 14px;background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface));border-top:1px solid var(--border)}
+.verify-actions input[type="text"]{min-width:160px}

--- a/shared/tripcard.js
+++ b/shared/tripcard.js
@@ -455,3 +455,39 @@ function bftGroup(b){
   if(n<=6) return 'moderate';
   return 'strong';
 }
+
+// ── Verify / validation card ─────────────────────────────────────────────────
+// Wraps tripCard() with a comment input + 1-N action buttons. Both the staff
+// review page and the captain validation page render with this; the
+// per-portal data-*-click prefix and button set are passed in.
+//
+// opts: {
+//   trip,                   // trip-shaped object passed to tripCard()
+//   prefix,                 // 'slr' | 'cq' (drives data-{prefix}-click etc.)
+//   wrapperId,              // id on the outer wrapper
+//   isVerified,             // adds .is-verified for green stripe
+//   commentId,              // id on the <input>
+//   commentValue,           // initial input value
+//   commentPlaceholder,     // <input placeholder>
+//   buttons: [{ kind:'primary'|'secondary'|'danger', label, action, args:[a1,a2?] }],
+//   footer,                 // optional html appended after the action row
+// }
+function verifyCard(opts) {
+  const t = opts.trip;
+  const cat = (allBoats.find(b => b.id === t.boatId)?.category) || t.boatCategory || '';
+  const catCol = boatCatColors(cat);
+  const verCls = opts.isVerified ? ' is-verified' : '';
+  const btnsHtml = (opts.buttons || []).map(b => {
+    const a1 = b.args && b.args[0] != null ? ` data-${opts.prefix}-arg="${esc(b.args[0])}"` : '';
+    const a2 = b.args && b.args[1] != null ? ` data-${opts.prefix}-arg2="${esc(b.args[1])}"` : '';
+    return `<button class="btn btn-${b.kind} btn-sm" data-${opts.prefix}-click="${esc(b.action)}"${a1}${a2}>${b.label}</button>`;
+  }).join('');
+  const inputHtml = opts.commentId
+    ? `<input type="text" id="${esc(opts.commentId)}" placeholder="${esc(opts.commentPlaceholder || '')}" value="${esc(opts.commentValue || '')}" class="text-md flex-1">`
+    : '';
+  return `<div class="verify-wrap${verCls}" id="${esc(opts.wrapperId)}" style="--tc-cat:${catCol.color}">
+    ${tripCard(t)}
+    <div class="verify-actions">${inputHtml}${btnsHtml}</div>
+    ${opts.footer || ''}
+  </div>`;
+}

--- a/staff/staff_logbook-review.css
+++ b/staff/staff_logbook-review.css
@@ -1,27 +1,8 @@
 .filter-bar { display:flex; gap:8px; margin-bottom:16px; flex-wrap:wrap; align-items:center; }
     .filter-bar input, .filter-bar select { flex:1; min-width:140px; }
-    /* Wrap the shared tripCard with the staff verify row so the two visually fuse. */
-    .slr-trip {
-      margin-bottom:12px;
-      border:1px solid var(--border);
-      border-left:3px solid var(--tc-cat, var(--border));
-      border-radius:var(--radius-md);
-      overflow:hidden;
-      box-shadow:var(--shadow-sm);
-    }
-    /* The inner trip-card sets border-left inline (style attribute) so we need
-       !important to suppress it — the wrapper draws the colored stripe instead. */
-    .slr-trip .trip-card {
-      margin-bottom:0;
-      border:0 !important;
-      border-radius:0;
-      box-shadow:none;
-    }
-    .slr-trip.is-verified { border-left:3px solid var(--green); }
-    .slr-verify-row { display:flex; flex-direction:column; gap:4px; padding:10px 14px; background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface)); border-top:1px solid var(--border); }
-    .slr-reviewer { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
-    .slr-reviewer input[type="text"] { min-width:160px; }
-    .slr-verified-by { padding-left:2px; }
+    /* Verify wrapper / action row live in shared/tripcard.css
+       (.verify-wrap / .verify-actions) — captain page uses the same. */
+    .slr-verified-by { padding:0 14px 8px; }
     .stat-strip { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:20px; }
     .stat-cell { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 10px; text-align:center; box-shadow:var(--shadow-sm); }
     .stat-n { font-size:22px; color:var(--accent-fg); font-weight:500; }

--- a/staff/staff_logbook-review.js
+++ b/staff/staff_logbook-review.js
@@ -192,25 +192,21 @@ function renderTrips() {
     const tripView = verifyTripIds.has(t.id) && !isVer
       ? Object.assign({}, t, { validationRequested: true })
       : t;
-    // Mirror trip-card boat-category tint on the wrapper so the verify row
-    // reads as the same surface (matches tripCard's --tc-cat formula).
-    const cat = (allBoats.find(b => b.id === t.boatId)?.category) || t.boatCategory || '';
-    const catCol = boatCatColors(cat);
-    return `<div class="slr-trip${isVer ? ' is-verified' : ''}" style="--tc-cat:${catCol.color}">
-      ${tripCard(tripView)}
-      <div class="slr-verify-row" id="vrow-${esc(t.id)}">
-        <div class="slr-reviewer">
-          <input type="text" id="comment-${esc(t.id)}" placeholder="${s('logrev.staffComment')}"
-                 value="${esc(t.staffComment || '')}" class="text-md flex-1">
-          ${isVer
-            ? `<button class="btn btn-secondary btn-sm" data-slr-click="unverifyTrip" data-slr-arg="${esc(t.id)}">✗ ${s('logrev.unverify')}</button>`
-            : `<button class="btn btn-primary btn-sm" data-slr-click="verifyTrip" data-slr-arg="${esc(t.id)}">✓ ${s('logrev.verify')}</button>`}
-        </div>
-        ${t.staffComment && isVer && t.verifiedBy
-          ? `<div class="slr-verified-by text-xs text-muted">— ${esc(t.verifiedBy)}</div>`
-          : ''}
-      </div>
-    </div>`;
+    return verifyCard({
+      trip: tripView,
+      prefix: 'slr',
+      wrapperId: 'vrow-' + t.id,
+      isVerified: isVer,
+      commentId: 'comment-' + t.id,
+      commentValue: t.staffComment || '',
+      commentPlaceholder: s('logrev.staffComment'),
+      buttons: [isVer
+        ? { kind:'secondary', label:'✗ ' + s('logrev.unverify'), action:'unverifyTrip', args:[t.id] }
+        : { kind:'primary',   label:'✓ ' + s('logrev.verify'),   action:'verifyTrip',   args:[t.id] }],
+      footer: (t.staffComment && isVer && t.verifiedBy)
+        ? `<div class="slr-verified-by text-xs text-muted">— ${esc(t.verifiedBy)}</div>`
+        : '',
+    });
   }).join('');
 }
 


### PR DESCRIPTION
Both the staff review page and the captain validation page were rendering the same structure (wrapper-as-card + tripCard + action row). Factor the shape into a single verifyCard() helper in shared/tripcard.js and move .verify-wrap / .verify-actions to shared/tripcard.css. Each portal now declares only its button set and prefix.

Captain validation cards gain the inline comment input the staff page already had: the rejection reason now lives in the row instead of an ymPrompt modal, matching the staff verify aesthetic.