### PR TITLE
Member portal: cut cold-load critical path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — speed up cold member-portal load
+
+First-load on the member portal was dominated by three things: weather/tides
+firing at the top of init and competing with `getConfig` / `getActiveCheckouts`
+for backend latency, an extra sequential `getNotifications` round-trip after
+content paint, and a full `scheduled_events` sheet read on every getConfig
+cache miss. This pass takes a swing at all three.
+
+Backend (`.gs`):
+- `config.gs` — getConfig's `scheduled_events` projection now has its own
+  CacheService entry (`sched_events_for_config`, 5 min TTL). The whole-config
+  cache is still 60s; the projection survives many config rebuilds so plain
+  config writes (flagConfig, staffStatus, etc.) don't pay for a fresh
+  scheduled_events sheet read. The cache stores parsed rows, not DTOs, so
+  activity_types changes are picked up immediately without invalidation.
+- `scheduling.gs` — `sched_upsert_` / `sched_cancel_` / `sched_hardDelete_`
+  invalidate the new projection cache on every write.
+- `public.gs` — `_schedToVolDto_` now accepts an optional `classMap` so the
+  in-getConfig conversion can pass the already-loaded `activity_types`. Was
+  an N+1: each volunteer event re-read the whole config sheet to look up its
+  class's `classTag`. Single-row callers (e.g. `saveVolunteerEvent`) keep
+  the legacy fallback and still work.
+- `code.gs` — `cPut_` accepts an optional `ttlSec` (default 60).
+
+Frontend:
+- `member/member.js` — weather + tide widgets used to start at the top of
+  init, racing the `getConfig` / `getActiveCheckouts` `Promise.all` for
+  network and CPU. They're now started in a `requestIdleCallback` after the
+  visible content paints. Cuts ~300-500ms of FCP delay on cold loads.
+- `member/member.js` — `getNotifications` is folded into the top-of-file
+  `prefetch` batch alongside `getConfig` / `getActiveCheckouts` so all three
+  fire in parallel; the post-render fetch reuses the cached promise via
+  `window._earlyNotifications`. Removes one sequential round-trip on cold
+  loads.
+
 ## Unreleased — drop one-shot migration / seed helpers and dead modules
 
 Sweep of legacy code that's already done its job. Every removed function was

--- a/code.gs
+++ b/code.gs
@@ -1155,7 +1155,7 @@ function deleteRow_(tabKey, keyField, keyValue) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function cGet_(k) { try { const v = CacheService.getScriptCache().get(k); return v ? JSON.parse(v) : null; } catch (e) { return null; } }
-function cPut_(k, v) { try { CacheService.getScriptCache().put(k, JSON.stringify(v), 60); } catch (e) { } }
+function cPut_(k, v, ttlSec) { try { CacheService.getScriptCache().put(k, JSON.stringify(v), ttlSec || 60); } catch (e) { } }
 function cDel_(k) { try { CacheService.getScriptCache().remove(k); } catch (e) { } }
 
 

--- a/config.gs
+++ b/config.gs
@@ -2,6 +2,37 @@
 // CONFIG  —  getConfig bundles everything; boats + locations stored as JSON rows
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// Cached projection of scheduled_events into the two slices getConfig_ needs:
+// volunteer rows (for the volunteerEvents DTO list) and cancelled-activity ids
+// (for the daily-log virtual-suppression list). The 60s getConfig cache covers
+// the hot path; this cache survives many config rebuilds (5min TTL) so plain
+// config writes — flagConfig, staffStatus, etc. — don't pay for a fresh
+// scheduled_events sheet read. Invalidated by sched_upsert_ / sched_cancel_ /
+// sched_hardDelete_ so any actual scheduled-events write rebuilds it.
+//
+// We cache parsed rows, not DTOs, so changes to activity_types (which feed the
+// volunteer-event subtitle) don't need to clear this cache — getConfig_
+// rebuilds DTOs on the fly from the in-scope cfgMap.
+function _scheduledEventsForConfig_() {
+  var cached = cGet_('sched_events_for_config');
+  if (cached) return cached;
+  var volunteerRows = [];
+  var cancelledActivityIds = [];
+  try {
+    (readAll_('scheduledEvents') || []).forEach(function (r) {
+      if (!r) return;
+      if (r.kind === 'volunteer' && r.status !== 'cancelled') {
+        volunteerRows.push(sched_parseRow_(r));
+      } else if (r.kind === 'activity' && r.status === 'cancelled' && r.id) {
+        cancelledActivityIds.push(String(r.id));
+      }
+    });
+  } catch (e) {}
+  var out = { volunteerRows: volunteerRows, cancelledActivityIds: cancelledActivityIds };
+  cPut_('sched_events_for_config', out, 300);
+  return out;
+}
+
 function getConfig_() {
   const c = cGet_('config'); if (c) return okJ(c);
   // Read the config sheet ONCE and look up all keys from the in-memory map
@@ -64,22 +95,21 @@ function getConfig_() {
     if (rpRaw) rowingPassport = JSON.parse(rpRaw);
   } catch (e) {}
   // Single pass over scheduled_events: derive volunteerEvents (DTO shape) +
-  // cancelled-activity tombstones from one sheet read. The tombstones let the
-  // admin Scheduling timeline and client-side projector suppress matching
-  // virtuals (`sched-{classId}-{date}`) without re-touching the sheet.
+  // cancelled-activity tombstones. The parsed-row projection is cached
+  // (see _scheduledEventsForConfig_) so plain config writes don't pay for a
+  // fresh sheet read; DTO conversion happens here using the in-scope
+  // activityTypes so subtitle changes are picked up immediately.
+  var classMap = {};
+  (activityTypes || []).forEach(function (t) {
+    if (t && t.id) classMap[t.id] = { classTag: t.classTag || '', classTagIS: t.classTagIS || '' };
+  });
+  var schedProj = _scheduledEventsForConfig_();
   var volunteerEvents = [];
-  var cancelledActivityOccurrences = [];
-  try {
-    (readAll_('scheduledEvents') || []).forEach(function (r) {
-      if (!r) return;
-      if (r.kind === 'volunteer' && r.status !== 'cancelled') {
-        var dto = _schedToVolDto_(sched_parseRow_(r));
-        if (dto) volunteerEvents.push(dto);
-      } else if (r.kind === 'activity' && r.status === 'cancelled' && r.id) {
-        cancelledActivityOccurrences.push(String(r.id));
-      }
-    });
-  } catch (e) {}
+  (schedProj.volunteerRows || []).forEach(function (ev) {
+    var dto = _schedToVolDto_(ev, classMap);
+    if (dto) volunteerEvents.push(dto);
+  });
+  var cancelledActivityOccurrences = (schedProj.cancelledActivityIds || []).slice();
   var clubCalendars = [];
   try {
     var ccRaw = getConfigValue_('clubCalendars', cfgMap);

--- a/member/member.js
+++ b/member/member.js
@@ -1,4 +1,13 @@
-prefetch({Config:['getConfig'],Checkouts:['getActiveCheckouts']});
+// Notifications need the kennitala in the params, so look up the cached user
+// (sessionStorage, no network) before firing the prefetch. requireAuth() runs
+// a few lines down and redirects if the user is missing — until then we just
+// skip the notifications prefetch and the post-render fallback path picks it up.
+var _u = (typeof getUser === 'function') ? getUser() : null;
+prefetch({
+  Config:        ['getConfig'],
+  Checkouts:     ['getActiveCheckouts'],
+  Notifications: _u && _u.kennitala ? ['getNotifications', { kennitala: _u.kennitala }] : null,
+});
 
 // ══ STATE ════════════════════════════════════════════════════════════════════
 const user = requireAuth();
@@ -34,15 +43,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('rReturnedLabel').textContent    = s('member.returned');
   document.getElementById('rNotes').placeholder            = s('lbl.optional');
 
-  wxWidget(document.getElementById('wxWidget'), { getStaffStatus: () => _staffStatus, onData: snap => { currentWx = snap; window._memberWxSnap = snap; } }).start();
-  tideWidget(document.getElementById('tideWidget')).start();
+  // Weather + tide widgets used to fire here at the top of init and competed
+  // with getConfig/getActiveCheckouts for backend latency on cold loads.
+  // They now start in an idle callback after the visible content paints —
+  // see the requestIdleCallback at the end of this handler.
 
   try {
     const [coRes, cfgRes] = await Promise.all([
       window._earlyCheckouts || apiGet('getActiveCheckouts'),
       window._earlyConfig || apiGet('getConfig'),
     ]);
-    if (cfgRes.flagConfig && typeof wxLoadFlagConfig === 'function') { wxLoadFlagConfig(cfgRes.flagConfig); document.getElementById('wxWidget')?._wxRefresh?.(); }
+    if (cfgRes.flagConfig && typeof wxLoadFlagConfig === 'function') { wxLoadFlagConfig(cfgRes.flagConfig); }
     checkouts = coRes.checkouts || [];
     boats     = (cfgRes.boats     || []).filter(b => b.active !== false && b.active !== 'false');
     locations = (cfgRes.locations || []).filter(l => l.active !== false && l.active !== 'false');
@@ -84,11 +95,22 @@ document.addEventListener('DOMContentLoaded', async () => {
       `<div class="empty-note text-red">${s('toast.loadFailed')}: ${esc(e.message)}</div>`;
   }
 
-  // Fetch notification counts (non-blocking)
-  apiGet('getNotifications', { kennitala: user.kennitala }).then(function(res) {
+  // Notification badges — prefetched at the top of the file when possible,
+  // fall back to a fresh apiGet if the cached user wasn't ready in time.
+  (window._earlyNotifications || apiGet('getNotifications', { kennitala: user.kennitala })).then(function(res) {
     if (!res || !res.counts) return;
     renderNotifBadges(res.counts);
   }).catch(function() {});
+
+  // Start weather + tide widgets after the visible content (active checkouts,
+  // fleet, calendars) has rendered. requestIdleCallback yields to layout/paint
+  // first; the timeout cap is a safety net for browsers that never go idle.
+  var _startWeatherWidgets = function () {
+    wxWidget(document.getElementById('wxWidget'), { getStaffStatus: () => _staffStatus, onData: snap => { currentWx = snap; window._memberWxSnap = snap; } }).start();
+    tideWidget(document.getElementById('tideWidget')).start();
+  };
+  if (typeof requestIdleCallback === 'function') requestIdleCallback(_startWeatherWidgets, { timeout: 1500 });
+  else setTimeout(_startWeatherWidgets, 0);
 
   warmContainer();
 });

--- a/public.gs
+++ b/public.gs
@@ -1301,7 +1301,13 @@ function volunteerWithdraw_(b) {
 // Shape a scheduled_events row into the legacy volunteer-event DTO the
 // frontend expects. Preserves the old field names (subtitle, active) so the
 // admin + member volunteer pages keep working without changes.
-function _schedToVolDto_(ev) {
+//
+// classMap is an optional `{ id -> { classTag, classTagIS } }` lookup. When
+// provided (e.g. from getConfig_'s already-loaded activityTypes), we skip the
+// per-call config-sheet read for the subtitle — was an N+1 across volunteer
+// events. Single-row callers (e.g. saveVolunteerEvent) can omit it and still
+// get the legacy fallback.
+function _schedToVolDto_(ev, classMap) {
   if (!ev) return null;
   // Subtitle comes from the class's bilingual classTag/classTagIS pair.
   // Each language picks its own with cross-fallback when one is empty so
@@ -1310,14 +1316,20 @@ function _schedToVolDto_(ev) {
   var subtitle = '';
   var subtitleIS = '';
   if (ev.activityTypeId) {
-    try {
-      var types = JSON.parse(getConfigSheetValue_('activity_types') || '[]');
-      var cls = types.find(function (t) { return t && t.id === ev.activityTypeId; });
-      if (cls) {
-        subtitle   = String(cls.classTag   || cls.classTagIS || '');
-        subtitleIS = String(cls.classTagIS || cls.classTag   || '');
-      }
-    } catch (e) {}
+    var cls = classMap && classMap[ev.activityTypeId];
+    if (cls) {
+      subtitle   = String(cls.classTag   || cls.classTagIS || '');
+      subtitleIS = String(cls.classTagIS || cls.classTag   || '');
+    } else {
+      try {
+        var types = JSON.parse(getConfigSheetValue_('activity_types') || '[]');
+        var found = types.find(function (t) { return t && t.id === ev.activityTypeId; });
+        if (found) {
+          subtitle   = String(found.classTag   || found.classTagIS || '');
+          subtitleIS = String(found.classTagIS || found.classTag   || '');
+        }
+      } catch (e) {}
+    }
   }
   if (!subtitle)   subtitle   = ev.subtypeName || '';
   if (!subtitleIS) subtitleIS = subtitle || '';

--- a/scheduling.gs
+++ b/scheduling.gs
@@ -183,6 +183,7 @@ function sched_upsert_(ev) {
     if (payload.roles  === undefined) payload.roles  = '[]';
     insertRow_('scheduledEvents', payload);
   }
+  cDel_('sched_events_for_config');
   return sched_getById_(id);
 }
 
@@ -197,6 +198,7 @@ function sched_cancel_(id, updatedBy) {
     updatedAt: now_(),
     updatedBy: updatedBy || '',
   });
+  cDel_('sched_events_for_config');
   return true;
 }
 
@@ -205,7 +207,9 @@ function sched_cancel_(id, updatedBy) {
 // daily-log ties, use sched_cancel_ instead.
 function sched_hardDelete_(id) {
   if (!id) return false;
-  return deleteRow_('scheduledEvents', 'id', id);
+  var ok = deleteRow_('scheduledEvents', 'id', id);
+  if (ok) cDel_('sched_events_for_config');
+  return ok;
 }
 
 // ── Batch helpers used by signup flows ───────────────────────────────────────


### PR DESCRIPTION
Three changes that compound on first load:

* Defer weather/tide widgets to requestIdleCallback after the visible content paints. They used to start at the top of init and competed with getConfig / getActiveCheckouts for backend latency.
* Fold getNotifications into the top-of-file prefetch batch so all three initial round-trips fire in parallel. The post-render fetch reuses the cached promise via window._earlyNotifications.
* Cache getConfig's scheduled_events projection separately (5min TTL) so plain config writes don't pay for a fresh sheet read. Removes a hidden N+1 in _schedToVolDto_ by passing the in-scope activity_types through as a classMap; legacy single-row callers still work.

cPut_ now takes an optional ttlSec arg so the new projection cache can opt into a longer-than-default TTL without forking the helper.