### PR TITLE
Opt-in cache for read-shaped POSTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — opt-in cache for read-shaped POSTs
+
+`shared/api.js` — new `_POST_CACHEABLE` map lets `apiPost` actions
+that are pure reads share the same memory + sessionStorage cache
+as `apiGet`. Same key shape (`ymir_<action>_<paramsJSON>`) so
+`_invalidateApiCache`'s prefix scan drops both kinds together, and
+the existing `prefetch({ <Name>: { post: '<action>' } })` form now
+populates the cache transparently.
+
+Two actions opted in:
+- `getVolunteerSignups` (30 s TTL) — admin/members/volunteer pages
+  all reach for it on init; previously each tab/refresh re-fetched.
+- `getShareTokens` (60 s TTL) — logbook share-management view.
+
+Matching `_INVALIDATES` updates so the cache stays correct under
+writes:
+- `volunteerSignup`, `volunteerWithdraw`, `deleteVolunteerEvent`
+  now drop `getVolunteerSignups`.
+- `createShareToken`, `revokeShareToken` now drop `getShareTokens`.
+
 ## Unreleased — fix dark-mode flash on page navigation
 
 The earlier `defer` change pushed `applyTheme()` (called at the bottom

--- a/shared/api.js
+++ b/shared/api.js
@@ -140,16 +140,21 @@ var _INVALIDATES = {
   overrideClassOccurrence: ['getConfig', 'getSlots', 'getDailyLog'],
   restoreClassOccurrence:  ['getConfig', 'getSlots', 'getDailyLog'],
   // Volunteer events live in scheduled_events (read by getConfig).
+  // deleteVolunteerEvent cascades to volunteerSignups rows for the event,
+  // so it also drops the cached signups.
   saveVolunteerEvent:      ['getConfig'],
-  deleteVolunteerEvent:    ['getConfig'],
+  deleteVolunteerEvent:    ['getConfig', 'getVolunteerSignups'],
   syncVolunteerEvents:     ['getConfig'],
-  // Volunteer signups write to a separate sheet that no cached read embeds
-  // (signups are fetched via apiPost('getVolunteerSignups'), uncached).
-  // volunteerSignup_ keeps getConfig because the first signup against a
-  // virtual recurring event materializes a scheduled_events row, which
-  // feeds getConfig.volunteerEvents. volunteerWithdraw_ touches no cached
-  // read at all and is intentionally absent.
-  volunteerSignup:         ['getConfig'],
+  // Volunteer signups: the volunteerSignups sheet itself is read via
+  // apiPost('getVolunteerSignups'), now in _POST_CACHEABLE. Both writes
+  // drop that cache. volunteerSignup_ also keeps getConfig because the
+  // first signup against a virtual recurring event materializes a
+  // scheduled_events row that feeds getConfig.volunteerEvents.
+  volunteerSignup:         ['getConfig', 'getVolunteerSignups'],
+  volunteerWithdraw:       ['getVolunteerSignups'],
+  // Share tokens — read-shaped POST, cacheable.
+  createShareToken:        ['getShareTokens'],
+  revokeShareToken:        ['getShareTokens'],
 
   // Member-row writes — members sheet only.
   saveMember:              ['getMembers'],
@@ -225,8 +230,50 @@ var _INVALIDATES = {
   deleteRecurrenceGroup:   ['getSlots'],
 };
 
+// Read-shaped POSTs: actions that go through apiPost (typically because
+// they take a payload-bound caller identity like kennitala) but are pure
+// reads with no side effects. Opt in here to share the same memory +
+// sessionStorage cache as apiGet — keys use the same
+// `ymir_<action>_<paramsJSON>` shape so _invalidateApiCache drops both
+// kinds in one prefix scan, and the prefetch helper's `{ post: ... }`
+// form populates the cache transparently.
+var _POST_CACHEABLE = {
+  getVolunteerSignups: 30000,
+  getShareTokens:      60000,
+};
+
 async function apiPost(action, payload) {
   payload = payload || {};
+  if (_POST_CACHEABLE[action] && !payload._fresh) {
+    try {
+      var _ck = 'ymir_' + action + '_' + JSON.stringify(payload);
+      var _now = Date.now();
+      var _mc = apiGet._memCache[_ck];
+      if (_mc && _now - _mc.ts < _POST_CACHEABLE[action]) return _mc.data;
+      var _cs = sessionStorage.getItem(_ck);
+      if (_cs) {
+        var _cp = JSON.parse(_cs);
+        if (_now - _cp.ts < _POST_CACHEABLE[action]) {
+          apiGet._memCache[_ck] = _cp;
+          return _cp.data;
+        }
+      }
+      if (apiGet._inflight[_ck]) return apiGet._inflight[_ck];
+      var _p = (async function () {
+        try {
+          var data = await _call(action, payload);
+          var entry = { ts: Date.now(), data: data };
+          apiGet._memCache[_ck] = entry;
+          try { sessionStorage.setItem(_ck, JSON.stringify(entry)); } catch(e) {}
+          return data;
+        } finally {
+          delete apiGet._inflight[_ck];
+        }
+      })();
+      apiGet._inflight[_ck] = _p;
+      return _p;
+    } catch(e) { /* fall through to plain _call */ }
+  }
   var invalidates = _INVALIDATES[action];
   if (invalidates) invalidates.forEach(_invalidateApiCache);
   return _call(action, payload);


### PR DESCRIPTION
shared/api.js — new _POST_CACHEABLE map lets apiPost actions that are pure reads share the same memory + sessionStorage cache as apiGet. Same key shape (ymir_<action>_<paramsJSON>) so _invalidateApiCache's prefix scan drops both kinds together, and the existing prefetch({ <Name>: { post: '<action>' } }) form now populates the cache transparently.

Two actions opted in:
- getVolunteerSignups (30s TTL) — admin/members/volunteer pages all reach for it on init; previously each tab/refresh re-fetched.
- getShareTokens (60s TTL) — logbook share-management view.

Matching _INVALIDATES updates so the cache stays correct under writes:
- volunteerSignup, volunteerWithdraw, deleteVolunteerEvent now drop getVolunteerSignups.
- createShareToken, revokeShareToken now drop getShareTokens.