### PR TITLE
Sheet helpers: trim headers + warn on duplicate columns

### DIFF
--- a/_setup.gs
+++ b/_setup.gs
@@ -190,14 +190,32 @@ function ensureTab_(ss, tabName, cols) {
     Logger.log('Created tab: ' + tabName + ' (' + cols.length + ' columns)');
     return sheet;
   }
-  // Tab exists — add any missing columns
-  var existing = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0].map(String);
+  // Tab exists — add any missing columns. Trim existing headers so a stray
+  // whitespace edit doesn't trick us into appending a duplicate column with
+  // the same logical name (writes go to indexOf-first, reads to last —
+  // silent divergence). Same trim applied to runtime reads in
+  // getSheetData_, so this stays in sync.
+  var existing = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0]
+    .map(function (h) { return String(h).trim(); });
+  // Loud-warn duplicates so a recurrence is visible in the migration log.
+  var seen = {}, dupes = [];
+  existing.forEach(function (h) {
+    if (!h) return;
+    if (seen[h]) { if (dupes.indexOf(h) === -1) dupes.push(h); }
+    else seen[h] = true;
+  });
+  if (dupes.length) {
+    Logger.log('⚠ Duplicate headers in tab "' + tabName + '": ' + dupes.join(', ')
+      + ' — writes hit indexOf(first), reads keep last; clean the sheet manually.');
+  }
   cols.forEach(function(col) {
-    if (!existing.includes(col)) {
+    var c = String(col == null ? '' : col).trim();
+    if (!c) return;
+    if (!existing.includes(c)) {
       var nextCol = existing.length + 1;
-      sheet.getRange(1, nextCol).setValue(col);
-      existing.push(col);
-      Logger.log('Added column "' + col + '" to tab "' + tabName + '"');
+      sheet.getRange(1, nextCol).setValue(c);
+      existing.push(c);
+      Logger.log('Added column "' + c + '" to tab "' + tabName + '"');
     }
   });
   return sheet;

--- a/code.gs
+++ b/code.gs
@@ -1034,7 +1034,31 @@ function getSheetData_(tabKey) {
   if (_sheetCache_[tabKey]) return _sheetCache_[tabKey];
   const sheet = getSheet_(tabKey);
   const data = sheet.getDataRange().getValues();
-  const headers = (data[0] || []).map(String);
+  // Trim header strings — a stray trailing space on a manually edited cell
+  // would otherwise break headers.indexOf() / .includes() and trick
+  // addColIfMissing_ into appending a duplicate column with the same
+  // logical name. Trim happens once here so every downstream caller sees
+  // clean keys.
+  const headers = (data[0] || []).map(function (h) { return String(h).trim(); });
+  // Loudly flag duplicate headers — they cause silent write/read divergence:
+  // updateRow_ / findOne_ / addColIfMissing_ key off the first match
+  // (indexOf), but readAll_'s `headers.forEach((h,i) => o[h] = …)` lets the
+  // last occurrence overwrite the first into the same JS key. So writes hit
+  // one column and reads return the other. Surface once per cache load
+  // (cached by getSheetData_ itself) so the warning fires when the data is
+  // actually read but doesn't spam every individual call.
+  var _seen = {}, _dupes = [];
+  for (var _i = 0; _i < headers.length; _i++) {
+    var _h = headers[_i];
+    if (!_h) continue;
+    if (_seen[_h]) { if (_dupes.indexOf(_h) === -1) _dupes.push(_h); }
+    else _seen[_h] = true;
+  }
+  if (_dupes.length) {
+    Logger.log('⚠ Duplicate headers in tab "' + (TABS_[tabKey] || tabKey) + '": '
+      + _dupes.join(', ')
+      + ' — writes hit indexOf(first), reads keep the last; clean the sheet.');
+  }
   // Raw, unfiltered — updateRow_'s (i + 2) arithmetic depends on this array
   // matching the actual sheet row positions. readAll_ applies the
   // trailing-blank filter in its mapping step.
@@ -1096,9 +1120,14 @@ function insertRow_(tabKey, obj) {
 }
 
 function addColIfMissing_(tabKey, colName) {
+  // Trim defensively — every sheet read trims headers (see getSheetData_),
+  // so the comparison would mismatch if the caller passed a name with stray
+  // whitespace; same for the value we'd write into the new cell.
+  var col = String(colName == null ? '' : colName).trim();
+  if (!col) return;
   const c = getSheetData_(tabKey);
-  if (!c.headers.includes(colName)) {
-    c.sheet.getRange(1, c.headers.length + 1).setValue(colName);
+  if (!c.headers.includes(col)) {
+    c.sheet.getRange(1, c.headers.length + 1).setValue(col);
     // Force the pending write to be committed before we re-read the sheet,
     // otherwise getDataRange().getValues() in the next getSheetData_ call
     // may return stale data that doesn't include the new column header.


### PR DESCRIPTION
A stray trailing space (or capitalization drift) on a manually edited sheet header was enough to fool addColIfMissing_'s headers.includes(...) check — it'd silently append a fresh column with the "missing" name. Two columns with the same logical name then cause silent write/read divergence: updateRow_ / findOne_ / addColIfMissing_ key off indexOf(first) for writes, but readAll_'s
`headers.forEach((h,i) => o[h] = …)` lets the LAST occurrence overwrite the first into the same JS key on reads. Net effect: writes land in one column, reads return the other.

Trim every header on read in getSheetData_, plus a defensive trim in addColIfMissing_'s argument so the comparison and the new-cell value stay consistent. Same trim applied in ensureTab_'s setupSpreadsheet path so re-runs of the migration don't recreate the bug.

Loud-warn (Logger.log) when duplicates are detected so a recurrence shows up in the execution log without spamming every request — fires once per cache load (getSheetData_) or once per migration run (ensureTab_).

Doesn't auto-clean existing duplicates; surfacing the warning is deliberate so the operator knows to manually delete the offending column (auto-deletion would risk data loss since which column holds the canonical value depends on the row's write history).

⚠️ Touches code.gs and _setup.gs — backend deploy required.

https://claude.ai/code/session_01PpDpjBmxfT6Cm3DgSQVMVX