### PR TITLE
Count unique OOS boats in the maintenance stat strip

### DIFF
--- a/maintenance/maintenance.js
+++ b/maintenance/maintenance.js
@@ -72,12 +72,15 @@ function populateBoatSelect() {
 function renderStats() {
   const open     = allRequests.filter(r => !boolVal(r.resolved));
   const critical = open.filter(r => r.severity === "critical");
-  const oos      = open.filter(r => boolVal(r.markOos) && r.category === "boat");
+  const oosBoatIds = new Set(
+    open.filter(r => boolVal(r.markOos) && r.category === "boat" && r.boatId)
+        .map(r => r.boatId)
+  );
   const pending  = allRequests.filter(r => boolVal(r.saumaklubbur) && !boolVal(r.approved) && !boolVal(r.resolved));
   const resolved = allRequests.filter(r => boolVal(r.resolved));
   document.getElementById("statOpen").textContent     = open.length;
   document.getElementById("statCritical").textContent = critical.length;
-  document.getElementById("statOos").textContent      = oos.length;
+  document.getElementById("statOos").textContent      = oosBoatIds.size;
   document.getElementById("statPending").textContent  = pending.length;
   document.getElementById("statResolved").textContent = resolved.length;
 


### PR DESCRIPTION
The 'Boats OOS' stat was filtering open requests with markOos=true and emitting the row count, so a boat with multiple OOS-flagged maintenance items was counted once per item. Switch to a Set keyed on boatId so the stat reflects how many distinct boats are out of service at the moment.

https://claude.ai/code/session_013xpPEM9hCexfVCZXwESafV