### PR TITLE
Make slot-only access crew-aware on the frontend and enforce it on th…

### DIFF
--- a/checkouts.gs
+++ b/checkouts.gs
@@ -38,7 +38,8 @@ function saveCheckout_(b) {
         if (!isStaffRole) {
           var hasAccess = false;
           // Owner check
-          if (checkBoat.ownership === 'private' && String(checkBoat.ownerId || checkBoat.ownerKennitala || '') === checkKt) hasAccess = true;
+          var isOwner = checkBoat.ownership === 'private' && String(checkBoat.ownerId || checkBoat.ownerKennitala || '') === checkKt;
+          if (isOwner) hasAccess = true;
           // Cert gate check (unified helper — honours expiry, rank, structured + legacy shapes)
           if (!hasAccess && checkMember) {
             var _coDefs = getCertDefsFromMap_(cfgMap);
@@ -55,8 +56,9 @@ function saveCheckout_(b) {
             var today = nowLocalDate_();
             hasAccess = checkBoat.reservations.some(function(r) { return String(r.memberKennitala) === checkKt && today >= r.startDate && today <= r.endDate; });
           }
-          // Slot-based scheduling check
-          if (!hasAccess && checkBoat.slotSchedulingEnabled) {
+          // Slot-based scheduling check — also feeds the slot-only override below.
+          var hasActiveSlotNow = false;
+          if (checkBoat.slotSchedulingEnabled) {
             var todayStr = nowLocalDate_();
             var nowTime = nowLocalTime_();
             try {
@@ -64,7 +66,7 @@ function saveCheckout_(b) {
                 return s.boatId === checkBoat.id && s.date === todayStr && s.startTime <= nowTime && s.endTime > nowTime && s.bookedByKennitala;
               });
               // Check if user booked a slot directly or via crew
-              hasAccess = slots.some(function(s) {
+              hasActiveSlotNow = slots.some(function(s) {
                 if (String(s.bookedByKennitala) === checkKt) return true;
                 if (s.bookedByCrewId) {
                   var crew = findOne_('crews', 'id', s.bookedByCrewId);
@@ -76,9 +78,12 @@ function saveCheckout_(b) {
                 return false;
               });
             } catch (e) { /* don't block on slot check errors */ }
+            if (hasActiveSlotNow) hasAccess = true;
           }
-          // If slot scheduling is enabled and boat is NOT available outside slots, enforce strictly
-          if (!hasAccess && checkBoat.slotSchedulingEnabled && !checkBoat.availableOutsideSlots) {
+          // Slot-only override: cert gates and allowlists qualify a member to
+          // BOOK a slot, but don't bypass the slot-only restriction itself.
+          // Owner exempt (set above); staff exempt above.
+          if (!isOwner && checkBoat.slotSchedulingEnabled && !checkBoat.availableOutsideSlots && !hasActiveSlotNow) {
             return failJ('Access denied: this boat requires a booked reservation slot');
           }
           if (!hasAccess) return failJ('Access denied: this boat requires authorization');

--- a/member/member.js
+++ b/member/member.js
@@ -12,7 +12,7 @@ prefetch({
 // ══ STATE ════════════════════════════════════════════════════════════════════
 const user = requireAuth();
 let _staffStatus = { onDuty: false, supportBoat: false };
-let boats=[], locations=[], checkouts=[], _slots=[];
+let boats=[], locations=[], checkouts=[], _slots=[], _crews=[];
 let _volunteerEvents=[], _volunteerSignups=[], _volunteerActTypes=[];
 let currentWx=null;
 let launchBoat=null, returnCo=null;
@@ -50,12 +50,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   try {
     const _today = todayISO();
-    const [coRes, cfgRes, slotsRes] = await Promise.all([
+    const [coRes, cfgRes, slotsRes, crewsRes] = await Promise.all([
       window._earlyCheckouts || apiGet('getActiveCheckouts'),
       window._earlyConfig || apiGet('getConfig'),
       apiGet('getSlots', { fromDate: _today, toDate: _today }),
+      apiGet('getCrews', { kennitala: user.kennitala }),
     ]);
     _slots = slotsRes.slots || [];
+    _crews = crewsRes.crews || [];
     if (cfgRes.certDefs && typeof registerCertDefsForBoats === 'function') {
       registerCertDefsForBoats(cfgRes.certDefs);
     }
@@ -164,7 +166,7 @@ function handleBoatQrScan(boatId) {
     showToast(s('qr.boatOos'), 'warn');
     return;
   }
-  if (!canAccessBoat(boat, user, { slots: _slots })) {
+  if (!canAccessBoat(boat, user, { slots: _slots, crews: _crews })) {
     showToast(s('fleet.badgeRestricted'), 'warn');
     return;
   }
@@ -259,7 +261,7 @@ function renderLaunchPicker(preselectedBoatId) {
   const avail=boats.filter(b=>
     !active.find(c=>c.boatId===b.id) &&
     !boolVal(b.oos) &&
-    canAccessBoat(b, user, { slots: _slots })
+    canAccessBoat(b, user, { slots: _slots, crews: _crews })
   );
   if(!avail.length){
     document.getElementById('launchModalBody').innerHTML=

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -260,18 +260,31 @@ function isAvailableOutsideSlots(boat) {
 /**
  * Check if user has a booked slot right now for this boat.
  * Requires _allSlots to be loaded (via loadSlots()).
+ * If `crews` is provided, also matches slots whose bookedByCrewId belongs to
+ * a crew the user is a member of.
  */
-function hasActiveSlot(boat, kennitala, slots) {
+function hasActiveSlot(boat, kennitala, slots, crews) {
   if (!boat || !slots || !slots.length) return false;
   var today = todayISO();
   var now = new Date();
   var nowTime = String(now.getHours()).padStart(2, '0') + ':' + String(now.getMinutes()).padStart(2, '0');
+  var kt = String(kennitala);
+  var userCrewIds = {};
+  if (Array.isArray(crews)) {
+    for (var ci = 0; ci < crews.length; ci++) {
+      var c = crews[ci];
+      if (!c || !c.id) continue;
+      var pairs = typeof c.pairs === 'string' ? parseJson(c.pairs, []) : (c.pairs || []);
+      var onCrew = pairs.some(function(p) { return (p.members || []).some(function(m) { return m && String(m.kennitala) === kt; }); });
+      if (onCrew) userCrewIds[c.id] = true;
+    }
+  }
   return slots.some(function(s) {
     if (s.boatId !== boat.id || s.date !== today) return false;
     if (s.startTime > nowTime || s.endTime <= nowTime) return false;
     if (!s.bookedByKennitala) return false;
-    if (String(s.bookedByKennitala) === String(kennitala)) return true;
-    // Crew member check handled by caller with crew data
+    if (String(s.bookedByKennitala) === kt) return true;
+    if (s.bookedByCrewId && userCrewIds[s.bookedByCrewId]) return true;
     return false;
   });
 }
@@ -292,7 +305,7 @@ function canAccessBoat(boat, user, opts) {
   // Only enforce when slot data is provided — display contexts that don't
   // load slots fall through to the permissive checks below.
   if (isSlotScheduled(boat) && !isAvailableOutsideSlots(boat) && opts && opts.slots) {
-    return hasActiveSlot(boat, user.kennitala, opts.slots);
+    return hasActiveSlot(boat, user.kennitala, opts.slots, opts.crews);
   }
   // Check cert gate via unified helper (honours expiry + rank + new structured shape)
   var gate = normalizeAccessGate(boat, opts && opts.certDefs);
@@ -306,7 +319,7 @@ function canAccessBoat(boat, user, opts) {
   if (hasActiveReservation(boat, user.kennitala)) return true;
   // Check active slot booking
   if (isSlotScheduled(boat) && opts && opts.slots) {
-    if (hasActiveSlot(boat, user.kennitala, opts.slots)) return true;
+    if (hasActiveSlot(boat, user.kennitala, opts.slots, opts.crews)) return true;
   }
   return false;
 }


### PR DESCRIPTION
…e backend

Two related fixes:

1. hasActiveSlot now accepts an optional crews list and matches slots whose bookedByCrewId belongs to a crew the user is on. Member init loads getCrews filtered by user.kennitala and threads it through canAccessBoat as opts.crews. Without this, crew-booked slots (captain books, three rowers on board) made the picker hide the boat from everyone except the booker.

2. saveCheckout_ no longer lets cert gates bypass availableOutsideSlots =false. Previously, hasAccess=true via gate/allowlist/reservation skipped the slot-only override. Now the override checks an independently-tracked hasActiveSlotNow and rejects when the boat is slot-only and the user has no active slot, regardless of other access paths. Owner and staff still exempt.