### PR TITLE
Group-link picker: post-facto linking on past daily logs

### DIFF
--- a/checkouts.gs
+++ b/checkouts.gs
@@ -2,12 +2,23 @@
 // CHECKOUTS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-function getActiveCheckouts_() {
+function getActiveCheckouts_(b) {
   // Compare against createdAt's UTC date since createdAt is stored as UTC ISO
   // via now_(); both operands must share the same reference frame.
   const todayUtc = now_().slice(0, 10);
+  const date = b && b.date ? String(b.date).slice(0, 10) : '';
   const all = readAll_('checkouts');
-  const result = all.filter(c => c.status === 'out' || (c.status === 'in' && (c.createdAt || '').slice(0, 10) === todayUtc));
+  // When a date is passed and it isn't today, return every checkout whose
+  // createdAt falls on that date — the daily-log "Link group checkout"
+  // picker uses this to allow post-facto linking on past daily logs. Today
+  // (or no date) keeps the original "active" semantics: currently-out plus
+  // anything checked back in earlier today.
+  let result;
+  if (date && date !== todayUtc) {
+    result = all.filter(c => (c.createdAt || '').slice(0, 10) === date);
+  } else {
+    result = all.filter(c => c.status === 'out' || (c.status === 'in' && (c.createdAt || '').slice(0, 10) === todayUtc));
+  }
   let memberMap = {};
   try { memberMap = getMemberMap_(); } catch (e) { }
   const enriched = result.map(c => {

--- a/code.gs
+++ b/code.gs
@@ -1318,7 +1318,7 @@ function route_(action, b, caller) {
     case 'createIncident': return createIncident_(b);
     case 'resolveIncident': return resolveIncident_(b);
     case 'addIncidentNote': return addIncidentNote_(b);
-    case 'getActiveCheckouts': return getActiveCheckouts_();
+    case 'getActiveCheckouts': return getActiveCheckouts_(b);
     case 'saveCheckout': return saveCheckout_(b, caller);
     case 'checkIn': return checkIn_(b, caller);
     case 'deleteCheckout': return deleteCheckout_(b.id);

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -1081,13 +1081,16 @@ async function openGroupLinkPicker() {
   // Always pull a fresh list rather than relying on loadTodayTrips' side
   // effect — past/future daily-log views never populate _activeCheckouts,
   // and the picker should also surface group sails that have already been
-  // checked back in today (so retroactive linking works).
+  // checked back in today (so retroactive linking works). For non-today
+  // views, pass viewDate so the backend returns every checkout from that
+  // day (any status) — required for post-facto linking.
+  const params = isToday() ? {} : { date: viewDate };
   try {
-    const r = await apiGet('getActiveCheckouts');
+    const r = await apiGet('getActiveCheckouts', params);
     _groupLinkPickerCache = r.checkouts || [];
-    window._activeCheckouts = _groupLinkPickerCache;
+    if (isToday()) window._activeCheckouts = _groupLinkPickerCache;
   } catch (e) {
-    _groupLinkPickerCache = window._activeCheckouts || [];
+    _groupLinkPickerCache = isToday() ? (window._activeCheckouts || []) : [];
   }
   _renderGroupLinkPicker();
   openModal('groupLinkModal');


### PR DESCRIPTION
getActiveCheckouts_ was hard-coded to today's active scope (status='out' plus today's checked-in), so the daily-log "Link group checkout" picker returned an empty list whenever the user was viewing yesterday or earlier — even when supervisor trips for yesterday's group sail were visible right above the activity card.

Threaded an optional `date` param through getActiveCheckouts_. When present and not today, returns every checkout whose createdAt falls on that date (any status), so the picker can reach back to past group sails for retroactive linking. Today (or no date) keeps the original "active" semantics — member portal, login prefetch, staff page all unaffected.

The picker passes viewDate when isToday() is false; when it IS today, no params, behaviour identical to before. window._activeCheckouts is only populated from today's response (that's what loadTodayTrips relies on; past-date responses shouldn't pollute it).

⚠️ Touches checkouts.gs and code.gs — backend deploy required.

https://claude.ai/code/session_01PpDpjBmxfT6Cm3DgSQVMVX