### PR TITLE
Make handbook doc sync work with both Drive v2 and v3

### DIFF
--- a/admin/handbook.js
+++ b/admin/handbook.js
@@ -913,7 +913,17 @@ async function syncHandbookDocs() {
     if (res.added)               parts.push(s('admin.handbook.doc.syncAdded')   + ' ' + res.added);
     if (res.skipped)             parts.push(s('admin.handbook.doc.syncSkipped') + ' ' + res.skipped);
     if (res.shortcutsUnresolved) parts.push(s('admin.handbook.doc.syncShortcutWarn') + ' ' + res.shortcutsUnresolved);
-    if (status) status.textContent = parts.join(' · ') || s('admin.handbook.doc.syncDone');
+    if (status) {
+      status.textContent = parts.join(' · ') || s('admin.handbook.doc.syncDone');
+      // Surface per-file reasons (target missing, sharing denied, v2/v3 field
+      // mismatch, etc.) so an admin can see why a shortcut didn't resolve.
+      if (Array.isArray(res.notes) && res.notes.length) {
+        status.title = res.notes.join('\n');
+        console.warn('syncHandbookDocs notes:', res.notes);
+      } else {
+        status.title = '';
+      }
+    }
     toast(s('toast.saved'));
   } catch (e) {
     if (status) status.textContent = s('toast.error') + ': ' + e.message;

--- a/handbook.gs
+++ b/handbook.gs
@@ -291,6 +291,27 @@ function deleteHandbookDoc_(b) {
   return okJ({ ok: true });
 }
 
+// Drive Advanced Service version-agnostic Files.get. Apps Script ships both
+// v2 and v3; the project picks one when the service is enabled.
+//   v3 only returns `shortcutDetails` if you list it in `fields`, and uses
+//       `name` / `webViewLink` / `supportsAllDrives`.
+//   v2 returns the full resource by default and uses `title` / `alternateLink`
+//       / `supportsTeamDrives`. Asking for v3 field names against v2 errors
+//       with "Invalid field selection".
+// Try v3 first; if Drive rejects the call (likely a v2 service rejecting v3
+// field names or `supportsAllDrives`), retry with v2-flavoured params.
+function _hbDriveGet_(fileId) {
+  try {
+    return Drive.Files.get(fileId, {
+      fields: 'id,shortcutDetails,name,webViewLink',
+      supportsAllDrives: true,
+    });
+  } catch (eV3) {
+    try { return Drive.Files.get(fileId, { supportsTeamDrives: true }); }
+    catch (eV2) { return Drive.Files.get(fileId); }
+  }
+}
+
 // Reconcile the configured Drive folder into the `handbookDocs` config list.
 // For each file not yet tracked by `driveFileId`, append a new entry with
 // `title = file name (sans extension)`. Shortcuts are resolved to their target
@@ -342,14 +363,20 @@ function syncHandbookDocs_() {
         continue;
       }
       try {
-        const meta = Drive.Files.get(id, { fields: 'shortcutDetails,name' });
-        const tid  = meta && meta.shortcutDetails && meta.shortcutDetails.targetId;
-        if (!tid) { shortcutsUnresolved++; skipped_reasons.push(name + ' (shortcut target missing)'); continue; }
+        const meta = _hbDriveGet_(id);
+        const tid = meta && meta.shortcutDetails && meta.shortcutDetails.targetId;
+        if (!tid) {
+          shortcutsUnresolved++;
+          skipped_reasons.push(name + ' (no shortcutDetails on response)');
+          continue;
+        }
         targetId = tid;
-        const target = Drive.Files.get(tid, { fields: 'name,webViewLink' });
+        const target = _hbDriveGet_(tid);
         if (target) {
-          if (target.webViewLink) url = target.webViewLink;
-          if (target.name) title = target.name;
+          const tUrl  = target.webViewLink || target.alternateLink;
+          const tName = target.name || target.title;
+          if (tUrl)  url   = tUrl;
+          if (tName) title = tName;
         }
       } catch (e) {
         shortcutsUnresolved++;


### PR DESCRIPTION
Drive v3 omits shortcutDetails/webViewLink unless requested via `fields`, and uses `name`/`supportsAllDrives`. Drive v2 returns the full resource by default and uses `title`/`alternateLink`/`supportsTeamDrives` — asking for v3 field names against v2 throws "Invalid field selection".

Add a version-agnostic _hbDriveGet_ that tries v3 first, then falls back to v2 params, then a bare get. Read both name/title and webViewLink/alternateLink off the response.

Surface per-file resolve reasons (response.notes) in the admin status line as a tooltip + console.warn so failures are debuggable.

https://claude.ai/code/session_01KfigLTatbqHZxveAsEStAd