### PR TITLE
Add Drive folder sync for handbook docs

### DIFF
--- a/admin/handbook.js
+++ b/admin/handbook.js
@@ -896,3 +896,27 @@ async function deleteHandbookDoc() {
   return _hbDelete('deleteHandbookDoc', 'docs', 'editingDocId',
     'hbDocModal', renderHandbookDocsList);
 }
+
+// Pull any new files from the configured Drive folder into the docs list.
+// Backend resolves shortcuts to their target file (Drive Advanced Service
+// must be enabled in the Apps Script project for that to work). Existing
+// rows are left alone so admin overrides survive re-syncs.
+async function syncHandbookDocs() {
+  const status = document.getElementById('hbDocsSyncStatus');
+  if (status) status.textContent = s('admin.handbook.doc.syncing');
+  try {
+    const res = await apiPost('syncHandbookDocs', {});
+    if (!res.ok) throw new Error(res.error || 'sync failed');
+    await loadHandbookAdmin(true);
+    renderHandbookDocsList();
+    const parts = [];
+    if (res.added)               parts.push(s('admin.handbook.doc.syncAdded')   + ' ' + res.added);
+    if (res.skipped)             parts.push(s('admin.handbook.doc.syncSkipped') + ' ' + res.skipped);
+    if (res.shortcutsUnresolved) parts.push(s('admin.handbook.doc.syncShortcutWarn') + ' ' + res.shortcutsUnresolved);
+    if (status) status.textContent = parts.join(' · ') || s('admin.handbook.doc.syncDone');
+    toast(s('toast.saved'));
+  } catch (e) {
+    if (status) status.textContent = s('toast.error') + ': ' + e.message;
+    toast(s('toast.error') + ': ' + e.message, 'err');
+  }
+}

--- a/admin/index.html
+++ b/admin/index.html
@@ -601,9 +601,12 @@
         <div class="col-body hidden" id="hbAdminDocsCard">
           <div class="loading-state"><span class="spinner"></span></div>
         </div>
-        <div style="padding:8px 0 4px">
+        <div class="flex-center gap-6" style="padding:8px 0 4px">
           <button class="btn btn-primary" data-admin-click="openHandbookDocModal" data-s="admin.handbookAddDoc"></button>
+          <button class="btn btn-secondary" data-admin-click="syncHandbookDocs" data-s="admin.handbookSyncDocs"></button>
+          <span class="text-xs text-muted" id="hbDocsSyncStatus"></span>
         </div>
+        <div class="text-xs text-muted mt-3" data-s="admin.handbookSyncDocsHint"></div>
       </div>
     </div>
 

--- a/code.gs
+++ b/code.gs
@@ -117,6 +117,7 @@ const ADMIN_ACTIONS_ = {
   saveHandbookDoc:     true,
   deleteHandbookDoc:   true,
   uploadHandbookDoc:   true,
+  syncHandbookDocs:    true,
   saveHandbookInfo:     true,
   deleteHandbookInfo:   true,
   saveHandbookContact:  true,
@@ -1363,6 +1364,7 @@ function route_(action, b, caller) {
     case 'saveHandbookDoc':     return saveHandbookDoc_(b);
     case 'deleteHandbookDoc':   return deleteHandbookDoc_(b);
     case 'uploadHandbookDoc':   return uploadHandbookDoc_(b);
+    case 'syncHandbookDocs':    return syncHandbookDocs_();
     case 'saveHandbookInfo':     return saveHandbookInfo_(b);
     case 'deleteHandbookInfo':   return deleteHandbookInfo_(b);
     case 'saveHandbookContact':  return saveHandbookContact_(b);

--- a/handbook.gs
+++ b/handbook.gs
@@ -291,6 +291,103 @@ function deleteHandbookDoc_(b) {
   return okJ({ ok: true });
 }
 
+// Reconcile the configured Drive folder into the `handbookDocs` config list.
+// For each file not yet tracked by `driveFileId`, append a new entry with
+// `title = file name (sans extension)`. Shortcuts are resolved to their target
+// via the Drive Advanced Service (if enabled) so the stored URL points at the
+// real file, not the shortcut. Existing rows are never touched — admins keep
+// any title / category overrides they've set.
+//
+// Requires the Drive Advanced Service to be enabled in the Apps Script project
+// for shortcut resolution. Without it, shortcuts are skipped and reported back.
+function syncHandbookDocs_() {
+  const folderId = PropertiesService.getScriptProperties().getProperty('DRIVE_FOLDER_ID_HANDBOOK_DOCS');
+  if (!folderId) return failJ('Drive folder not configured');
+  let folder;
+  try { folder = DriveApp.getFolderById(folderId); }
+  catch (e) { return failJ('Drive folder not accessible: ' + e.message); }
+
+  const existing = readConfigList_('handbookDocs');
+  const trackedIds = {};
+  existing.forEach(function (d) {
+    if (d && d.driveFileId) trackedIds[String(d.driveFileId)] = true;
+  });
+
+  // Highest current sortOrder so newly added rows append cleanly to the end.
+  let maxSort = 0;
+  existing.forEach(function (d) {
+    var n = Number(d && d.sortOrder || 0);
+    if (n > maxSort) maxSort = n;
+  });
+
+  const driveAvailable = (typeof Drive !== 'undefined' && Drive && Drive.Files);
+  let added = 0, skipped = 0, shortcutsUnresolved = 0;
+  const skipped_reasons = [];
+
+  const files = folder.getFiles();
+  while (files.hasNext()) {
+    const f = files.next();
+    const id   = f.getId();
+    const mime = f.getMimeType();
+    const name = f.getName();
+
+    let targetId = id;
+    let url      = f.getUrl();
+    let title    = name;
+
+    if (mime === 'application/vnd.google-apps.shortcut') {
+      if (!driveAvailable) {
+        shortcutsUnresolved++;
+        skipped_reasons.push(name + ' (shortcut — enable Drive Advanced Service)');
+        continue;
+      }
+      try {
+        const meta = Drive.Files.get(id, { fields: 'shortcutDetails,name' });
+        const tid  = meta && meta.shortcutDetails && meta.shortcutDetails.targetId;
+        if (!tid) { shortcutsUnresolved++; skipped_reasons.push(name + ' (shortcut target missing)'); continue; }
+        targetId = tid;
+        const target = Drive.Files.get(tid, { fields: 'name,webViewLink' });
+        if (target) {
+          if (target.webViewLink) url = target.webViewLink;
+          if (target.name) title = target.name;
+        }
+      } catch (e) {
+        shortcutsUnresolved++;
+        skipped_reasons.push(name + ' (shortcut: ' + e.message + ')');
+        continue;
+      }
+    }
+
+    if (trackedIds[String(targetId)]) { skipped++; continue; }
+
+    const cleanTitle = String(title || name).replace(/\.[^.]+$/, '') || 'Untitled';
+    maxSort += 10;
+    saveConfigListItem_('handbookDocs', {
+      id:          '',
+      category:    '',
+      categoryIS:  '',
+      title:       cleanTitle,
+      titleIS:     '',
+      url:         url,
+      driveFileId: targetId,
+      notes:       '',
+      notesIS:     '',
+      sortOrder:   maxSort,
+      active:      true,
+    });
+    trackedIds[String(targetId)] = true;
+    added++;
+  }
+
+  return okJ({
+    ok: true,
+    added: added,
+    skipped: skipped,
+    shortcutsUnresolved: shortcutsUnresolved,
+    notes: skipped_reasons,
+  });
+}
+
 // Script Property required: DRIVE_FOLDER_ID_HANDBOOK_DOCS
 function uploadHandbookDoc_(b) {
   if (!b.fileData) return failJ('fileData required');

--- a/shared/api.js
+++ b/shared/api.js
@@ -154,6 +154,7 @@ var _INVALIDATES = {
   reorderHandbookRoles:['getHandbook'],
   saveHandbookDoc:     ['getHandbook'],
   deleteHandbookDoc:   ['getHandbook'],
+  syncHandbookDocs:    ['getHandbook'],
   saveHandbookInfo:     ['getHandbook'],
   deleteHandbookInfo:   ['getHandbook'],
   saveHandbookContact:  ['getHandbook'],

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -1875,6 +1875,13 @@ var _STRINGS_FLAT = {
   "admin.handbook.doc.sortOrder": "Sort order",
   "admin.handbook.doc.modalAdd":  "Add document",
   "admin.handbook.doc.modalEdit": "Edit document",
+  "admin.handbookSyncDocs":       "Sync from Drive",
+  "admin.handbookSyncDocsHint":   "Pulls in any new files (or shortcuts) dropped into the handbook docs Drive folder. Existing rows keep their title and category.",
+  "admin.handbook.doc.syncing":          "Syncing…",
+  "admin.handbook.doc.syncDone":         "No new files.",
+  "admin.handbook.doc.syncAdded":        "Added:",
+  "admin.handbook.doc.syncSkipped":      "Already tracked:",
+  "admin.handbook.doc.syncShortcutWarn": "Shortcuts unresolved:",
 
   "admin.handbook.info.kind":     "Section",
   "admin.handbook.info.kind.contacts": "Contact numbers",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -1875,6 +1875,13 @@ var _STRINGS_FLAT = {
   "admin.handbook.doc.sortOrder": "Röðun",
   "admin.handbook.doc.modalAdd":  "Bæta við skjali",
   "admin.handbook.doc.modalEdit": "Breyta skjali",
+  "admin.handbookSyncDocs":       "Samstilla við Drive",
+  "admin.handbookSyncDocsHint":   "Sækir nýjar skrár (eða flýtileiðir) sem hafa verið settar í Drive-möppuna fyrir handbókarskjöl. Skjöl sem þegar eru skráð halda titli og flokki.",
+  "admin.handbook.doc.syncing":          "Samstilli…",
+  "admin.handbook.doc.syncDone":         "Engar nýjar skrár.",
+  "admin.handbook.doc.syncAdded":        "Bætt við:",
+  "admin.handbook.doc.syncSkipped":      "Þegar skráð:",
+  "admin.handbook.doc.syncShortcutWarn": "Flýtileiðir óleystar:",
 
   "admin.handbook.info.kind":     "Kafli",
   "admin.handbook.info.kind.contacts": "Símanúmer",


### PR DESCRIPTION
New 'Sync from Drive' button on the admin handbook docs col-section calls syncHandbookDocs_, which lists DRIVE_FOLDER_ID_HANDBOOK_DOCS and upserts any file not already tracked by driveFileId. Shortcuts are resolved to their target file (name + webViewLink) via the Drive Advanced Service so the stored URL points at the real document. The file's name (sans extension) becomes the default title; admins can still open the doc modal to override title/titleIS/category.

Existing rows are never touched on re-sync, so admin overrides survive. Without the Drive Advanced Service enabled, shortcuts are skipped and counted in the response so the admin sees what needs configuration.

https://claude.ai/code/session_01KfigLTatbqHZxveAsEStAd