### PR TITLE
apiGet memory tier + content-visibility on long card lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — apiGet memory tier + content-visibility on long card lists
+
+Two more low-risk frontend speedups.
+
+- `shared/api.js` — added an in-process memory tier on top of the existing
+  sessionStorage cache. Every cache hit was previously doing
+  `JSON.parse(sessionStorage.getItem(_ck))` against the full payload
+  (tens of KB for `getMembers` / `getTrips`); now warm hits return the
+  already-parsed object directly. sessionStorage stays as the cross-tab
+  / back-button persistence layer; `_invalidateApiCache` clears both
+  tiers via the same prefix scan. `_fresh` bypass and inflight dedup
+  unchanged.
+- `shared/tripcard.css` — `content-visibility:auto` plus an intrinsic-size
+  hint on `.trip-card`. Off-screen trip cards skip layout/paint until they
+  scroll into view, which is the whole logbook's hot path on clubs with
+  long histories.
+- `shared/style.css` — same treatment on `.vp-card` (volunteer + scheduled
+  events). Smaller list, same idea.
+
 ## Unreleased — frontend cold-load tuning
 
 Three low-risk changes to shave latency off every cold page load.

--- a/shared/api.js
+++ b/shared/api.js
@@ -38,8 +38,21 @@ async function apiGet(action, params) {
   if (_CACHEABLE[action] && !params._fresh) {
     try {
       var _ck = 'ymir_' + action + '_' + JSON.stringify(params);
+      var _now = Date.now();
+      // Memory tier: skip sessionStorage + JSON.parse on warm hits. Same
+      // TTL as sessionStorage; populated on every miss-then-fetch and on
+      // sessionStorage-hit promotions so subsequent reads in this tab go
+      // straight to the parsed object.
+      var _mc = apiGet._memCache[_ck];
+      if (_mc && _now - _mc.ts < _CACHEABLE[action]) return _mc.data;
       var _cs = sessionStorage.getItem(_ck);
-      if (_cs) { var _cp = JSON.parse(_cs); if (Date.now() - _cp.ts < _CACHEABLE[action]) return _cp.data; }
+      if (_cs) {
+        var _cp = JSON.parse(_cs);
+        if (_now - _cp.ts < _CACHEABLE[action]) {
+          apiGet._memCache[_ck] = _cp; // promote so the next hit skips parse
+          return _cp.data;
+        }
+      }
       // In-flight dedup: if an identical request is already running (cache
       // miss during page init often fires several parallel apiGet calls for
       // the same action+params), reuse the pending promise instead of kicking
@@ -48,7 +61,9 @@ async function apiGet(action, params) {
       var _p = (async function () {
         try {
           var data = await _call(action, params);
-          sessionStorage.setItem(_ck, JSON.stringify({ ts: Date.now(), data: data }));
+          var entry = { ts: Date.now(), data: data };
+          apiGet._memCache[_ck] = entry;
+          try { sessionStorage.setItem(_ck, JSON.stringify(entry)); } catch(e) {}
           return data;
         } finally {
           delete apiGet._inflight[_ck];
@@ -61,10 +76,11 @@ async function apiGet(action, params) {
   return _call(action, params);
 }
 apiGet._inflight = {};
+apiGet._memCache = {};
 
-// Drop every sessionStorage cache entry for the given action (any params).
-// Used by apiPost's invalidation pass — entries are keyed by `ymir_<action>_<paramsJSON>`
-// so a prefix scan removes all of them.
+// Drop every cached entry (memory + sessionStorage) for the given action.
+// Called by apiPost after a write so the next read sees fresh data. Both
+// tiers use the same `ymir_<action>_<paramsJSON>` key shape.
 function _invalidateApiCache(action) {
   var prefix = 'ymir_' + action + '_';
   try {
@@ -73,6 +89,12 @@ function _invalidateApiCache(action) {
       if (k && k.indexOf(prefix) === 0) sessionStorage.removeItem(k);
     }
   } catch(e) {}
+  if (apiGet._memCache) {
+    var keys = Object.keys(apiGet._memCache);
+    for (var j = 0; j < keys.length; j++) {
+      if (keys[j].indexOf(prefix) === 0) delete apiGet._memCache[keys[j]];
+    }
+  }
 }
 // Which cache entries each write-action invalidates. Single source of truth.
 // Keys are apiPost action names; values are the getXxx reads whose cached

--- a/shared/style.css
+++ b/shared/style.css
@@ -1535,7 +1535,8 @@ textarea { min-height: 70px; }
    .vp-card which enables click-to-edit plus hover affordance.
    ───────────────────────────────────────────────────────────────────────── */
 .vp-card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md);
-  box-shadow:var(--shadow-sm); padding:10px 12px; margin-bottom:8px; }
+  box-shadow:var(--shadow-sm); padding:10px 12px; margin-bottom:8px;
+  content-visibility:auto; contain-intrinsic-size:auto 80px; }
 .vp-card.admin { cursor:pointer; transition:border-color .2s; }
 .vp-card.admin:hover { border-color:var(--accent)55; }
 

--- a/shared/tripcard.css
+++ b/shared/tripcard.css
@@ -1,7 +1,11 @@
 /* ── Trip card (shared between logbook & captain) ── */
 /* --tc-cat / --tc-cat-bg are set inline from boatCatColors() so the card and
    its expanded sections tint with the boat category. */
-.trip-card{background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface));border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm)}
+/* content-visibility:auto skips layout/paint while the card is off-screen.
+   The intrinsic-size hint (~76px closed, larger when open) keeps the
+   scrollbar steady; the browser re-uses the real measured height once an
+   off-screen card has rendered once. Big win on logbooks with 100+ cards. */
+.trip-card{background:color-mix(in srgb, var(--tc-cat, transparent) 5%, var(--surface));border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:8px;overflow:hidden;transition:border-color .2s,box-shadow .2s;box-shadow:var(--shadow-sm);content-visibility:auto;contain-intrinsic-size:auto 76px}
 .trip-card:hover{border-color:var(--moss-l)}
 .trip-card-main{display:grid;grid-template-columns:52px 1fr auto;align-items:stretch;cursor:pointer}
 .trip-date-col{background:color-mix(in srgb, var(--tc-cat, transparent) 10%, var(--card));border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 6px;text-align:center}


### PR DESCRIPTION
shared/api.js
  Add an in-process memory tier on top of the existing sessionStorage
  cache. Every cache hit was previously doing JSON.parse against the
  full payload (tens of KB for getMembers / getTrips); now warm hits
  return the already-parsed object directly. sessionStorage stays as
  the cross-tab / back-button persistence layer. _invalidateApiCache
  clears both tiers via the same prefix scan. _fresh bypass and
  inflight dedup unchanged.

shared/tripcard.css
  content-visibility:auto with contain-intrinsic-size:auto 76px on
  .trip-card. Off-screen trip cards skip layout/paint until they
  scroll into view — the whole logbook's hot path on clubs with
  long histories.

shared/style.css
  Same treatment on .vp-card (volunteer + scheduled events).