### PR TITLE
Hide credential-gated and slot-only boats from the member launch picker

### DIFF
--- a/member/member.js
+++ b/member/member.js
@@ -12,7 +12,7 @@ prefetch({
 // ══ STATE ════════════════════════════════════════════════════════════════════
 const user = requireAuth();
 let _staffStatus = { onDuty: false, supportBoat: false };
-let boats=[], locations=[], checkouts=[];
+let boats=[], locations=[], checkouts=[], _slots=[];
 let _volunteerEvents=[], _volunteerSignups=[], _volunteerActTypes=[];
 let currentWx=null;
 let launchBoat=null, returnCo=null;
@@ -49,10 +49,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   // see the requestIdleCallback at the end of this handler.
 
   try {
-    const [coRes, cfgRes] = await Promise.all([
+    const _today = todayISO();
+    const [coRes, cfgRes, slotsRes] = await Promise.all([
       window._earlyCheckouts || apiGet('getActiveCheckouts'),
       window._earlyConfig || apiGet('getConfig'),
+      apiGet('getSlots', { fromDate: _today, toDate: _today }),
     ]);
+    _slots = slotsRes.slots || [];
+    if (cfgRes.certDefs && typeof registerCertDefsForBoats === 'function') {
+      registerCertDefsForBoats(cfgRes.certDefs);
+    }
     if (cfgRes.flagConfig && typeof wxLoadFlagConfig === 'function') { wxLoadFlagConfig(cfgRes.flagConfig); }
     checkouts = coRes.checkouts || [];
     boats     = (cfgRes.boats     || []).filter(b => b.active !== false && b.active !== 'false');
@@ -158,6 +164,10 @@ function handleBoatQrScan(boatId) {
     showToast(s('qr.boatOos'), 'warn');
     return;
   }
+  if (!canAccessBoat(boat, user, { slots: _slots })) {
+    showToast(s('fleet.badgeRestricted'), 'warn');
+    return;
+  }
   launchBoatById(boatId);
 }
 
@@ -246,7 +256,11 @@ function openReturnModal(coId) {
 // Step 1 — boat picker
 function renderLaunchPicker(preselectedBoatId) {
   const active=checkouts.filter(c=>c.status==='out');
-  const avail=boats.filter(b=>!active.find(c=>c.boatId===b.id)&&!boolVal(b.oos));
+  const avail=boats.filter(b=>
+    !active.find(c=>c.boatId===b.id) &&
+    !boolVal(b.oos) &&
+    canAccessBoat(b, user, { slots: _slots })
+  );
   if(!avail.length){
     document.getElementById('launchModalBody').innerHTML=
       '<div class="mb-12" style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px">'+

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -286,6 +286,14 @@ function canAccessBoat(boat, user, opts) {
   if (isStaff(user)) return true;
   // Private boat owner always has access
   if (boat.ownership === 'private' && String(boat.ownerId || boat.ownerKennitala || '') === String(user.kennitala)) return true;
+  // Slot-only boats (slot scheduling on, not available outside slots): an
+  // active slot booking is the sole non-staff/non-owner path. Cert gates and
+  // allowlists qualify a member to book, but don't bypass the slot itself.
+  // Only enforce when slot data is provided — display contexts that don't
+  // load slots fall through to the permissive checks below.
+  if (isSlotScheduled(boat) && !isAvailableOutsideSlots(boat) && opts && opts.slots) {
+    return hasActiveSlot(boat, user.kennitala, opts.slots);
+  }
   // Check cert gate via unified helper (honours expiry + rank + new structured shape)
   var gate = normalizeAccessGate(boat, opts && opts.certDefs);
   if (gate) {


### PR DESCRIPTION
The launch picker filtered only by checkout state and OOS, so controlled boats (gated on a credential or restricted to booked slots) appeared as launchable. The backend rejected the launch on submit, but the user had already filled the form.

renderLaunchPicker now filters via canAccessBoat with today's slot data, and handleBoatQrScan toasts when a scanned boat is restricted. Member init now also calls registerCertDefsForBoats so rank-based gates resolve correctly. canAccessBoat treats availableOutsideSlots=false as an override: when slot data is passed, only an active slot grants access (staff/owner exempt), so cert gates can't bypass the slot rule.

Known limitation: hasActiveSlot only matches direct bookings, not crew-booked slots — a follow-up.