### PR TITLE
Fix overnight checkout overdue detection

### DIFF
--- a/alerts.gs
+++ b/alerts.gs
@@ -205,13 +205,25 @@ function getOverdueAlerts_(b) {
     if (retByStr.length === 4 && !retByStr.includes(':')) retByStr = retByStr.slice(0,2) + ':' + retByStr.slice(2);
     const [retH, retM] = retByStr.split(':').map(Number);
     if (isNaN(retH) || isNaN(retM)) return;
-    // Build expected return as a full Date using today as base
-    // (no reliable date stored in sheet for active checkouts)
-    const retDt = new Date(todayStr + 'T' + String(retH).padStart(2,'0') + ':' + String(retM).padStart(2,'0') + ':00');
-    // If retBy < checkedOutAt time (overnight), return is the following day
+    // Build expected return relative to the actual checkout date (createdAt is a full ISO
+    // timestamp set on insert). Anchoring on today breaks once the wall clock crosses midnight
+    // for an overnight checkout — the alert would never fire.
+    const createdRaw = row[col('createdAt')];
+    const createdDt  = createdRaw instanceof Date ? createdRaw
+                     : (createdRaw ? new Date(createdRaw) : null);
+    const baseDateStr = (createdDt && !isNaN(createdDt.getTime()))
+      ? Utilities.formatDate(createdDt, Session.getScriptTimeZone(), 'yyyy-MM-dd')
+      : todayStr;
+    const retDt = new Date(baseDateStr + 'T' + String(retH).padStart(2,'0') + ':' + String(retM).padStart(2,'0') + ':00');
+    // If retBy < checkedOutAt time (overnight), return is the day after the checkout
     const coAtVal  = row[col('checkedOutAt')];
-    const coH      = coAtVal instanceof Date ? coAtVal.getHours() : parseInt((String(coAtVal||'').split(':')[0]||'0'), 10);
-    if (!isNaN(coH) && retH < coH) retDt.setDate(retDt.getDate() + 1);
+    const coH      = coAtVal instanceof Date ? coAtVal.getHours()
+                   : parseInt((String(coAtVal||'').split(':')[0]||'0'), 10);
+    const coM      = coAtVal instanceof Date ? coAtVal.getMinutes()
+                   : parseInt((String(coAtVal||'').split(':')[1]||'0'), 10);
+    if (!isNaN(coH) && (retH * 60 + retM) < ((coH || 0) * 60 + (coM || 0))) {
+      retDt.setDate(retDt.getDate() + 1);
+    }
     const overdueMin = Math.round((now_ms - retDt.getTime()) / 60000);
     if (overdueMin < cfg.firstAlertMins) return;
     let snoozedUntil = null;

--- a/shared/api.js
+++ b/shared/api.js
@@ -802,6 +802,17 @@ function fmtTimeNow() {
 }
 function fmtDateNow() { return window.toLocalISODate(); }
 
+// Overdue check that handles overnight checkouts (e.g. out 21:00, return 03:00):
+// when retBy is earlier than tout, return is the next day — only overdue once the wall
+// clock has rolled past midnight (now < tout) and past retBy. All args are "HH:MM" strings.
+function isCheckoutOverdue(retBy, tout, nowStr) {
+  if (!retBy) return false;
+  nowStr = nowStr || fmtTimeNow();
+  if (!tout) return retBy < nowStr;
+  if (retBy < tout) return nowStr < tout && nowStr > retBy;
+  return nowStr > retBy;
+}
+
 // Coerce legacy time values into canonical HH:MM so <input type="time"> accepts
 // them on load. Handles "1700" / "0900" / "9:00" / "17.00" plus Sheets serial
 // fractions (0.7083 → 17:00). Returns '' for unrecognized input so the field

--- a/shared/boats.js
+++ b/shared/boats.js
@@ -472,8 +472,8 @@ function renderCheckoutCard(co, opts) {
   const emoji     = boatEmoji(cat);
   const now       = new Date().toTimeString().slice(0,5);
   const retBy     = co.expectedReturn||co.returnBy||"";
-  const overdue   = co.isOverdue === true || co.isOverdue === 'true' || (retBy && retBy < now);
   const tout      = sstr(co.checkedOutAt||co.timeOut).slice(0,5);
+  const overdue   = co.isOverdue === true || co.isOverdue === 'true' || isCheckoutOverdue(retBy, tout, now);
 
   // Top badge (member view only — staff don't need it, they see all)
   let topBadge = "";

--- a/staff/staff.js
+++ b/staff/staff.js
@@ -155,7 +155,8 @@ function renderStats() {
   const active  = checkouts.filter(c => c.status === 'out');
   const overdue = active.filter(c => {
     if (!c.expectedReturn) return false;
-    return c.expectedReturn < fmtTimeNow();
+    const tout = sstr(c.checkedOutAt || c.timeOut).slice(0, 5);
+    return isCheckoutOverdue(c.expectedReturn, tout);
   });
   const people  = active.reduce((n, c) => n + (parseInt(c.crew) || 1), 0);
   // Count total boats: group checkouts may have multiple boats
@@ -918,7 +919,8 @@ async function staffGroupCheckIn(id) {
 function renderGroupCard(c) {
   const now = new Date().toTimeString().slice(0, 5);
   const retBy = c.expectedReturn || c.returnBy || '';
-  const overdue = retBy && retBy < now;
+  const tout       = sstr(c.checkedOutAt || c.timeOut).slice(0, 5);
+  const overdue = isCheckoutOverdue(retBy, tout, now);
   let boatArr;
   try { boatArr = c.boatNames ? (typeof c.boatNames==='string'?JSON.parse(c.boatNames):c.boatNames) : [c.boatName||'—']; } catch(e){ boatArr=[c.boatName||'—']; }
   let staffArr;
@@ -927,7 +929,6 @@ function renderGroupCard(c) {
   const partic     = parseInt(c.participants) || 0;
   const total      = partic + staffArr.length;
   const boatCount  = boatArr.length;
-  const tout       = sstr(c.checkedOutAt || c.timeOut).slice(0, 5);
   const actName    = c.activityTypeName || '';
 
   // Left column pills: activity → first staff → boats → total


### PR DESCRIPTION
A checkout with a return time earlier in the day than the launch time (e.g. out 21:00, return 03:00) was being flagged as overdue immediately, because the frontend compared two HH:MM strings lexicographically. Add isCheckoutOverdue() in shared/api.js and route the three offending call sites (renderCheckoutCard, staff renderStats, renderGroupCard) through it so overnight returns are only overdue once the wall clock has rolled past midnight.

Backend overdue alerts had a parallel bug: retDt was anchored on today's date, so once midnight passed on an overnight checkout the alert never fired. Anchor on the row's createdAt instead.