### PR TITLE
Revert defer on shared/strings.js — document.write needs sync execution

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <script src="../shared/boats.js" defer></script>
   <script src="../shared/weather.js" defer></script>
   <script src="../shared/ui.js" defer></script>

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../../shared/style.css">
   <link rel="stylesheet" href="payroll.css">
   <script src="../../shared/api.js" defer></script>
-  <script src="../../shared/strings.js" defer></script>
+  <script src="../../shared/strings.js"></script>
   <script src="../../shared/ui.js" defer></script>
   <script src="../../shared/layout.js" defer></script>
   </head>

--- a/captain/index.html
+++ b/captain/index.html
@@ -13,7 +13,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/list-filter.js" defer></script>
 <script src="../shared/calendar.js" defer></script>
 <script src="../shared/boats.js" defer></script>

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/calendar.js" defer></script>
 <script src="../shared/boats.js" defer></script>
 <script src="../shared/certs.js" defer></script>

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>
 <script src="../shared/boats.js" defer></script>

--- a/guardian/index.html
+++ b/guardian/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <link rel="stylesheet" href="guardian.css">
 </head>
 <body>

--- a/handbook/index.html
+++ b/handbook/index.html
@@ -12,7 +12,7 @@
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>
   <script src="../shared/layout.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <link rel="stylesheet" href="handbook.css">
 </head>
 <body>

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -12,7 +12,7 @@
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>
   <script src="../shared/layout.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <script src="../shared/qr.js" defer></script>
   <link rel="stylesheet" href="incidents.css">
 </head>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -14,7 +14,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/trip-form.js" defer></script>
 <script src="../shared/list-filter.js" defer></script>
 <script src="../shared/guests.js" defer></script>

--- a/login/index.html
+++ b/login/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://script.google.com" crossorigin>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <link rel="stylesheet" href="login.css">
 </head>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -12,7 +12,7 @@
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>
   <script src="../shared/layout.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <script src="../shared/list-filter.js" defer></script>
   <script src="../shared/maintenance.js" defer></script>
   <link rel="stylesheet" href="maintenance.css">

--- a/member/index.html
+++ b/member/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
         integrity="sha384-mFKkGiGvT5vo1fEyGCD3hshDdKmW3wzXW/x+fWriYJArD0R3gawT6lMvLboM22c0"
         crossorigin="anonymous" defer></script>
 <script src="../shared/api.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>
 <link rel="stylesheet" href="../shared/style.css">

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -12,7 +12,7 @@
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>
   <script src="../shared/layout.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <script src="../shared/maintenance.js" defer></script>
   <link rel="stylesheet" href="saumaklubbur.css">
 </head>

--- a/settings/index.html
+++ b/settings/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="https://accounts.google.com/gsi/client" async defer></script>
 <link rel="stylesheet" href="settings.css">
 </head>

--- a/staff/index.html
+++ b/staff/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/guests.js" defer></script>
 <script src="../shared/weather.js" defer></script>
 <script src="../shared/tides.js" defer></script>

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -13,7 +13,7 @@
   <script src="../shared/ui.js" defer></script>
   <script src="../shared/layout.js" defer></script>
   <script src="../shared/boats.js" defer></script>
-  <script src="../shared/strings.js" defer></script>
+  <script src="../shared/strings.js"></script>
   <script src="../shared/certs.js" defer></script>
   <script src="../shared/mcm.js" defer></script>
   <script src="../shared/tripcard.js" defer></script>

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -12,7 +12,7 @@
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/dateutil.js" defer></script>
 <script src="../shared/certs.js" defer></script>
 <script src="../shared/volunteer.js" defer></script>

--- a/weather/index.html
+++ b/weather/index.html
@@ -10,7 +10,7 @@
 <link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
-<script src="../shared/strings.js" defer></script>
+<script src="../shared/strings.js"></script>
 <script src="../shared/ui.js" defer></script>
 <script src="../shared/layout.js" defer></script>
 <script src="../shared/weather.js" defer></script>


### PR DESCRIPTION
strings.js uses document.write() to inject the language file (strings-is.js / strings-en.js) synchronously during HTML parse so _STRINGS_FLAT is populated before any downstream script runs. The file header explicitly warns about this. Adding `defer` made document.write run after parse, where modern browsers silently no-op it — _STRINGS_FLAT never loaded, s(key) returned the key, and pages rendered with raw i18n keys like "member.title" instead of translated text.

Reverts only the strings.js tag in every portal HTML. The other deferred shared scripts (api.js, ui.js, layout.js, list-filter, calendar, boat-modal, slot-modal, trip-form, weather, tides, dateutil, boats) stay deferred — none of them use document.write or other parse-time-sensitive patterns. With strings.js non-defer and the rest defer, execution order is: parse pauses on strings.js, language file loads synchronously, parse resumes, deferred scripts execute in document order — which is exactly what we want.