### PR TITLE
Load logbook-confirm.js before logbook.js to fix init race

### DIFF
--- a/captain/index.html
+++ b/captain/index.html
@@ -29,10 +29,10 @@
      reads the flag — otherwise the IIFE proceeds, calls renderCerts() (which
      only exists in /logbook), and the failure briefly flashes as a toast. -->
 <script src="captain.js" defer></script>
+<script src="../shared/logbook-confirm.js" defer></script>
 <script src="../shared/logbook.js" defer></script>
 <script src="../shared/logbook-form.js" defer></script>
 <script src="../shared/logbook-share.js" defer></script>
-<script src="../shared/logbook-confirm.js" defer></script>
 <script src="../shared/logbook-edit.js" defer></script>
 <link rel="stylesheet" href="captain.css">
 </head>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -348,10 +348,10 @@
 
 <script src="logbook.js" defer></script>
 <script src="../shared/tripcard.js" defer></script>
+<script src="../shared/logbook-confirm.js" defer></script>
 <script src="../shared/logbook.js" defer></script>
 <script src="../shared/logbook-form.js" defer></script>
 <script src="../shared/logbook-share.js" defer></script>
-<script src="../shared/logbook-confirm.js" defer></script>
 <script src="../shared/logbook-edit.js" defer></script>
 
 


### PR DESCRIPTION
The init IIFE in shared/logbook.js awaits Promise.all([getTrips, getConfig, getMembers]) and then calls applyFilter() -> tripcard, which reads _confirmations. When all three fetches are cache hits the await resumes via microtasks before the next defer script parses, so _confirmations (declared in logbook-confirm.js) is undefined and the catch surfaces "Could not load: _confirmations is not defined".

https://claude.ai/code/session_01AXWNjM9yzFJxuVBeuxoGD5