### PR TITLE
Fix dark-mode flash on page navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — fix dark-mode flash on page navigation
+
+The earlier `defer` change pushed `applyTheme()` (called at the bottom
+of `shared/ui.js`) past the first paint, so dark-mode users saw a
+brief light flash on every navigation between portals before the
+`data-theme="dark"` attribute landed on `<html>`.
+
+Fix: a tiny new `shared/theme-init.js` (~5 lines) reads the saved
+theme from localStorage and sets the attribute synchronously during
+HTML parse. Loaded as a non-deferred `<script>` immediately before
+the first stylesheet link in every portal's `<head>`, so the
+attribute is in place before CSS evaluates its `[data-theme="dark"]`
+selectors. The full theme helpers in `api.js` stay deferred; the
+later `applyTheme()` call in `ui.js` is now a harmless no-op (sets
+the same value).
+
 ## Unreleased — `_INVALIDATES` audit
 
 Pruned the cache-invalidation map in `shared/api.js`. Each entry was

--- a/admin/index.html
+++ b/admin/index.html
@@ -8,6 +8,7 @@
   <title>Ýmir — Admin</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
   <script src="../shared/strings.js"></script>

--- a/admin/payroll/index.html
+++ b/admin/payroll/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="icon" type="image/svg+xml" href="../../shared/logo.svg">
   <title>Ýmir — Payroll</title>
+  <script src="../../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../../shared/style.css">
   <link rel="stylesheet" href="payroll.css">
   <script src="../../shared/api.js" defer></script>

--- a/captain/index.html
+++ b/captain/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Captain's Quarters</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <link rel="stylesheet" href="../shared/tripcard.css">
 <script src="../shared/api.js" defer></script>

--- a/coxswain/index.html
+++ b/coxswain/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Coxswain's Seat</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Daily Log</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/guardian/index.html
+++ b/guardian/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Guardian</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/handbook/index.html
+++ b/handbook/index.html
@@ -8,6 +8,7 @@
   <title>Ýmir — Handbook</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>

--- a/incidents/index.html
+++ b/incidents/index.html
@@ -8,6 +8,7 @@
   <title>Ýmir — Incident Report</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>

--- a/logbook/index.html
+++ b/logbook/index.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="preconnect" href="https://unpkg.com">
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <link rel="stylesheet" href="../shared/tripcard.css">
 <script src="../shared/api.js" defer></script>

--- a/login/index.html
+++ b/login/index.html
@@ -8,6 +8,7 @@
   <title>Ýmir — Sign In</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
   <script src="../shared/strings.js"></script>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -8,6 +8,7 @@
   <title>Ýmir — Maintenance</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>

--- a/member/index.html
+++ b/member/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Member Hub</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
 <link rel="preconnect" href="https://unpkg.com">
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H"
       crossorigin="anonymous">

--- a/saumaklubbur/index.html
+++ b/saumaklubbur/index.html
@@ -8,6 +8,7 @@
   <title>Ýmir — Saumaklúbbur</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <script src="../shared/api.js" defer></script>
   <script src="../shared/ui.js" defer></script>

--- a/settings/index.html
+++ b/settings/index.html
@@ -8,6 +8,7 @@
 <title>Ymir — Settings</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/shared/theme-init.js
+++ b/shared/theme-init.js
@@ -1,0 +1,11 @@
+// Runs synchronously during HTML parse to set data-theme on <html> before
+// the first paint, so dark-mode users don't see a light→dark flash when
+// navigating between pages. The full theme helpers (getTheme/setTheme/
+// applyTheme) live in api.js (deferred); this just primes the attribute
+// early. Keep it tiny — it's render-blocking by design.
+(function () {
+  try {
+    var t = localStorage.getItem('ymirTheme') || 'light';
+    document.documentElement.setAttribute('data-theme', t);
+  } catch (e) {}
+})();

--- a/staff/index.html
+++ b/staff/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Staff</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -7,6 +7,7 @@
   <title>Ýmir — Logbook Review</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://script.google.com" crossorigin>
+  <script src="../shared/theme-init.js"></script>
   <link rel="stylesheet" href="../shared/style.css">
   <link rel="stylesheet" href="../shared/tripcard.css">
   <script src="../shared/api.js" defer></script>

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Volunteer</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/ui.js" defer></script>

--- a/weather/index.html
+++ b/weather/index.html
@@ -8,6 +8,7 @@
 <title>Ýmir — Weather</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://script.google.com" crossorigin>
+<script src="../shared/theme-init.js"></script>
 <link rel="stylesheet" href="../shared/style.css">
 <script src="../shared/api.js" defer></script>
 <script src="../shared/strings.js"></script>


### PR DESCRIPTION
The earlier defer change pushed applyTheme() (called at the bottom of shared/ui.js) past the first paint, so dark-mode users saw a brief light flash on every navigation between portals before the data-theme attribute landed on <html>.

Fix: a tiny new shared/theme-init.js (~5 lines) reads the saved theme from localStorage and sets the attribute synchronously during HTML parse. Loaded as a non-deferred <script> immediately before the first stylesheet link in every portal's <head>, so the attribute is in place before CSS evaluates its [data-theme="dark"] selectors.

The full theme helpers in api.js stay deferred; the later applyTheme() call in ui.js is now a harmless no-op (sets the same value).