### PR TITLE
Backend handbook caching + gzipped GPX uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — backend handbook caching + gzipped GPX uploads
+
+⚠️ **Backend changes (.gs files) — won't take effect until you push to
+Apps Script.**
+
+`handbook.gs` — `getHandbook_` now consults `cGet_('handbook')` /
+`cPut_('handbook', …)` (default 60 s TTL via the existing CacheService
+helpers). The hydrated handbook payload is one of the heaviest reads
+in the app (joins handbookRoles + members + boat-cat colours +
+contacts + docs + info), and the existing frontend cache is 10 min,
+so a 60 s backend cache catches almost all cold-container reads.
+
+Invalidation is centralised: `saveConfigListItem_` /
+`deleteConfigListItem_` in `alerts.gs` now drop the `handbook` cache
+when their key starts with `handbook` (covers 7 of the 10 handbook
+writers via the helper). The remaining direct writer
+(`reorderHandbookRoles_` in `handbook.gs`) gets an explicit
+`cDel_('handbook')`.
+
+`trips.gs` — `saveTripTrack_` honours an optional `b.compressed === 'gzip'`
+flag and `Utilities.ungzip()`s the bytes before parsing. Backwards
+compatible: clients that don't set the flag keep working as before.
+
+Frontend (`shared/api.js`, `shared/logbook-form.js`,
+`shared/logbook-edit.js`) — new `readFileForUpload(file)` helper uses
+`CompressionStream('gzip')` (browser-native, no library, CSP-safe) on
+`.gpx` / `.kml` uploads to cut payload ~60-70 % before base64 encoding.
+KMZ (already zipped) and photos (already JPEG/PNG) skip compression
+and fall back to the legacy data-URL form. If `CompressionStream`
+isn't available (very old browsers) the helper degrades to the same
+fallback transparently.
+
 ## Unreleased — opt-in cache for read-shaped POSTs
 
 `shared/api.js` — new `_POST_CACHEABLE` map lets `apiPost` actions

--- a/alerts.gs
+++ b/alerts.gs
@@ -124,6 +124,9 @@ function saveConfigListItem_(key, patch) {
   }
   setConfigSheetValue_(key, JSON.stringify(arr));
   cDel_('config');
+  // Handbook tabs read this same store via getHandbook_, which keeps its
+  // own derived cache. Drop it here so handbook* writes invalidate both.
+  if (String(key).indexOf('handbook') === 0) cDel_('handbook');
   return { id: item.id, item: item, created: created, updated: !created };
 }
 
@@ -143,6 +146,7 @@ function deleteConfigListItem_(key, id, opts) {
   }
   setConfigSheetValue_(key, JSON.stringify(arr));
   cDel_('config');
+  if (String(key).indexOf('handbook') === 0) cDel_('handbook');
   return soft ? { deactivated: true } : { deleted: true };
 }
 

--- a/handbook.gs
+++ b/handbook.gs
@@ -16,6 +16,8 @@
 // `handbookInfo_<id>` keys instead of one mega-blob.
 
 function getHandbook_() {
+  const cached = cGet_('handbook');
+  if (cached) return okJ(cached);
   const rolesRaw    = readConfigList_('handbookRoles').filter(_hbActive_);
   const contactsRaw = readConfigList_('handbookContacts').filter(_hbActive_);
   const docs        = readConfigList_('handbookDocs').filter(_hbActive_);
@@ -45,12 +47,14 @@ function getHandbook_() {
     });
   });
 
-  return okJ({
+  const out = {
     roles:    roles.sort(_hbByOrder_),
     contacts: contacts.sort(_hbByOrder_),
     docs:     docs.sort(_hbByOrder_),
     info:     info.sort(_hbByOrder_),
-  });
+  };
+  cPut_('handbook', out);
+  return okJ(out);
 }
 
 function _hbActive_(r) { return r && bool_(r.active); }
@@ -248,6 +252,7 @@ function reorderHandbookRoles_(b) {
   if (updated) {
     setConfigSheetValue_('handbookRoles', JSON.stringify(arr));
     cDel_('config');
+    cDel_('handbook');
   }
   return okJ({ updated: updated });
 }

--- a/shared/api.js
+++ b/shared/api.js
@@ -990,3 +990,52 @@ function warmContainer() {
 
   resetIdleTimer();
 }
+
+// ── File upload helper ───────────────────────────────────────────────────────
+// Reads `file` and returns the upload-ready payload object expected by the
+// `uploadTripFile` / similar Apps Script endpoints:
+//   { fileName, fileData, mimeType[, compressed: 'gzip'] }
+//
+// GPX/KML are XML and shrink ~60-70% under gzip — the browser's
+// CompressionStream gives us that for free, no library required. KMZ is
+// already a zip; re-gzipping a zip gains nothing, so we leave it raw.
+// Photos and everything else fall back to the legacy data-URL form so
+// the backend keeps working untouched. If CompressionStream isn't
+// available (very old browsers) we transparently skip the optimisation.
+//
+// Backend contract: when `compressed: 'gzip'` is present, fileData is
+// raw base64 of gzipped bytes (no `data:` prefix); the handler must
+// `Utilities.ungzip()` before consuming.
+function readFileForUpload(file) {
+  function asDataUrl() {
+    return new Promise(function (resolve, reject) {
+      var r = new FileReader();
+      r.onload  = function (e) { resolve({ fileName: file.name, fileData: e.target.result, mimeType: file.type || 'application/octet-stream' }); };
+      r.onerror = function ()  { reject(new Error('Read error')); };
+      r.readAsDataURL(file);
+    });
+  }
+  var ext = (file.name.split('.').pop() || '').toLowerCase();
+  if ((ext !== 'gpx' && ext !== 'kml') ||
+      typeof CompressionStream === 'undefined' ||
+      typeof file.stream !== 'function') {
+    return asDataUrl();
+  }
+  try {
+    var gz = file.stream().pipeThrough(new CompressionStream('gzip'));
+    return new Response(gz).arrayBuffer().then(function (buf) {
+      var bytes = new Uint8Array(buf), bin = '', CHUNK = 0x8000;
+      for (var i = 0; i < bytes.length; i += CHUNK) {
+        bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+      }
+      return {
+        fileName:   file.name,
+        fileData:   btoa(bin),
+        mimeType:   file.type || 'application/octet-stream',
+        compressed: 'gzip',
+      };
+    }).catch(asDataUrl);
+  } catch (e) {
+    return asDataUrl();
+  }
+}

--- a/shared/logbook-edit.js
+++ b/shared/logbook-edit.js
@@ -172,13 +172,9 @@ function inlineUploadTrack(tripId) {
     if (!file) return;
     showToast(s('logbook.uploadingTrack'));
     try {
-      const fileData = await new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = () => reject(new Error('Read error'));
-        reader.readAsDataURL(file);
-      });
-      const res = await apiPost('uploadTripFile', { fileType: 'track', fileName: file.name, fileData, mimeType: file.type });
+      // readFileForUpload gzips GPX/KML transparently before base64-encoding.
+      const info = await readFileForUpload(file);
+      const res = await apiPost('uploadTripFile', { fileType: 'track', fileName: info.fileName, fileData: info.fileData, mimeType: info.mimeType, compressed: info.compressed });
       if (!res.ok) { showToast(s('logbook.uploadFailed'), 'err'); return; }
       // Save track to trip
       const updates = { trackFileUrl: res.trackFileUrl || '', trackSimplified: res.trackSimplified || '', trackSource: res.trackSource || '' };

--- a/shared/logbook-form.js
+++ b/shared/logbook-form.js
@@ -450,14 +450,17 @@ function handleTrackFile(input){
   if(!file){ _pendingTrack=null; document.getElementById('mTrackStatus').textContent=''; return; }
   const statusEl=document.getElementById('mTrackStatus');
   statusEl.textContent=s('logbook.readingFile');
-  const reader=new FileReader();
-  reader.onload=function(e){
-    _pendingTrack={fileName:file.name, fileData:e.target.result, mimeType:file.type||'application/octet-stream'};
+  // readFileForUpload (in shared/api.js) gzips GPX/KML transparently before
+  // base64-encoding; KMZ and other formats fall through as plain data URLs.
+  readFileForUpload(file).then(function(info){
+    _pendingTrack=info;
     statusEl.textContent=s('logbook.fileReady',{name:file.name});
     statusEl.style.color='var(--accent)';
-  };
-  reader.onerror=function(){ statusEl.textContent=s('logbook.readError'); statusEl.style.color='var(--red)'; _pendingTrack=null; };
-  reader.readAsDataURL(file);
+  }).catch(function(){
+    statusEl.textContent=s('logbook.readError');
+    statusEl.style.color='var(--red)';
+    _pendingTrack=null;
+  });
 }
 
 function handlePhotoFiles(input){
@@ -693,7 +696,7 @@ async function submitManual(){
   let trackFileUrl='', trackSimplified='', trackSource='', distanceNm=distInput;
   if(_pendingTrack){
     try{
-      const tr=await apiPost('uploadTripFile',{fileType:'track',fileName:_pendingTrack.fileName,fileData:_pendingTrack.fileData,mimeType:_pendingTrack.mimeType});
+      const tr=await apiPost('uploadTripFile',{fileType:'track',fileName:_pendingTrack.fileName,fileData:_pendingTrack.fileData,mimeType:_pendingTrack.mimeType,compressed:_pendingTrack.compressed});
       if(tr.ok){
         trackFileUrl=tr.trackFileUrl||'';
         trackSimplified=tr.trackSimplified||'';

--- a/trips.gs
+++ b/trips.gs
@@ -671,6 +671,18 @@ function saveTripTrack_(b) {
     let contentBytes = Utilities.base64Decode(b.fileData.replace(/^data:[^;]+;base64,/, ''));
     let parseFormat  = ext;
 
+    // Frontend may gzip GPX/KML before base64-encoding to cut upload size
+    // ~60-70% (XML compresses well; KMZ is already zipped, photos JPEG).
+    // The flag tells us to ungzip first; without it we treat the bytes raw
+    // for backwards compatibility with un-upgraded clients.
+    if (b.compressed === 'gzip') {
+      try {
+        contentBytes = Utilities.ungzip(Utilities.newBlob(contentBytes, 'application/x-gzip')).getBytes();
+      } catch (e) {
+        return failJ('Failed to decompress upload: ' + e.message);
+      }
+    }
+
     // KMZ = zipped KML — decompress and extract .kml entry
     if (ext === 'kmz') {
       const blobs = Utilities.unzip(Utilities.newBlob(contentBytes, 'application/zip', safeName));


### PR DESCRIPTION
handbook.gs — getHandbook_ now consults cGet_('handbook') / cPut_('handbook', ...) (default 60s TTL). The hydrated handbook payload is one of the heaviest reads (joins handbookRoles + members
+ boat-cat colours + contacts + docs + info); the existing frontend cache is 10 min, so a 60s backend cache catches almost all cold-container reads.

Invalidation is centralised: saveConfigListItem_ / deleteConfigListItem_ in alerts.gs drop the handbook cache when their key starts with 'handbook' (covers 7 of the 10 handbook writers via the helper). The remaining direct writer (reorderHandbookRoles_) gets an explicit cDel_('handbook').

trips.gs — saveTripTrack_ honours an optional b.compressed === 'gzip' flag and Utilities.ungzip()s the bytes before parsing. Backwards compatible: clients that don't set the flag keep working as before.

Frontend (shared/api.js, shared/logbook-form.js, shared/logbook-edit.js) — new readFileForUpload(file) helper uses CompressionStream('gzip') (browser-native, no library, CSP-safe) on .gpx / .kml uploads to cut payload ~60-70% before base64 encoding. KMZ (already zipped) and photos (already JPEG/PNG) skip compression and fall back to the legacy data-URL form. If CompressionStream isn't available the helper degrades to the same fallback transparently.