### PR TITLE
Captain validation: surface VERIFICATION PENDING badge on cards

### DIFF
--- a/captain/captain.js
+++ b/captain/captain.js
@@ -179,7 +179,12 @@ function renderValidation() {
   el.innerHTML = _verificationRequests.map(r => {
     // Reuse the canonical trip card. Fall back to the request payload when
     // the trip can't be found locally (e.g. outside the limit window).
-    var trip = _allTrips.find(t => t.id === r.tripId) || _verifyReqAsTrip(r);
+    var rawTrip = _allTrips.find(t => t.id === r.tripId) || _verifyReqAsTrip(r);
+    // Surface the ⏳ VERIFICATION PENDING badge — these cards exist because of
+    // a pending verify handshake, but the local trip row may not have the flag
+    // set yet. Match the staff review page's approach.
+    var isVer = rawTrip.verified && rawTrip.verified !== 'false';
+    var trip = isVer ? rawTrip : Object.assign({}, rawTrip, { validationRequested: true });
     return verifyCard({
       trip: trip,
       prefix: 'cq',


### PR DESCRIPTION
These cards represent pending verify-handshake requests by definition, but the underlying trip row (from _allTrips) may not have the flag set. Set validationRequested:true on the trip view passed to verifyCard so tripCard() lights up the ⏳ badge — same approach the staff review page already uses.