### PR TITLE
Use the canonical maint card on captain and coxswain pages

### DIFF
--- a/captain/captain.js
+++ b/captain/captain.js
@@ -158,18 +158,15 @@ function renderMaint() {
   items.sort((a, b) => (b.createdAt || '') > (a.createdAt || '') ? 1 : -1);
 
   if (!items.length) { el.innerHTML = '<div class="empty-note">' + s('cq.noMaint') + '</div>'; return; }
-  el.innerHTML = items.slice(0, 50).map(m => {
-    var sev = m.severity || 'low';
-    var resolved = m.resolved || boolVal(m.resolved);
-    return '<div class="cq-card">'
-      + '<div class="cq-card-title"><span class="sev-dot sev-' + esc(sev) + '"></span>' + esc(m.boatName || m.itemName || 'Unknown') + '</div>'
-      + '<div class="cq-card-sub">' + esc(sstr(m.description)).slice(0, 120) + '</div>'
-      + '<div class="cq-card-meta">' + esc(sev.toUpperCase()) + ' · '
-        + (resolved ? '<span style="color:var(--green)">RESOLVED</span>' : '<span style="color:var(--yellow)">OPEN</span>')
-        + ' · ' + esc(sstr(m.createdAt).slice(0, 10))
-      + '</div>'
-    + '</div>';
-  }).join('');
+  var rendered = items.slice(0, 50);
+  el.innerHTML = rendered.map(m => maintRenderCardCompact(m)).join('');
+  el.querySelectorAll('.maint-card-compact').forEach(card => {
+    card.addEventListener('click', () => {
+      const id = card.dataset.id;
+      const r  = rendered.find(x => x.id === id);
+      if (r) maintOpenDetail(r, (typeof user !== 'undefined' && user) ? user.name : null);
+    });
+  });
 }
 
 // ══ VALIDATION REQUESTS ══════════════════════════════════════════════════════

--- a/coxswain/coxswain.js
+++ b/coxswain/coxswain.js
@@ -163,14 +163,14 @@ function renderMaint() {
     el.innerHTML = '<div class="empty-note">' + s('cox.noMaint') + '</div>';
     return;
   }
-  el.innerHTML = items.map(m => {
-    var sevClass = 'sev-' + (m.severity || 'low');
-    return '<div class="cx-card">'
-      + '<div style="font-size:12px;font-weight:500;color:var(--text)"><span class="sev-dot ' + sevClass + '"></span>' + esc(m.boatName || '') + '</div>'
-      + '<div style="font-size:11px;color:var(--muted);margin-top:3px">' + esc(m.description || m.title || '') + '</div>'
-      + '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + esc(m.reportedBy || '') + ' · ' + fmtDate(m.createdAt) + '</div>'
-      + '</div>';
-  }).join('');
+  el.innerHTML = items.map(m => maintRenderCardCompact(m)).join('');
+  el.querySelectorAll('.maint-card-compact').forEach(card => {
+    card.addEventListener('click', () => {
+      const id = card.dataset.id;
+      const r  = items.find(x => x.id === id);
+      if (r) maintOpenDetail(r, (typeof user !== 'undefined' && user) ? user.name : null);
+    });
+  });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Captain (keelboat) and coxswain (rowing) hubs were rendering maintenance items with their own bespoke .cq-card / .cx-card markup, so they didn't pick up any of the recent green-header styling, the spool-overrides-cat-icon for sauma items, or the expandable detail modal. Switch both to maintRenderCardCompact() (same renderer as the staff hub) and wire each card's click to maintOpenDetail() so the modal opens for inline editing, commenting, severity changes, OOS toggle, and resolve. The .cq-card / .cx-card classes are still used by validation / crew sections on those pages, so they stay defined.

https://claude.ai/code/session_013xpPEM9hCexfVCZXwESafV