### PR TITLE
Wrap fleet card badges to a new line on narrow cards

### DIFF
--- a/shared/boats.js
+++ b/shared/boats.js
@@ -420,9 +420,9 @@ function renderBoatCard(boat, opts) {
   const catBorder = `border-left:3px solid ${boatCatColors(cat).color};`;
 
   return `<div class="bc-card bc-${status}"${clickAttr} style="${charteredMuted}${catBorder}">`
-       + `<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:4px">`
+       + `<div style="display:flex;align-items:flex-start;flex-wrap:wrap;gap:4px 8px;margin-bottom:4px">`
        + `<div style="font-size:14px;font-weight:500;color:var(--text)">${emoji} ${name}</div>`
-       + `<div style="display:flex;gap:4px;flex-shrink:0">${ownerBadge}${bdgHtml}</div>`
+       + `<div style="display:flex;gap:4px;flex-shrink:0;margin-left:auto">${ownerBadge}${bdgHtml}</div>`
        + `</div>`
        + locLine + infoLine + oosLine + ownerLine + charterLine
        + (opts.extraHtml||"")


### PR DESCRIPTION
The fleet grid uses minmax(180px, 1fr), so cards with two badges (AUTHORIZED + AVAIL ≈ 125px) overflowed: badges were clipped on the right edge while the title wrapped awkwardly mid-name. Switch the header row to flex-wrap and keep badges right-aligned via margin-left, so they drop to a second line cleanly when there isn't room.

https://claude.ai/code/session_01UGwy2fZMowrytA9i2DMatC