### PR TITLE
Use shared mcm credential modal on staff logbook-review

### DIFF
--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -15,6 +15,7 @@
   <script src="../shared/boats.js"></script>
   <script src="../shared/strings.js"></script>
   <script src="../shared/certs.js" defer></script>
+  <script src="../shared/mcm.js" defer></script>
   <script src="../shared/tripcard.js" defer></script>
   <link rel="stylesheet" href="staff_logbook-review.css">
 </head>
@@ -99,7 +100,7 @@
             <div class="text-lg fw-500" id="certPanelName"></div>
             <div class="text-sm text-muted" id="certPanelMeta"></div>
           </div>
-          <button data-slr-click="openCertAssignModal" class="btn btn-primary btn-sm">+ Add / Change cert</button>
+          <button data-slr-click="openCertAssignModal" class="btn btn-primary btn-sm" data-s="cq.assignCred"></button>
         </div>
         <div id="certPanelList"></div>
       </div>
@@ -121,52 +122,6 @@
     </div>
 
   </div>
-
-<!-- ══ CERT ASSIGNMENT MODAL ══ -->
-<div class="modal-overlay hidden" id="tripCertModal" data-slr-close-self>
-  <div class="modal" style="max-width:440px">
-    <div class="modal-header mb-16">
-      <h3 id="tcmTitle"></h3>
-      <button class="modal-close-x" data-slr-close="tripCertModal">×</button>
-    </div>
-
-    <!-- Current certs for this member -->
-    <div class="mb-14">
-      <div class="section-label mb-8" data-s="logrev.certModal"></div>
-      <div id="tcmCurrentList"><div class="text-sm text-muted" style="font-style:italic" data-s="lbl.loading"></div></div>
-    </div>
-
-    <!-- Assign new cert -->
-    <div style="border-top:1px solid var(--border);padding-top:14px">
-      <div class="section-label mb-10" data-s="logrev.assignCert"></div>
-      <div class="field">
-        <label data-s="lbl.type" for="tcmCertType"></label>
-        <select id="tcmCertType" data-slr-change="tcmCertTypeChanged">
-          <option value=""></option>
-        </select>
-      </div>
-      <div class="field d-none" id="tcmSubcatField">
-        <label data-s="cert.level" for="tcmSubcat"></label>
-        <select id="tcmSubcat"><option value=""></option></select>
-      </div>
-      <div class="grid2 gap-10">
-        <div class="field">
-          <label data-s="logrev.assignedDate" for="tcmAssignedAt"></label>
-          <input type="date" id="tcmAssignedAt">
-        </div>
-        <div class="field d-none" id="tcmExpiryField">
-          <label data-s="logrev.expires" for="tcmExpiresAt"></label>
-          <input type="date" id="tcmExpiresAt">
-        </div>
-      </div>
-      <button class="btn btn-primary w-full mt-4" data-slr-click="tcmAssign" id="tcmAssignBtn" data-s="logrev.assignBtn"></button>
-    </div>
-
-    <div class="mt-8" style="text-align:right">
-      <button class="btn btn-secondary" data-slr-close="tripCertModal" data-s="btn.close"></button>
-    </div>
-  </div>
-</div>
 
 <script src="staff_logbook-review.js" defer></script>
 </body>

--- a/staff/staff_logbook-review.js
+++ b/staff/staff_logbook-review.js
@@ -39,13 +39,15 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('filterOptPending').textContent  = s('logrev.filterPending');
   document.getElementById('filterOptVerified').textContent = s('logrev.filterVerified');
   document.getElementById('certMemberSearch').placeholder  = s('logrev.certSearchPlaceholder');
-  document.getElementById('tcmAssignBtn').textContent      = s('logrev.assignBtn');
-
-  // Pre-fill today in assigned-date
-  document.getElementById('tcmAssignedAt').value = todayISO();
 
   init();
 });
+
+// ── Shared mcm.js wiring (cert modal — same component admin/captain use) ──────
+window.mcmGetMembers        = function () { return allMembers; };
+window.mcmGetCertDefs       = function () { return _certDefs; };
+window.mcmGetCertCategories = function () { return _certCats; };
+window.mcmOnUpdate          = function () { renderCertPanelList(); applyCertFilter(); };
 
 // ── Init: load trips + members + certDefs in one pass ────────────────────────
 async function init() {
@@ -90,17 +92,6 @@ function _enrichTripMember(t) {
     (t.memberId       && x.id        === t.memberId)
   );
   return m ? { ...t, memberName: m.name } : t;
-}
-
-function _buildCertTypeSelect() {
-  const sel = document.getElementById('tcmCertType');
-  sel.innerHTML = `<option value="">${s('lbl.selectDots')}</option>`;
-  _certDefs.forEach(d => {
-    const o = document.createElement('option');
-    o.value       = d.id;
-    o.textContent = certDefName(d);
-    sel.appendChild(o);
-  });
 }
 
 // ── Stats ─────────────────────────────────────────────────────────────────────
@@ -282,8 +273,8 @@ function selectCertMember(m) {
   document.getElementById('certPanelName').textContent = m.name;
   document.getElementById('certPanelMeta').textContent =
     [m.kennitala, m.email].filter(Boolean).join(' · ');
-  document.getElementById('certMemberPanel').style.display = '';
-  document.getElementById('certMemberEmpty').style.display = 'none';
+  document.getElementById('certMemberPanel').classList.remove('d-none');
+  document.getElementById('certMemberEmpty').classList.add('d-none');
 
   renderCertPanelList();
 }
@@ -300,169 +291,17 @@ function renderCertPanelList() {
     return;
   }
 
-  el.innerHTML = certs.map(c => {
-    const expiry = c.expiresAt
-      ? (new Date(c.expiresAt) < new Date()
-          ? `<span class="text-red">Expired ${esc(c.expiresAt)}</span>`
-          : `Expires ${esc(c.expiresAt)}`)
-      : 'Does not expire';
-    const defLabel = c.def ? certDefName(c.def) : (c.certId || '');
-    const label = c.subcat
-      ? `${esc(defLabel)} — ${esc(certSubcatLabel(c.subcat))}`
-      : esc(defLabel);
-    return `<div class="cert-row">
-      <div>
-        <div class="cert-name">${label}</div>
-        <div class="cert-meta">${expiry}${c.assignedAt ? ' · Issued ' + esc(c.assignedAt) : ''}</div>
-      </div>
-      <div class="cert-actions">
-        <button class="btn btn-secondary btn-sm"
-          data-slr-click="editCert" data-slr-arg="${esc(c.certId)}" data-slr-arg2="${esc(c.sub||'')}">Edit</button>
-        <button class="btn btn-secondary btn-sm text-red"
-          data-slr-click="deleteCert" data-slr-arg="${esc(c.certId)}" data-slr-arg2="${esc(c.sub||'')}">✕</button>
-      </div>
-    </div>`;
-  }).join('');
+  el.innerHTML = certs.map(certBadgeHTML).join('');
 }
 
-// ── Cert assignment modal ─────────────────────────────────────────────────────
-function openCertAssignModal(certId, subcatKey) {
+// Open the shared credential modal (same component used by admin/captain).
+function openCertAssignModal() {
   if (!_certMember) return;
-
-  document.getElementById('tcmTitle').textContent =
-    s('cert.assign') + ' — ' + _certMember.name;
-
-  // Show current certs
-  const m     = allMembers.find(x => x.id === _certMember.id);
-  const certs = m ? enrichMemberCerts(_parseJson(m.certifications, []), _certDefs, _certCats) : [];
-  document.getElementById('tcmCurrentList').innerHTML = certs.length
-    ? certs.map(certBadgeHTML).join('')
-    : `<div class="text-muted text-sm" style="font-style:italic">${s('cert.noCerts')}</div>`;
-
-  // Reset / pre-fill form
-  document.getElementById('tcmAssignedAt').value     = todayISO();
-  document.getElementById('tcmExpiresAt').value      = '';
-  document.getElementById('tcmSubcatField').style.display = 'none';
-  document.getElementById('tcmExpiryField').style.display = 'none';
-
-  if (certId) {
-    document.getElementById('tcmCertType').value = certId;
-    tcmCertTypeChanged();
-    if (subcatKey) {
-      // wait one tick for subcat select to render
-      setTimeout(() => {
-        document.getElementById('tcmSubcat').value = subcatKey;
-      }, 50);
-    }
-  } else {
-    document.getElementById('tcmCertType').value = '';
+  if (typeof window.openMemberCertModal !== 'function') {
+    showToast(s('toast.error'), 'err');
+    return;
   }
-
-  openModal('tripCertModal');
-}
-
-function editCert(certId, subcatKey) {
-  openCertAssignModal(certId, subcatKey);
-}
-
-function tcmCertTypeChanged() {
-  const def    = _certDefs.find(d => d.id === document.getElementById('tcmCertType').value);
-  const sField = document.getElementById('tcmSubcatField');
-  const eField = document.getElementById('tcmExpiryField');
-
-  if (def?.subcats?.length) {
-    const sSel = document.getElementById('tcmSubcat');
-    sSel.innerHTML = `<option value="">${s('lbl.selectDots')}</option>`;
-    def.subcats.forEach(sc => {
-      const o = document.createElement('option');
-      o.value = sc.key; o.textContent = sc.label;
-      sSel.appendChild(o);
-    });
-    sField.style.display = '';
-  } else {
-    sField.style.display = 'none';
-  }
-
-  if (def?.expires) {
-    eField.style.display = '';
-  } else {
-    document.getElementById('tcmExpiresAt').value = '';
-    eField.style.display = 'none';
-  }
-}
-
-async function tcmAssign() {
-  const certId = document.getElementById('tcmCertType').value;
-  if (!certId) { showToast(s('lbl.type') + ' required.', 'err'); return; }
-
-  const def = _certDefs.find(d => d.id === certId);
-  const sub = def?.subcats?.length ? document.getElementById('tcmSubcat').value : null;
-  if (def?.subcats?.length && !sub) { showToast(s('cert.level') + ' required.', 'err'); return; }
-
-  if (!_certMember) { showToast(s('logrev.noMemberSelected'), 'err'); return; }
-
-  const m = allMembers.find(x => x.id === _certMember.id);
-  if (!m) { showToast(s('logrev.memberNotFound'), 'err'); return; }
-
-  const newCert = {
-    certId,
-    sub:        sub || null,
-    assignedBy: user.name,
-    assignedAt: document.getElementById('tcmAssignedAt').value || todayISO(),
-    expiresAt:  document.getElementById('tcmExpiresAt').value  || null,
-  };
-
-  // Apply rank rule (removes lower-ranked subcats of same cert), then
-  // remove exact duplicate before appending
-  let existing = _parseJson(m.certifications, []);
-  existing = applyRankRule(existing, newCert, _certDefs);
-  existing = existing.filter(c => !(c.certId === certId && (c.sub || null) === (sub || null)));
-  const updated = [...existing, newCert];
-
-  try {
-    await apiPost('saveMemberCert', { memberId: _certMember.id, certifications: updated });
-
-    // Update local copy
-    const idx = allMembers.findIndex(x => x.id === _certMember.id);
-    if (idx >= 0) allMembers[idx] = { ...allMembers[idx], certifications: JSON.stringify(updated) };
-
-    // Refresh current-certs display inside modal
-    document.getElementById('tcmCurrentList').innerHTML =
-      enrichMemberCerts(updated, _certDefs, _certCats).map(certBadgeHTML).join('');
-
-    // Reset form
-    document.getElementById('tcmCertType').value         = '';
-    document.getElementById('tcmSubcatField').style.display = 'none';
-    document.getElementById('tcmExpiryField').style.display = 'none';
-
-    showToast('✓ ' + s('cert.assign') + ': ' + m.name);
-
-    // Refresh cert panel list too
-    renderCertPanelList();
-  } catch (e) {
-    showToast(s('toast.error') + ': ' + e.message, 'err');
-  }
-}
-
-async function deleteCert(certId, subcatKey) {
-  if (!_certMember) return;
-  if (!await ymConfirm('Remove this credential?')) return;
-
-  const m = allMembers.find(x => x.id === _certMember.id);
-  if (!m) return;
-
-  let certs = _parseJson(m.certifications, []);
-  certs = certs.filter(c => !(c.certId === certId && (c.sub || '') === (subcatKey || '')));
-
-  try {
-    await apiPost('saveMemberCert', { memberId: _certMember.id, certifications: certs });
-    const idx = allMembers.findIndex(x => x.id === _certMember.id);
-    if (idx >= 0) allMembers[idx] = { ...allMembers[idx], certifications: JSON.stringify(certs) };
-    renderCertPanelList();
-    showToast(s('logrev.credentialRemoved'));
-  } catch (e) {
-    showToast(s('toast.error') + ': ' + e.message, 'err');
-  }
+  window.openMemberCertModal(_certMember.id);
 }
 
 // ── Utilities ──────────────────────────────────────────────────────────────────
@@ -494,8 +333,8 @@ function _parseJson(v, fallback) {
 
 function setCertMode(mode) {
   const isMember = mode === 'member';
-  document.getElementById('certPanelModeA').style.display  = isMember ? '' : 'none';
-  document.getElementById('certPanelModeB').style.display  = isMember ? 'none' : '';
+  document.getElementById('certPanelModeA').classList.toggle('d-none', !isMember);
+  document.getElementById('certPanelModeB').classList.toggle('d-none', isMember);
   document.getElementById('certModeByMember').style.background = isMember ? 'var(--accent)' : 'var(--surface)';
   document.getElementById('certModeByMember').style.color      = isMember ? '#fff' : 'var(--muted)';
   document.getElementById('certModeByType').style.background   = isMember ? 'var(--surface)' : 'var(--accent)';
@@ -566,10 +405,6 @@ function applyCertFilter() {
   if (typeof document === 'undefined' || document._slrListeners) return;
   document._slrListeners = true;
   document.addEventListener('click', function (e) {
-    var cs = e.target.closest('[data-slr-close-self]');
-    if (cs && e.target === cs) { closeModal('tripCertModal'); return; }
-    var cl = e.target.closest('[data-slr-close]');
-    if (cl) { closeModal(cl.dataset.slrClose); return; }
     var c = e.target.closest('[data-slr-click]');
     if (c && typeof window[c.dataset.slrClick] === 'function') {
       var a = [c.dataset.slrArg, c.dataset.slrArg2].filter(function (v) { return v != null; });


### PR DESCRIPTION
The certification panel built its own assign-modal and toggled visibility via inline `style.display=''`, which doesn't override the `.d-none` class — so the member-cert panel and the by-credential filter never appeared, and the bespoke modal duplicated logic the admin/captain pages already share.

Switched to `shared/mcm.js` (same component admin/captain use), fixed the visibility toggles to flip the `d-none` class instead of clearing inline display, and removed the now-redundant tcm* form/assign/edit/delete code paths.

https://claude.ai/code/session_0196i9Lec1hkyNbYgtPoCWNE