### PR TITLE
getConfig/getHandbook: dedup sheet reads, drop migration

### DIFF
--- a/config.gs
+++ b/config.gs
@@ -63,25 +63,27 @@ function getConfig_() {
     const rpRaw = getConfigValue_('rowingPassport', cfgMap);
     if (rpRaw) rowingPassport = JSON.parse(rpRaw);
   } catch (e) {}
+  // Single pass over scheduled_events: derive volunteerEvents (DTO shape) +
+  // cancelled-activity tombstones from one sheet read. The tombstones let the
+  // admin Scheduling timeline and client-side projector suppress matching
+  // virtuals (`sched-{classId}-{date}`) without re-touching the sheet.
   var volunteerEvents = [];
-  try { volunteerEvents = listVolunteerEventDtos_(); } catch (e) { volunteerEvents = []; }
+  var cancelledActivityOccurrences = [];
+  try {
+    (readAll_('scheduledEvents') || []).forEach(function (r) {
+      if (!r) return;
+      if (r.kind === 'volunteer' && r.status !== 'cancelled') {
+        var dto = _schedToVolDto_(sched_parseRow_(r));
+        if (dto) volunteerEvents.push(dto);
+      } else if (r.kind === 'activity' && r.status === 'cancelled' && r.id) {
+        cancelledActivityOccurrences.push(String(r.id));
+      }
+    });
+  } catch (e) {}
   var clubCalendars = [];
   try {
     var ccRaw = getConfigValue_('clubCalendars', cfgMap);
     if (ccRaw) clubCalendars = JSON.parse(ccRaw);
-  } catch (e) {}
-  // Cancelled activity-class occurrences (tombstone rows in scheduled_events
-  // with kind='activity' status='cancelled'). The admin Scheduling timeline
-  // and any client-side projector use this to suppress matching virtuals
-  // (`sched-{classId}-{date}`) without the projection itself touching the
-  // sheet on every render.
-  var cancelledActivityOccurrences = [];
-  try {
-    (readAll_('scheduledEvents') || []).forEach(function (r) {
-      if (r && r.kind === 'activity' && r.status === 'cancelled' && r.id) {
-        cancelledActivityOccurrences.push(String(r.id));
-      }
-    });
   } catch (e) {}
   var config = { activityTypes, dailyChecklist, overdueAlerts, flagConfig, flagOverride, certDefs, certCategories, boats, locations, launchChecklists, boatCategories, staffStatus, allowBreaks, charterCalendars, rowingPassport, volunteerEvents, clubCalendars, cancelledActivityOccurrences };
   cPut_('config', config);

--- a/handbook.gs
+++ b/handbook.gs
@@ -16,16 +16,6 @@
 // `handbookInfo_<id>` keys instead of one mega-blob.
 
 function getHandbook_() {
-  // One-shot migration from the legacy per-handbook tabs. Runs at most once
-  // per config key — only triggers when the config key is empty AND the old
-  // sheet still has data. Idempotent on re-entry.
-  var migration = null;
-  try { migration = _hbAutoMigrateSheetsToConfig_(); }
-  catch (e) {
-    Logger.log('handbook auto-migrate: ' + e);
-    migration = { counts: { roles: 0, docs: 0, contacts: 0, info: 0 }, notes: { error: String(e) } };
-  }
-
   const rolesRaw    = readConfigList_('handbookRoles').filter(_hbActive_);
   const contactsRaw = readConfigList_('handbookContacts').filter(_hbActive_);
   const docs        = readConfigList_('handbookDocs').filter(_hbActive_);
@@ -60,12 +50,6 @@ function getHandbook_() {
     contacts: contacts.sort(_hbByOrder_),
     docs:     docs.sort(_hbByOrder_),
     info:     info.sort(_hbByOrder_),
-    // Surface auto-migration breadcrumbs in the response so admins can see
-    // *why* a target was skipped without digging into the Apps Script log.
-    // Stays in the response (it's tiny — a 3-key counts object plus a 3-key
-    // notes object) and naturally settles to "skip:already-populated" once
-    // migration has run.
-    _migration: migration,
   });
 }
 
@@ -365,81 +349,3 @@ function deleteHandbookInfo_(b) {
   return okJ({ ok: true });
 }
 
-// ── One-shot migration: legacy per-handbook tabs → config keys ───────────────
-// Reads the old `handbook_roles`, `handbook_docs`, `handbook_contacts` tabs
-// (if they still exist) and copies their rows into the corresponding config
-// keys. Idempotent: skips any key that's already populated.
-//
-// Called automatically from getHandbook_ on first read, but also exposed as
-// `migrateHandbookSheetsToConfig` for manual invocation from the admin UI.
-function _hbAutoMigrateSheetsToConfig_() {
-  const targets = [
-    { tab: 'handbook_roles',    key: 'handbookRoles',    type: 'roles'    },
-    { tab: 'handbook_docs',     key: 'handbookDocs',     type: 'docs'     },
-    { tab: 'handbook_contacts', key: 'handbookContacts', type: 'contacts' },
-    { tab: 'handbook_info',     key: 'handbookInfo',     type: 'info'     },
-  ];
-  var ss = null;
-  var migrated = { roles: 0, docs: 0, contacts: 0, info: 0 };
-  var notes    = { roles: '', docs: '', contacts: '', info: '' };
-  targets.forEach(function (t) {
-    try {
-      // Already migrated? Skip.
-      if (readConfigList_(t.key).length) {
-        notes[t.type] = 'skip:already-populated';
-        return;
-      }
-      if (!ss) ss = ss_();
-      const sheet = ss.getSheetByName(t.tab);
-      if (!sheet) {
-        notes[t.type] = 'skip:no-tab';
-        return;
-      }
-      if (sheet.getLastRow() < 2) {
-        notes[t.type] = 'skip:no-rows';
-        return;
-      }
-      const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0].map(String);
-      const data    = sheet.getRange(2, 1, sheet.getLastRow() - 1, sheet.getLastColumn()).getValues();
-      const items = data.map(function (r) {
-        var obj = {};
-        headers.forEach(function (h, i) {
-          var v = r[i];
-          if (h === 'active')         obj.active    = bool_(v);
-          else if (h === 'sortOrder') obj.sortOrder = Number(v || 0);
-          else                        obj[h]        = v == null ? '' : String(v);
-        });
-        // Roles store members/areas as JSON-stringified cells in the legacy
-        // schema; lift them up into native arrays for the new shape.
-        if (t.type === 'roles') {
-          obj.members = _hbCoerceArray_(obj.members);
-          obj.areas   = _hbCoerceArray_(obj.areas);
-        }
-        return obj;
-      }).filter(function (obj) { return obj.id; });
-      if (items.length) {
-        setConfigSheetValue_(t.key, JSON.stringify(items));
-        // Force a flush before the next target reads the config sheet.
-        // Apps Script otherwise batches writes, so the next iteration's
-        // readConfigList_ check could see stale state.
-        SpreadsheetApp.flush();
-        migrated[t.type] = items.length;
-        notes[t.type]    = 'migrated';
-      } else {
-        notes[t.type] = 'skip:no-id-rows';
-      }
-    } catch (err) {
-      notes[t.type] = 'error:' + (err && err.message ? err.message : String(err));
-    }
-  });
-  if (migrated.roles || migrated.docs || migrated.contacts || migrated.info) {
-    cDel_('config');
-  }
-  Logger.log('handbook auto-migrate: counts=' + JSON.stringify(migrated) + ' notes=' + JSON.stringify(notes));
-  return { counts: migrated, notes: notes };
-}
-
-function migrateHandbookSheetsToConfig_() {
-  var result = _hbAutoMigrateSheetsToConfig_();
-  return okJ({ ok: true, migrated: result.counts, notes: result.notes });
-}

--- a/public.gs
+++ b/public.gs
@@ -1351,14 +1351,6 @@ function _schedToVolDto_(ev) {
   };
 }
 
-// List volunteer events in DTO shape for getConfig_ to return. Excludes
-// cancelled rows so the admin view doesn't show stale entries; orphaned rows
-// (soft-deleted but kept for signup history) are included with active=false.
-function listVolunteerEventDtos_() {
-  var rows = sched_listVolunteerEvents_();
-  return rows.map(_schedToVolDto_);
-}
-
 function ensureVolunteerSignupsTab_() {
   const ss = SpreadsheetApp.openById(SHEET_ID_);
   ensureTab_(ss, 'volunteer_signups', SCHEMA_.volunteer_signups);


### PR DESCRIPTION
- config.gs: collapse two readAll_('scheduledEvents') passes into one, deriving volunteerEvents (DTO) + cancelledActivityOccurrences from a single iteration. Halves sheet I/O on every getConfig cache miss.

- handbook.gs: remove _hbAutoMigrateSheetsToConfig_ + the unconditional migration probe at the top of getHandbook_. Migration is complete; every read was paying for 4× readConfigList_ checks before falling through to the four reads it actually needed.

- public.gs: drop now-unused listVolunteerEventDtos_.