### PR TITLE
Unify button heights across the maint detail-modal action and comment…

### DIFF
--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -240,16 +240,16 @@ function maintOpenDetail(r, currentUser) {
       <div class="comment-add" style="margin-top:12px">
         <div style="display:flex;gap:6px;align-items:center">
           <input id="mdCommentInput" type="text" placeholder="${s('maint.addCommentPh')}" style="flex:1">
-          <label class="btn-ghost-sm icon-btn" style="cursor:pointer;padding:6px 10px" title="${s('maint.attachPhoto')}" aria-label="${s('maint.attachPhoto')}">${icon('image-plus')}
+          <label class="btn-ghost-sm icon-btn" style="cursor:pointer" title="${s('maint.attachPhoto')}" aria-label="${s('maint.attachPhoto')}">${icon('image-plus')}
             <input id="mdCommentPhoto" type="file" accept="image/*" style="display:none">
           </label>
-          <button id="mdCommentBtn" class="btn-ghost-sm icon-btn" style="padding:6px 10px" title="${s('maint.postBtn')}" aria-label="${s('maint.postBtn')}">${icon('message-square-plus')}</button>
+          <button id="mdCommentBtn" class="btn-ghost-sm icon-btn" title="${s('maint.postBtn')}" aria-label="${s('maint.postBtn')}">${icon('message-square-plus')}</button>
         </div>
         <div id="mdCommentPhotoPreview" style="margin-top:6px"></div>
       </div>
       ${isSauma && !boolVal(r.approved) ? `<div style="margin-bottom:10px;padding:8px 12px;border-radius:6px;background:var(--accent)11;border:1px solid var(--accent)44;font-size:12px;color:var(--accent-fg);display:flex;align-items:center;gap:6px;flex-wrap:wrap">${icon('hourglass')}<span>${s('maint.pendingReview')}</span><button id="mdApproveBtn" class="btn btn-primary btn-sm" style="margin-left:auto">${s('maint.approveBtn')}</button></div>` : ''}
       <div class="req-actions" style="margin-top:10px;display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-        <button id="mdDeleteBtn" class="btn-ghost-sm danger icon-btn" style="padding:6px 10px" title="${s('maint.deleteBtn')}" aria-label="${s('maint.deleteBtn')}">${icon('trash-2')}</button>
+        <button id="mdDeleteBtn" class="btn-ghost-sm danger icon-btn" title="${s('maint.deleteBtn')}" aria-label="${s('maint.deleteBtn')}">${icon('trash-2')}</button>
         ${typeof window.maintOpenEdit === 'function' ? `<button id="mdEditBtn" class="btn-ghost-sm">${s('btn.edit')}</button>` : ''}
         ${showReassign ? `<button id="mdReassignBtn" class="btn-ghost-sm icon-btn">${icon('spool')}<span>${isSauma ? s('maint.reassignToMaint') : s('maint.reassignToSauma')}</span></button>` : ''}
         ${isSauma && boolVal(r.approved) ? `<button id="mdHoldBtn" class="btn-ghost-sm icon-btn" style="margin-left:auto">${isOnHold ? icon('play')+'<span>'+s('maint.resumeBtn')+'</span>' : icon('pause')+'<span>'+s('maint.putOnHold')+'</span>'}</button>` : ''}

--- a/shared/style.css
+++ b/shared/style.css
@@ -1050,6 +1050,24 @@ textarea { min-height: 70px; }
 .btn-ghost-sm.danger        { color: var(--red); }
 .btn-ghost-sm.danger:hover  { color: var(--red); border-color: var(--red); background: color-mix(in srgb, var(--red) 8%, transparent); }
 
+/* Maintenance detail modal — unify the height of the action-row and the
+   comment-row buttons across the .btn-ghost-sm / .btn-primary mix so they
+   line up vertically regardless of which classes a given button uses. */
+.req-actions > button,
+.req-actions > label,
+.comment-add button,
+.comment-add label {
+  min-height: 32px;
+  padding: 6px 12px;
+  box-sizing: border-box;
+}
+.req-actions > button.icon-btn,
+.req-actions > label.icon-btn,
+.comment-add button.icon-btn,
+.comment-add label.icon-btn {
+  padding: 6px 10px;
+}
+
 /* Dashed add button */
 .btn-dashed {
   background: none;


### PR DESCRIPTION
… rows

The trash, edit, reassign, hold/resume, and resolve buttons mix .btn-ghost-sm and .btn .btn-primary .btn-sm, which have different default paddings — so they sat at visibly different heights even when wrapped on the same row. Adds a scoped rule to .req-actions / .comment-add that pins min-height to 32px and normalises padding to 6px 12px (icon-only buttons get 6px 10px instead). Removes the now- redundant inline padding overrides from the trash, photo-attach, and send-comment buttons.

https://claude.ai/code/session_013xpPEM9hCexfVCZXwESafV