### PR TITLE
Move handbook cache invalidation out of generic config-list helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,11 @@ in the app (joins handbookRoles + members + boat-cat colours +
 contacts + docs + info), and the existing frontend cache is 10 min,
 so a 60 s backend cache catches almost all cold-container reads.
 
-Invalidation is centralised: `saveConfigListItem_` /
-`deleteConfigListItem_` in `alerts.gs` now drop the `handbook` cache
-when their key starts with `handbook` (covers 7 of the 10 handbook
-writers via the helper). The remaining direct writer
-(`reorderHandbookRoles_` in `handbook.gs`) gets an explicit
-`cDel_('handbook')`.
+Each handbook writer drops the cache itself with an explicit
+`cDel_('handbook')` call before its `okJ` return — no cross-domain
+coupling in the generic `saveConfigListItem_` / `deleteConfigListItem_`
+helpers (which still live in `alerts.gs` for legacy reasons but
+shouldn't grow handbook-specific knowledge).
 
 `trips.gs` — `saveTripTrack_` honours an optional `b.compressed === 'gzip'`
 flag and `Utilities.ungzip()`s the bytes before parsing. Backwards

--- a/alerts.gs
+++ b/alerts.gs
@@ -124,9 +124,6 @@ function saveConfigListItem_(key, patch) {
   }
   setConfigSheetValue_(key, JSON.stringify(arr));
   cDel_('config');
-  // Handbook tabs read this same store via getHandbook_, which keeps its
-  // own derived cache. Drop it here so handbook* writes invalidate both.
-  if (String(key).indexOf('handbook') === 0) cDel_('handbook');
   return { id: item.id, item: item, created: created, updated: !created };
 }
 
@@ -146,7 +143,6 @@ function deleteConfigListItem_(key, id, opts) {
   }
   setConfigSheetValue_(key, JSON.stringify(arr));
   cDel_('config');
-  if (String(key).indexOf('handbook') === 0) cDel_('handbook');
   return soft ? { deactivated: true } : { deleted: true };
 }
 

--- a/handbook.gs
+++ b/handbook.gs
@@ -154,6 +154,7 @@ function saveHandbookContact_(b) {
     sortOrder:  Number(b.sortOrder || 0),
     active:     b.active === false ? false : true,
   });
+  cDel_('handbook');
   return okJ({ id: res.id, saved: true });
 }
 
@@ -161,6 +162,7 @@ function deleteHandbookContact_(b) {
   if (!b.id) return failJ('id required');
   const res = deleteConfigListItem_('handbookContacts', b.id, { soft: true });
   if (!res.deactivated) return failJ('Contact not found', 404);
+  cDel_('handbook');
   return okJ({ ok: true });
 }
 
@@ -220,6 +222,7 @@ function saveHandbookRole_(b) {
     sortOrder:       Number(b.sortOrder || 0),
     active:          b.active === false ? false : true,
   });
+  cDel_('handbook');
   return okJ({ id: res.id, saved: true });
 }
 
@@ -228,6 +231,7 @@ function deleteHandbookRole_(b) {
   // Soft-delete leaves children's parentId intact so the admin can re-parent.
   const res = deleteConfigListItem_('handbookRoles', b.id, { soft: true });
   if (!res.deactivated) return failJ('Role not found', 404);
+  cDel_('handbook');
   return okJ({ ok: true });
 }
 
@@ -275,6 +279,7 @@ function saveHandbookDoc_(b) {
     sortOrder:   Number(b.sortOrder || 0),
     active:      b.active === false ? false : true,
   });
+  cDel_('handbook');
   return okJ({ id: res.id, saved: true });
 }
 
@@ -293,6 +298,7 @@ function deleteHandbookDoc_(b) {
     } catch (e) {}
   }
   deleteConfigListItem_('handbookDocs', b.id, { soft: true });
+  cDel_('handbook');
   return okJ({ ok: true });
 }
 
@@ -411,6 +417,7 @@ function syncHandbookDocs_() {
     added++;
   }
 
+  if (added) cDel_('handbook');
   return okJ({
     ok: true,
     added: added,
@@ -468,6 +475,7 @@ function saveHandbookInfo_(b) {
     sortOrder: Number(b.sortOrder || 0),
     active:    b.active === false ? false : true,
   });
+  cDel_('handbook');
   return okJ({ id: res.id, saved: true });
 }
 
@@ -475,6 +483,7 @@ function deleteHandbookInfo_(b) {
   if (!b.id) return failJ('id required');
   const res = deleteConfigListItem_('handbookInfo', b.id, { soft: true });
   if (!res.deactivated) return failJ('Info section not found', 404);
+  cDel_('handbook');
   return okJ({ ok: true });
 }
 


### PR DESCRIPTION
The previous commit centralised cDel_('handbook') inside saveConfigListItem_ / deleteConfigListItem_ (in alerts.gs, where those generic helpers happen to live) by checking whether the key starts with 'handbook'. That gave the helpers cross-domain knowledge they shouldn't carry — they're meant to be domain-agnostic, used by handbook, activity types, cert defs, boats, locations, etc. Adding handbook-specific lines also spread one feature's logic across two files for no good reason.

Reverted the helpers and added an explicit cDel_('handbook') before the okJ return in each of the 10 handbook writers. The reorderHandbookRoles_ writer (which writes the config sheet directly, not through the helpers) keeps its existing explicit cDel_ from the previous commit.

End state: handbook concerns live in handbook.gs only; alerts.gs is back to just owning its own write helpers.