### PR TITLE
Login getConfig piggyback + scheduled-events config-cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — login getConfig piggyback + scheduled-events config-cache fix
+
+⚠️ **Backend changes (.gs files) — won't take effect until pushed to
+Apps Script.**
+
+Two follow-ups to the request-batching / stale-while-revalidate work:
+
+**Login piggyback.** `loginMember_` and `loginWithGoogle_` now embed a
+server-rendered `getConfig` snapshot (`config: _loginConfigPiggyback_()`)
+in their response. The login client (`login/login.js`) seeds it into
+the shared API cache via the new `seedApiCache(action, params, data)`
+helper in `shared/api.js`, so the destination portal's first
+`apiGet('getConfig')` is an instant cache hit instead of paying a full
+Apps Script round-trip during the post-login redirect. Free
+server-side after the first warm `CacheService` hit.
+
+**Scheduled-events cache invalidation.** `sched_upsert_`, `sched_cancel_`,
+and `sched_hardDelete_` in `scheduling.gs` were dropping only the
+`'sched_events_for_config'` sub-cache, but `getConfig_` short-circuits
+on its own `'config'` cache before ever consulting the sub-cache — so
+volunteer-event saves (and class-occurrence cancel/override/restore
+which all flow through these helpers) could serve up to 60s of stale
+config to the next reader. Each writer now also calls `cDel_('config')`.
+
 ## Unreleased — request batching + stale-while-revalidate
 
 ⚠️ **Backend changes (.gs files) — won't take effect until pushed to

--- a/login/login.js
+++ b/login/login.js
@@ -161,6 +161,9 @@ async function handleGoogleCredential(resp) {
     if (data.sessionToken) {
       setSession(data.sessionToken, data.expiresAt || null, data.sessionId || null);
     }
+    // Login response carries an embedded getConfig snapshot — seed the cache
+    // so the destination portal's first apiGet('getConfig') is an instant hit.
+    if (data.config) seedApiCache('getConfig', {}, data.config);
     user.usingDefaultPassword = !!data.usingDefaultPassword;
     if (data.usingDefaultPassword) {
       // Rare path: a Google-linked member whose password was admin-reset.
@@ -244,6 +247,9 @@ async function doLogin() {
     if (data.sessionToken) {
       setSession(data.sessionToken, data.expiresAt || null, data.sessionId || null);
     }
+    // Login response carries an embedded getConfig snapshot — seed the cache
+    // so the destination portal's first apiGet('getConfig') is an instant hit.
+    if (data.config) seedApiCache('getConfig', {}, data.config);
 
     // Flag the user record so downstream pages can nag about the default
     // password until it's been changed.

--- a/members.gs
+++ b/members.gs
@@ -107,6 +107,17 @@ function validateMember_(kennitala, caller) {
 // member's initials (case-insensitive). Issues a session token on success
 // and enforces a 5-per-15-min rate limit per kennitala.
 // Response shape: { member, wards, usingDefaultPassword, sessionToken, expiresAt }
+// Bundle a server-rendered getConfig snapshot into the login response so the
+// destination portal's first apiGet('getConfig') is a cache hit on the client
+// (saves one full Apps Script round-trip during the post-login redirect).
+// Wraps the existing CacheService-backed getConfig_ so this is essentially
+// free server-side after the first warm hit. Returns null on any failure —
+// the client just falls back to its normal prefetch path.
+function _loginConfigPiggyback_() {
+  try { return JSON.parse(getConfig_().getContent()); }
+  catch (e) { return null; }
+}
+
 function loginMember_(b) {
   const username = String((b && b.username) || '').trim();
   const password = String((b && b.password) || '');
@@ -145,6 +156,7 @@ function loginMember_(b) {
     sessionToken: session.token,
     expiresAt: session.expiresAt,
     sessionId: session.id,
+    config: _loginConfigPiggyback_(),
   });
 }
 
@@ -304,6 +316,7 @@ function loginWithGoogle_(b) {
     sessionToken: session.token,
     expiresAt: session.expiresAt,
     sessionId: session.id,
+    config: _loginConfigPiggyback_(),
   });
 }
 

--- a/scheduling.gs
+++ b/scheduling.gs
@@ -184,6 +184,11 @@ function sched_upsert_(ev) {
     insertRow_('scheduledEvents', payload);
   }
   cDel_('sched_events_for_config');
+  // The outer 'config' cache embeds the volunteerEvents projection
+  // (cancelled-activity tombstones too), so a scheduled-events write must
+  // drop it too — otherwise getConfig_ short-circuits on its own cache
+  // before ever consulting the freshly-cleared sub-cache.
+  cDel_('config');
   return sched_getById_(id);
 }
 
@@ -199,6 +204,7 @@ function sched_cancel_(id, updatedBy) {
     updatedBy: updatedBy || '',
   });
   cDel_('sched_events_for_config');
+  cDel_('config');
   return true;
 }
 
@@ -208,7 +214,10 @@ function sched_cancel_(id, updatedBy) {
 function sched_hardDelete_(id) {
   if (!id) return false;
   var ok = deleteRow_('scheduledEvents', 'id', id);
-  if (ok) cDel_('sched_events_for_config');
+  if (ok) {
+    cDel_('sched_events_for_config');
+    cDel_('config');
+  }
   return ok;
 }
 

--- a/shared/api.js
+++ b/shared/api.js
@@ -108,6 +108,22 @@ function _refreshInBackground(ck, action, params) {
   p.catch(function () {});
 }
 
+// Public: seed the cache for an action+params with a server-supplied payload
+// so the next apiGet/apiPost is a hit. Used by the login response piggyback
+// (loginMember bundles a getConfig snapshot to skip the post-redirect round
+// trip), and available to any flow that already has fresh data in hand —
+// websocket push, server-rendered hydration, etc. Same key shape as apiGet
+// so _invalidateApiCache drops it on the next write.
+function seedApiCache(action, params, data) {
+  if (!action || data == null) return;
+  try {
+    var ck = 'ymir_' + action + '_' + JSON.stringify(params || {});
+    var entry = { ts: Date.now(), data: data };
+    apiGet._memCache[ck] = entry;
+    try { sessionStorage.setItem(ck, JSON.stringify(entry)); } catch (e) {}
+  } catch (e) {}
+}
+
 // Drop every cached entry (memory + sessionStorage) for the given action.
 // Called by apiPost after a write so the next read sees fresh data. Both
 // tiers use the same `ymir_<action>_<paramsJSON>` key shape.


### PR DESCRIPTION
Two follow-ups to the request-batching / SWR work:

Login piggyback. loginMember_ and loginWithGoogle_ now embed a server-rendered getConfig snapshot in their response; login.js seeds it into the API cache via a new seedApiCache(action, params, data) helper. The destination portal's first apiGet('getConfig') is an instant cache hit instead of paying a full Apps Script round-trip during the post-login redirect. Free server-side after the first warm CacheService hit.

Scheduled-events cache invalidation. sched_upsert_, sched_cancel_, and sched_hardDelete_ were dropping only 'sched_events_for_config', but getConfig_ short-circuits on its own 'config' cache before consulting the sub-cache — so volunteer-event saves and class-occurrence cancel/override/restore could serve up to 60s of stale config. Each writer now also drops 'config'.