### PR TITLE
Cold-load tuning: preconnect crossorigin, defer head scripts, prefetc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — frontend cold-load tuning
+
+Three low-risk changes to shave latency off every cold page load.
+
+- `crossorigin` added to the `<link rel="preconnect" href="https://script.google.com">`
+  hint in every portal HTML. `fetch()` runs in CORS-anonymous mode, so without
+  the attribute the warmed TLS connection is the wrong type and the browser
+  opens a fresh one for the real apiGet. Reclaims the preconnect's intent.
+- `defer` added to all shared `<script src="…/shared/*.js">` tags in `<head>`
+  across every portal (api.js, ui.js, layout.js, strings.js, plus per-portal
+  helpers like list-filter, calendar, boat-modal, slot-modal, trip-form,
+  weather, tides, dateutil, boats). They no longer block HTML parse; defer
+  preserves document execution order so dependents (the portal entry script
+  is itself defer) still see the same globals. CSP forbids inline scripts so
+  there were no in-document call sites depending on synchronous availability.
+- `prefetch({…})` added at script-parse time in the six portals that didn't
+  already have one — captain, coxswain, dailylog, incidents, maintenance,
+  saumaklubbur. Each kicks off the same apiGets the page would have awaited
+  inside `DOMContentLoaded`; apiGet's existing inflight-dedup map makes the
+  later awaits pick up the in-flight promises without code changes. User-
+  bound calls (getConfirmations, getCrewInvites, getRowingPassport) read the
+  cached user from `getUser()` — same gate the existing member.js prefetch
+  uses.
+
 ## Unreleased — emoji → icons across maintenance, saumaklúbbur, incidents
 
 Replaced ad-hoc emoji glyphs across the maintenance, saumaklúbbur, and

--- a/admin/index.html
+++ b/admin/index.html
@@ -7,22 +7,22 @@
   <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
   <title>Ýmir — Admin</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/strings.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
   <script src="../shared/boats.js" defer></script>
   <script src="../shared/weather.js" defer></script>
-  <script src="../shared/ui.js"></script>
-  <script src="../shared/layout.js"></script>
+  <script src="../shared/ui.js" defer></script>
+  <script src="../shared/layout.js" defer></script>
   <script src="../shared/certs.js" defer></script>
   <script src="../shared/volunteer.js" defer></script>
   <script src="../shared/volunteer-role-presets.js" defer></script>
   <script src="../shared/scheduled-event.js" defer></script>
   <script src="../shared/mcm.js" defer></script>
-  <script src="../shared/calendar.js"></script>
-  <script src="../shared/boat-modal.js"></script>
-  <script src="../shared/slot-modal.js"></script>
+  <script src="../shared/calendar.js" defer></script>
+  <script src="../shared/boat-modal.js" defer></script>
+  <script src="../shared/slot-modal.js" defer></script>
   <link rel="stylesheet" href="admin.css">
 </head>
 <body>

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -8,10 +8,10 @@
   <title>Ýmir — Payroll</title>
   <link rel="stylesheet" href="../../shared/style.css">
   <link rel="stylesheet" href="payroll.css">
-  <script src="../../shared/api.js"></script>
-  <script src="../../shared/strings.js"></script>
-  <script src="../../shared/ui.js"></script>
-  <script src="../../shared/layout.js"></script>
+  <script src="../../shared/api.js" defer></script>
+  <script src="../../shared/strings.js" defer></script>
+  <script src="../../shared/ui.js" defer></script>
+  <script src="../../shared/layout.js" defer></script>
   </head>
 <body>
 <div class="page">

--- a/captain/captain.js
+++ b/captain/captain.js
@@ -1,5 +1,18 @@
 window._logbookSkipInit = true;
 
+// Kick off init reads at script-parse time so they race the rest of the
+// deferred-script chain. apiGet's inflight dedup means the awaits below
+// pick up these promises instead of firing fresh network calls.
+var _cqU = (typeof getUser === 'function') ? getUser() : null;
+prefetch({
+  Config:               ['getConfig'],
+  Maintenance:          ['getMaintenance'],
+  Trips:                ['getTrips', { limit: 500 }],
+  VerificationRequests: ['getVerificationRequests'],
+  Members:              ['getMembers'],
+  Confirmations: _cqU && _cqU.kennitala ? ['getConfirmations', { kennitala: _cqU.kennitala }] : null,
+});
+
 // ══ STATE ════════════════════════════════════════════════════════════════════
 const user = requireAuth();
 if (!user || !isCaptain(user)) { window.location.href = '../member/'; throw new Error('Not a captain'); }

--- a/captain/index.html
+++ b/captain/index.html
@@ -7,22 +7,22 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Captain's Quarters</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
 <link rel="stylesheet" href="../shared/tripcard.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
-<script src="../shared/list-filter.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
+<script src="../shared/list-filter.js" defer></script>
 <script src="../shared/calendar.js" defer></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/certs.js" defer></script>
 <script src="../shared/mcm.js" defer></script>
 <script src="../shared/maintenance.js" defer></script>
-<script src="../shared/boat-modal.js"></script>
-<script src="../shared/slot-modal.js"></script>
-<script src="../shared/trip-form.js"></script>
+<script src="../shared/boat-modal.js" defer></script>
+<script src="../shared/slot-modal.js" defer></script>
+<script src="../shared/trip-form.js" defer></script>
 <script src="../shared/tripcard.js" defer></script>
 <!-- captain.js must run before shared/logbook.js so its top-level
      `window._logbookSkipInit = true` is set before logbook.js's auto-init IIFE

--- a/coxswain/coxswain.js
+++ b/coxswain/coxswain.js
@@ -1,4 +1,17 @@
-// ══ AUTH (runs immediately — api.js is non-deferred) ═════════════════════════
+// Kick off init reads at script-parse time. apiGet's inflight dedup means the
+// awaits inside DOMContentLoaded pick up these in-flight promises instead of
+// firing fresh network calls.
+var _cxU = (typeof getUser === 'function') ? getUser() : null;
+prefetch({
+  Config:        ['getConfig'],
+  Maintenance:   ['getMaintenance'],
+  Trips:         ['getTrips', { limit: 200 }],
+  CrewBoard:     ['getCrewBoard', {}],
+  CrewInvites:   _cxU && _cxU.kennitala ? ['getCrewInvites', { kennitala: _cxU.kennitala }] : null,
+  RowingPassport:_cxU && _cxU.id ? ['getRowingPassport', { memberId: _cxU.id }] : null,
+});
+
+// ══ AUTH ═════════════════════════════════════════════════════════════════════
 const user = requireAuth();
 if (!user || !hasRowingEndorsement(user)) { window.location.href = '../member/'; throw new Error('No rowing endorsement'); }
 const _isReleasedRower = isReleasedRower(user);

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -7,12 +7,12 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Coxswain's Seat</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
 <script src="../shared/calendar.js" defer></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/certs.js" defer></script>

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -1,6 +1,13 @@
 // ════════════════════════════════════════════════════════════════════════════
 // SECTION 1 — AUTH + CONSTANTS
 // ════════════════════════════════════════════════════════════════════════════
+// Race the network with the rest of init: today's daily log + config are
+// every page load's two unconditional reads.
+prefetch({
+  DailyLog: ['getDailyLog', { date: todayISO() }],
+  Config:   ['getConfig'],
+});
+
 const user  = requireAuth(isStaff);
 const L     = getLang();
 const TODAY = todayISO();

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -7,14 +7,14 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Daily Log</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
-<script src="../shared/weather.js"></script>
-<script src="../shared/tides.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
+<script src="../shared/weather.js" defer></script>
+<script src="../shared/tides.js" defer></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/maintenance.js" defer></script>
 <link rel="stylesheet" href="dailylog.css">

--- a/guardian/index.html
+++ b/guardian/index.html
@@ -7,12 +7,12 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Guardian</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
 <link rel="stylesheet" href="guardian.css">
 </head>
 <body>

--- a/handbook/index.html
+++ b/handbook/index.html
@@ -7,12 +7,12 @@
   <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
   <title>Ýmir — Handbook</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/ui.js"></script>
-  <script src="../shared/layout.js"></script>
-  <script src="../shared/strings.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/ui.js" defer></script>
+  <script src="../shared/layout.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
   <link rel="stylesheet" href="handbook.css">
 </head>
 <body>

--- a/incidents/incidents.js
+++ b/incidents/incidents.js
@@ -1,3 +1,6 @@
+// Race the network: page init awaits these via the inflight-dedup path.
+prefetch({ Incidents: ['getIncidents'], Config: ['getConfig'] });
+
 const user = requireAuth(isStaff);
 const L    = getLang();
 

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -7,12 +7,12 @@
   <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
   <title>Ýmir — Incident Report</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/ui.js"></script>
-  <script src="../shared/layout.js"></script>
-  <script src="../shared/strings.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/ui.js" defer></script>
+  <script src="../shared/layout.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
   <script src="../shared/qr.js" defer></script>
   <link rel="stylesheet" href="incidents.css">
 </head>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -7,16 +7,16 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Logbook</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="preconnect" href="https://unpkg.com">
 <link rel="stylesheet" href="../shared/style.css">
 <link rel="stylesheet" href="../shared/tripcard.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
-<script src="../shared/trip-form.js"></script>
-<script src="../shared/list-filter.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
+<script src="../shared/trip-form.js" defer></script>
+<script src="../shared/list-filter.js" defer></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/certs.js" defer></script>
 <script src="../shared/boats.js" defer></script>

--- a/login/index.html
+++ b/login/index.html
@@ -7,10 +7,10 @@
   <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
   <title>Ýmir — Sign In</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/strings.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <link rel="stylesheet" href="login.css">
 </head>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -7,13 +7,13 @@
   <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
   <title>Ýmir — Maintenance</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/ui.js"></script>
-  <script src="../shared/layout.js"></script>
-  <script src="../shared/strings.js"></script>
-  <script src="../shared/list-filter.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/ui.js" defer></script>
+  <script src="../shared/layout.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/list-filter.js" defer></script>
   <script src="../shared/maintenance.js" defer></script>
   <link rel="stylesheet" href="maintenance.css">
 </head>

--- a/maintenance/maintenance.js
+++ b/maintenance/maintenance.js
@@ -1,3 +1,5 @@
+// Race the network with the rest of init.
+prefetch({ Maintenance: ['getMaintenance'], Config: ['getConfig'] });
 
 // ── State ──────────────────────────────────────────────────────────────────────
 let allRequests = [];

--- a/member/index.html
+++ b/member/index.html
@@ -7,12 +7,12 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Member Hub</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>YMIR — Club Dashboard</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="preconnect" href="https://unpkg.com">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H"
@@ -18,8 +18,8 @@
 <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"
         integrity="sha384-mFKkGiGvT5vo1fEyGCD3hshDdKmW3wzXW/x+fWriYJArD0R3gawT6lMvLboM22c0"
         crossorigin="anonymous" defer></script>
-<script src="../shared/api.js"></script>
-<script src="../shared/strings.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/strings.js" defer></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>
 <link rel="stylesheet" href="../shared/style.css">

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -7,12 +7,12 @@
   <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
   <title>Ýmir — Saumaklúbbur</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/ui.js"></script>
-  <script src="../shared/layout.js"></script>
-  <script src="../shared/strings.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/ui.js" defer></script>
+  <script src="../shared/layout.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
   <script src="../shared/maintenance.js" defer></script>
   <link rel="stylesheet" href="saumaklubbur.css">
 </head>

--- a/saumaklubbur/saumaklubbur.js
+++ b/saumaklubbur/saumaklubbur.js
@@ -1,3 +1,5 @@
+// Race the network with the rest of init.
+prefetch({ Maintenance: ['getMaintenance'], Config: ['getConfig'] });
 
 let allProjects = [];
 let currentFilter = "open";

--- a/settings/index.html
+++ b/settings/index.html
@@ -7,12 +7,12 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ymir — Settings</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
 <script src="https://accounts.google.com/gsi/client" async defer></script>
 <link rel="stylesheet" href="settings.css">
 </head>

--- a/staff/index.html
+++ b/staff/index.html
@@ -7,12 +7,12 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Staff</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -6,14 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ýmir — Logbook Review</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://script.google.com">
+  <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
   <link rel="stylesheet" href="../shared/tripcard.css">
-  <script src="../shared/api.js"></script>
-  <script src="../shared/ui.js"></script>
-  <script src="../shared/layout.js"></script>
-  <script src="../shared/boats.js"></script>
-  <script src="../shared/strings.js"></script>
+  <script src="../shared/api.js" defer></script>
+  <script src="../shared/ui.js" defer></script>
+  <script src="../shared/layout.js" defer></script>
+  <script src="../shared/boats.js" defer></script>
+  <script src="../shared/strings.js" defer></script>
   <script src="../shared/certs.js" defer></script>
   <script src="../shared/mcm.js" defer></script>
   <script src="../shared/tripcard.js" defer></script>

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -7,13 +7,13 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Volunteer</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/strings.js"></script>
-<script src="../shared/dateutil.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/strings.js" defer></script>
+<script src="../shared/dateutil.js" defer></script>
 <script src="../shared/certs.js" defer></script>
 <script src="../shared/volunteer.js" defer></script>
 <link rel="stylesheet" href="volunteer.css">

--- a/weather/index.html
+++ b/weather/index.html
@@ -7,14 +7,14 @@
 <link rel="icon" type="image/svg+xml" href="../shared/logo.svg">
 <title>Ýmir — Weather</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://script.google.com">
+<link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
-<script src="../shared/api.js"></script>
-<script src="../shared/strings.js"></script>
-<script src="../shared/ui.js"></script>
-<script src="../shared/layout.js"></script>
-<script src="../shared/weather.js"></script>
-<script src="../shared/tides.js"></script>
+<script src="../shared/api.js" defer></script>
+<script src="../shared/strings.js" defer></script>
+<script src="../shared/ui.js" defer></script>
+<script src="../shared/layout.js" defer></script>
+<script src="../shared/weather.js" defer></script>
+<script src="../shared/tides.js" defer></script>
 <link rel="stylesheet" href="weather.css">
 </head>
 <body>


### PR DESCRIPTION
…h in remaining portals

Three low-risk changes to shave latency off every cold page load.

- Add `crossorigin` to the script.google.com preconnect link in every portal HTML. fetch() runs in CORS-anonymous mode; without the attribute the warmed TLS connection is the wrong type and the browser opens a fresh one for the real apiGet, defeating the preconnect.
- Add `defer` to all shared <script src="…/shared/*.js"> tags in <head> across every portal — api.js, ui.js, layout.js, strings.js plus per-portal helpers (list-filter, calendar, boat-modal, slot-modal, trip-form, weather, tides, dateutil, boats). They no longer block HTML parse; defer preserves document execution order so dependents (portal entry scripts are themselves defer) still see the same globals. CSP forbids inline scripts so there are no in-document call sites depending on synchronous availability.
- Add `prefetch({…})` at script-parse time to the six portals that didn't already have one (captain, coxswain, dailylog, incidents, maintenance, saumaklubbur). Each fires the same apiGets the page would await in DOMContentLoaded; apiGet's inflight-dedup makes the later awaits pick up the in-flight promises with no call-site changes. User-bound calls read the cached user from getUser(), same gate the existing member.js prefetch uses.