### PR TITLE
Make card and modal header text green by default

### DIFF
--- a/maintenance/maintenance.css
+++ b/maintenance/maintenance.css
@@ -23,7 +23,7 @@
     .req-card.sev-low      { border-left:3px solid var(--green); }
 
     .req-header { display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
-    .req-title { font-size:13px; font-weight:500; color:var(--text); margin-bottom:4px; }
+    .req-title { font-size:13px; font-weight:500; color:var(--accent-fg); margin-bottom:4px; }
     .req-meta  { display:flex; flex-wrap:wrap; gap:6px; align-items:center; font-size:11px; color:var(--muted); }
     .req-desc  { font-size:12px; color:var(--muted); margin-top:8px; line-height:1.5; }
     .req-actions { display:flex; gap:8px; align-items:center; margin-top:10px; flex-wrap:wrap; }

--- a/saumaklubbur/saumaklubbur.css
+++ b/saumaklubbur/saumaklubbur.css
@@ -15,7 +15,7 @@
     .req-card.sev-medium   { border-left:3px solid var(--yellow); }
     .req-card.sev-low      { border-left:3px solid var(--green); }
     .req-header { display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
-    .req-title { font-size:13px; font-weight:500; color:var(--text); margin-bottom:4px; }
+    .req-title { font-size:13px; font-weight:500; color:var(--accent-fg); margin-bottom:4px; }
     .req-meta  { display:flex; flex-wrap:wrap; gap:6px; align-items:center; font-size:11px; color:var(--muted); }
     .req-desc  { font-size:12px; color:var(--muted); margin-top:8px; line-height:1.5; }
     .req-photo { width:80px; height:60px; object-fit:cover; border-radius:var(--radius-sm); border:1px solid var(--border);
@@ -87,7 +87,7 @@
     .kanban-card.sev-medium { border-left:3px solid var(--yellow); }
     .kanban-card.sev-low    { border-left:3px solid var(--green); }
     .kanban-card.on-hold    { opacity:.55; }
-    .kanban-card .kc-title { font-size:12px; font-weight:500; color:var(--text);
+    .kanban-card .kc-title { font-size:12px; font-weight:500; color:var(--accent-fg);
       margin-bottom:4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
     .kanban-card .kc-meta { display:flex; flex-wrap:wrap; gap:4px; align-items:center;
       font-size:10px; color:var(--muted); }

--- a/shared/maintenance.js
+++ b/shared/maintenance.js
@@ -94,8 +94,8 @@ function maintRenderCardCompact(r) {
     <div style="flex:1;min-width:0;display:flex;align-items:center;gap:6px;overflow:hidden">
       <span style="flex-shrink:0;color:var(--accent-fg);display:inline-flex">${catSvg}</span>
       ${subject ? `<span style="font-weight:600;font-size:13px;color:var(--accent-fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${subject}</span>` : ''}
-      ${part ? `<span style="${subject?'font-size:12px;color:var(--muted);':'font-weight:600;font-size:13px;'}white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${part}</span>` : ''}
-      ${fallback ? `<span style="font-weight:600;font-size:13px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${fallback}</span>` : ''}
+      ${part ? `<span style="${subject?'font-size:12px;color:var(--muted);':'font-weight:600;font-size:13px;color:var(--accent-fg);'}white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${part}</span>` : ''}
+      ${fallback ? `<span style="font-weight:600;font-size:13px;color:var(--accent-fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${fallback}</span>` : ''}
     </div>
     ${oosTag}
   </div>`;
@@ -171,7 +171,7 @@ function maintOpenDetail(r, currentUser) {
       : (r.part || maintTitleFallback_(r));
 
     document.getElementById('maintDetailTitle').innerHTML =
-      `<span style="color:var(--accent-fg);display:inline-flex;vertical-align:-2px;margin-right:6px">${catSvg}</span>${esc(titleText)}`;
+      `<span style="color:var(--accent-fg);display:inline-flex;vertical-align:-2px;margin-right:6px">${catSvg}</span><span style="color:var(--accent-fg)">${esc(titleText)}</span>`;
 
     // Severity dropdown — saumaklúbbur only gets low/medium/high
     const allSevs = isSauma ? ['low','medium','high'] : ['low','medium','high','critical'];


### PR DESCRIPTION
Promotes the .req-title / .kc-title color to var(--accent-fg) in maintenance.css and saumaklubbur.css so the entire title token (boat name, or part name when there's no boat, or the description fallback) reads as the primary brand-tinted text rather than only the boat name. The existing inline override on the secondary " · part" span keeps that text muted as a hierarchy cue.

Also brings the maint-portal compact card (inline-styled) and the detail-modal title in line — the part-without-subject and fallback spans on the compact card switch from default body text / muted to accent-fg, and the modal title now wraps its text in an accent-fg span to match the leading icon.

https://claude.ai/code/session_013xpPEM9hCexfVCZXwESafV