### PR TITLE
Move config-sheet helpers from alerts.gs to config.gs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — relocate config-sheet helpers to config.gs
+
+⚠️ **Backend changes (.gs files) — won't take effect until pushed to
+Apps Script.**
+
+`alerts.gs` had grown to host a pile of generic config-sheet helpers
+(`getConfigMap_`, `getConfigValue_`, `getConfigSheetValue_`,
+`setConfigSheetValue_`, `readConfigList_`, `saveConfigListItem_`,
+`deleteConfigListItem_`) plus per-section parsers
+(`getFlagConfigFromMap_`, `getCertDefsFromMap_`,
+`getCertCategoriesFromMap_`) — all unrelated to alerts. They lived
+there because that's where the alerts feature first introduced them,
+not because they belonged.
+
+Moved all 10 to the top of `config.gs`, grouped in three sections:
+sheet primitives, config-list CRUD, per-section parsers. `alerts.gs`
+keeps only `getAlertConfig_` / `getAlertConfigFromMap_` (genuinely
+alert-specific) and the `requireField_` / `requireMember_` validators
+(generic but only defined here, never imported, leaving for separate
+dead-code cleanup).
+
+Pure relocation — function bodies untouched, no behaviour change.
+The Apps Script global namespace is flat across all `.gs` files so
+every existing call site keeps working.
+
+Also updated `CLAUDE.md`'s file-layout note for `config.gs`.
+
 ## Unreleased — backend handbook caching + gzipped GPX uploads
 
 ⚠️ **Backend changes (.gs files) — won't take effect until you push to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 - `members.gs` — member CRUD, sessions API, preferences, daily log
 - `maintenance.gs` — maintenance projects
 - `payroll.gs` — punch clock, pay periods, launamiðar XML
-- `config.gs` — config bundle + certifications
+- `config.gs` — config-sheet primitives (`getConfigMap_`, `getConfigSheetValue_`, `setConfigSheetValue_`), config-list CRUD (`saveConfigListItem_`, `deleteConfigListItem_`, `readConfigList_`), per-section parsers (`getCertDefsFromMap_`, `getFlagConfigFromMap_`, …), `getConfig_` bundle + certifications
 - `incidents.gs` — incident reports
 - `checkouts.gs` — checkouts, reservation slots, crews
 - `trips.gs` — trips, handshake confirmations, file uploads (GPS tracks + photos)

--- a/alerts.gs
+++ b/alerts.gs
@@ -16,22 +16,6 @@ function getAlertConfig_() {
   } catch (e) { return defaults; }
 }
 
-// Read the entire config sheet once and return a key→value map
-function getConfigMap_() {
-  let sheet;
-  try { sheet = getSheet_('config'); } catch (e) { return {}; }
-  if (sheet.getLastRow() < 2) return {};
-  const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
-  const map = {};
-  data.forEach(r => { map[String(r[0]).trim()] = String(r[1]).trim(); });
-  return map;
-}
-
-function getConfigValue_(key, map) {
-  const v = map[key];
-  return v !== undefined ? v : null;
-}
-
 function getAlertConfigFromMap_(cfgMap) {
   const raw = getConfigValue_('overdueAlerts', cfgMap);
   const defaults = {
@@ -44,106 +28,6 @@ function getAlertConfigFromMap_(cfgMap) {
     const p = JSON.parse(raw);
     return { ...defaults, ...p, channels: { ...defaults.channels, ...(p.channels || {}) } };
   } catch (e) { return defaults; }
-}
-
-function getFlagConfigFromMap_(cfgMap) {
-  const raw = getConfigValue_('flagConfig', cfgMap);
-  if (!raw) return null;
-  try { return JSON.parse(raw); } catch (e) { return null; }
-}
-
-function getCertDefsFromMap_(cfgMap) {
-  const raw = getConfigValue_('certDefs', cfgMap);
-  if (!raw) return [];
-  try { return normalizeCertDefsRaw_(JSON.parse(raw)); } catch (e) { return []; }
-}
-
-function getCertCategoriesFromMap_(cfgMap) {
-  const raw = getConfigValue_('certCategories', cfgMap);
-  if (!raw) return [];
-  try { return normalizeCertCategoriesRaw_(JSON.parse(raw)); } catch (e) { return []; }
-}
-
-function getConfigSheetValue_(key) {
-  let sheet;
-  try { sheet = getSheet_('config'); } catch (e) { return null; }
-  if (sheet.getLastRow() < 2) return null;
-  const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
-  const row = data.find(r => String(r[0]).trim() === key);
-  return row ? String(row[1]).trim() : null;
-}
-
-function setConfigSheetValue_(key, value) {
-  let sheet;
-  try { sheet = getSheet_('config'); } catch (e) {
-    sheet = ss_().insertSheet('config');
-    sheet.getRange(1, 1, 1, 2).setValues([['key', 'value']]);
-  }
-  const lastRow = sheet.getLastRow();
-  if (lastRow >= 2) {
-    const keys = sheet.getRange(2, 1, lastRow - 1, 1).getValues().map(r => String(r[0]).trim());
-    const idx = keys.indexOf(key);
-    if (idx !== -1) { sheet.getRange(idx + 2, 2).setValue(literalWrite_(value)); return; }
-  }
-  sheet.appendRow([key, literalWrite_(value)]);
-}
-
-// ── Config-list CRUD helpers ──────────────────────────────────────────────────
-// Many admin entities (activity types, cert defs, boat categories, locations,
-// volunteer events, etc.) are stored as JSON arrays under a single config key.
-// These helpers collapse the save/delete boilerplate: parse → find-by-id →
-// merge-or-push → stringify → cache-clear.
-//
-//   saveConfigListItem_('activity_types', { id, ...fields })
-//     → inserts if id empty/missing; merges into existing row otherwise.
-//       Returns { id, item, created|updated: true }.
-//
-//   deleteConfigListItem_('activity_types', id, { soft: true })
-//     → hard-removes by default. With { soft: true } sets active=false instead.
-//       Returns { deleted: true } (or { deactivated: true } for soft delete).
-function readConfigList_(key) {
-  try { return JSON.parse(getConfigSheetValue_(key) || '[]') || []; }
-  catch (e) { return []; }
-}
-
-function saveConfigListItem_(key, patch) {
-  if (!key) throw new Error('saveConfigListItem_: key required');
-  const arr = readConfigList_(key);
-  const ts  = now_();
-  const idx = patch && patch.id ? arr.findIndex(x => x && x.id === patch.id) : -1;
-  let item, created = false;
-  if (idx >= 0) {
-    item = Object.assign(arr[idx], patch, { updatedAt: ts });
-    arr[idx] = item;
-  } else {
-    // id last so an empty-string `patch.id` can't clobber the freshly-minted uid.
-    var newId = (patch && patch.id) || uid_();
-    item = Object.assign({}, patch || {}, { id: newId, createdAt: ts, updatedAt: ts });
-    arr.push(item);
-    created = true;
-  }
-  setConfigSheetValue_(key, JSON.stringify(arr));
-  cDel_('config');
-  return { id: item.id, item: item, created: created, updated: !created };
-}
-
-function deleteConfigListItem_(key, id, opts) {
-  if (!key || !id) throw new Error('deleteConfigListItem_: key and id required');
-  const soft = !!(opts && opts.soft);
-  let arr = readConfigList_(key);
-  if (soft) {
-    const idx = arr.findIndex(x => x && x.id === id);
-    if (idx < 0) return { deleted: false };
-    arr[idx].active = false;
-    arr[idx].updatedAt = now_();
-  } else {
-    const before = arr.length;
-    arr = arr.filter(x => !x || x.id !== id);
-    if (arr.length === before) return { deleted: false };
-  }
-  setConfigSheetValue_(key, JSON.stringify(arr));
-  cDel_('config');
-  return soft ? { deactivated: true } : { deleted: true };
 }
 
 // ── Validation helpers ────────────────────────────────────────────────────────

--- a/config.gs
+++ b/config.gs
@@ -2,6 +2,135 @@
 // CONFIG  —  getConfig bundles everything; boats + locations stored as JSON rows
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// ── Config-sheet primitives ──────────────────────────────────────────────────
+// The `config` sheet is a key/value store: column A holds the key, column B
+// the (typically JSON) value. Most domain config (boats, locations, certDefs,
+// activityTypes, flagConfig, …) lives in here under one row per key.
+
+// Read the entire config sheet once and return a key→value map.
+function getConfigMap_() {
+  let sheet;
+  try { sheet = getSheet_('config'); } catch (e) { return {}; }
+  if (sheet.getLastRow() < 2) return {};
+  const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
+  const map = {};
+  data.forEach(r => { map[String(r[0]).trim()] = String(r[1]).trim(); });
+  return map;
+}
+
+function getConfigValue_(key, map) {
+  const v = map[key];
+  return v !== undefined ? v : null;
+}
+
+// One-shot read of a single config key (re-reads the sheet — prefer
+// getConfigMap_ + getConfigValue_ when reading several keys in one request).
+function getConfigSheetValue_(key) {
+  let sheet;
+  try { sheet = getSheet_('config'); } catch (e) { return null; }
+  if (sheet.getLastRow() < 2) return null;
+  const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
+  const row = data.find(r => String(r[0]).trim() === key);
+  return row ? String(row[1]).trim() : null;
+}
+
+function setConfigSheetValue_(key, value) {
+  let sheet;
+  try { sheet = getSheet_('config'); } catch (e) {
+    sheet = ss_().insertSheet('config');
+    sheet.getRange(1, 1, 1, 2).setValues([['key', 'value']]);
+  }
+  const lastRow = sheet.getLastRow();
+  if (lastRow >= 2) {
+    const keys = sheet.getRange(2, 1, lastRow - 1, 1).getValues().map(r => String(r[0]).trim());
+    const idx = keys.indexOf(key);
+    if (idx !== -1) { sheet.getRange(idx + 2, 2).setValue(literalWrite_(value)); return; }
+  }
+  sheet.appendRow([key, literalWrite_(value)]);
+}
+
+// ── Config-list CRUD helpers ──────────────────────────────────────────────────
+// Many admin entities (activity types, cert defs, boat categories, locations,
+// volunteer events, etc.) are stored as JSON arrays under a single config key.
+// These helpers collapse the save/delete boilerplate: parse → find-by-id →
+// merge-or-push → stringify → cache-clear.
+//
+//   saveConfigListItem_('activity_types', { id, ...fields })
+//     → inserts if id empty/missing; merges into existing row otherwise.
+//       Returns { id, item, created|updated: true }.
+//
+//   deleteConfigListItem_('activity_types', id, { soft: true })
+//     → hard-removes by default. With { soft: true } sets active=false instead.
+//       Returns { deleted: true } (or { deactivated: true } for soft delete).
+function readConfigList_(key) {
+  try { return JSON.parse(getConfigSheetValue_(key) || '[]') || []; }
+  catch (e) { return []; }
+}
+
+function saveConfigListItem_(key, patch) {
+  if (!key) throw new Error('saveConfigListItem_: key required');
+  const arr = readConfigList_(key);
+  const ts  = now_();
+  const idx = patch && patch.id ? arr.findIndex(x => x && x.id === patch.id) : -1;
+  let item, created = false;
+  if (idx >= 0) {
+    item = Object.assign(arr[idx], patch, { updatedAt: ts });
+    arr[idx] = item;
+  } else {
+    // id last so an empty-string `patch.id` can't clobber the freshly-minted uid.
+    var newId = (patch && patch.id) || uid_();
+    item = Object.assign({}, patch || {}, { id: newId, createdAt: ts, updatedAt: ts });
+    arr.push(item);
+    created = true;
+  }
+  setConfigSheetValue_(key, JSON.stringify(arr));
+  cDel_('config');
+  return { id: item.id, item: item, created: created, updated: !created };
+}
+
+function deleteConfigListItem_(key, id, opts) {
+  if (!key || !id) throw new Error('deleteConfigListItem_: key and id required');
+  const soft = !!(opts && opts.soft);
+  let arr = readConfigList_(key);
+  if (soft) {
+    const idx = arr.findIndex(x => x && x.id === id);
+    if (idx < 0) return { deleted: false };
+    arr[idx].active = false;
+    arr[idx].updatedAt = now_();
+  } else {
+    const before = arr.length;
+    arr = arr.filter(x => !x || x.id !== id);
+    if (arr.length === before) return { deleted: false };
+  }
+  setConfigSheetValue_(key, JSON.stringify(arr));
+  cDel_('config');
+  return soft ? { deactivated: true } : { deleted: true };
+}
+
+// ── Config-bundle parsers ─────────────────────────────────────────────────────
+// Pull a specific section out of an already-fetched cfgMap. Used by
+// getConfig_ to assemble its bundle without re-reading the config sheet for
+// each section, and by domain endpoints (checkouts.gs, public.gs) that need
+// one section without paying for the full bundle.
+
+function getFlagConfigFromMap_(cfgMap) {
+  const raw = getConfigValue_('flagConfig', cfgMap);
+  if (!raw) return null;
+  try { return JSON.parse(raw); } catch (e) { return null; }
+}
+
+function getCertDefsFromMap_(cfgMap) {
+  const raw = getConfigValue_('certDefs', cfgMap);
+  if (!raw) return [];
+  try { return normalizeCertDefsRaw_(JSON.parse(raw)); } catch (e) { return []; }
+}
+
+function getCertCategoriesFromMap_(cfgMap) {
+  const raw = getConfigValue_('certCategories', cfgMap);
+  if (!raw) return [];
+  try { return normalizeCertCategoriesRaw_(JSON.parse(raw)); } catch (e) { return []; }
+}
+
 // Cached projection of scheduled_events into the two slices getConfig_ needs:
 // volunteer rows (for the volunteerEvents DTO list) and cancelled-activity ids
 // (for the daily-log virtual-suppression list). The 60s getConfig cache covers


### PR DESCRIPTION
alerts.gs had grown to host a pile of generic config-sheet helpers that lived there only because that's where the alerts feature first introduced them. Moved 10 functions to config.gs:

  Sheet primitives:
    getConfigMap_, getConfigValue_,
    getConfigSheetValue_, setConfigSheetValue_

  Config-list CRUD:
    readConfigList_, saveConfigListItem_, deleteConfigListItem_

  Per-section parsers:
    getFlagConfigFromMap_, getCertDefsFromMap_, getCertCategoriesFromMap_

Pure relocation — bodies untouched, no behaviour change. The Apps Script global namespace is flat across all .gs files so every existing call site keeps working.

alerts.gs now contains only alert-specific code
(getAlertConfig_, getAlertConfigFromMap_, getOverdueAlerts_, silenceAlert_, …) plus the requireField_ / requireMember_ validators (generic but only defined here, no callers — left in place for separate dead-code cleanup).

CLAUDE.md's file-layout line for config.gs updated to reflect the broader ownership.