### PR TITLE
Activities: collapse kind enum to signupRequired boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — activities vocabulary cleanup (kind → signupRequired)
+
+First step of a broader vocabulary alignment around scheduled activities.
+The `scheduled_events` row's `kind` column ('volunteer' | 'activity') was
+really a yes/no question — "is this signup-tracked?" — masquerading as a
+two-value enum. Replaces it with a `signupRequired` boolean. The `kind`
+column stays on the row during the transition and is written in lockstep
+by `sched_rowShape_`, so any external/legacy reader still sees a valid
+discriminator until it migrates.
+
+Schema: `_setup.gs` adds `signupRequired` to the `scheduled_events`
+column list and runs an idempotent backfill on `setupSpreadsheet()` —
+empty cells are derived from the existing `kind` value (`'volunteer'` →
+`true`, otherwise `false`).
+
+Backend: `sched_parseRow_` emits both `signupRequired` (canonical) and
+`kind` (legacy mirror); `sched_rowShape_` accepts either and writes both.
+Internal predicates in `scheduling.gs`, `config.gs`, `members.gs`,
+`checkouts.gs`, and `public.gs` switch to `signupRequired`. Write callers
+(`saveGroupCheckout`, `cancelClassOccurrence`, `rescheduleActivity`,
+volunteer-event upserts, daily-log activity sync) now pass
+`signupRequired: true|false` as the canonical field.
+
+Frontend: `shared/scheduled-event.js` accepts `opts.signupRequired` and
+emits both fields on the normalized object. `admin/scheduling.js` row
+predicates switch to `ev.signupRequired`. No UI/UX change.
+
+Vocabulary direction (still to land in follow-ups): rename
+`scheduled_events` JS identifiers to `activities`, rename `activity_types`
+to `activity_templates`, drop the legacy `kind` column once all readers
+have migrated.
+
 ## Unreleased — staff Logbook Review: activity-log filter section
 
 Adds a third section to the staff Logbook Review page (below trips

--- a/_setup.gs
+++ b/_setup.gs
@@ -151,13 +151,21 @@ var SCHEMA_ = {
   volunteer_signups: [
     'id','eventId','roleId','kennitala','name','signedUpAt',
   ],
-  // Unified scheduled-events table — single source of truth for volunteer
-  // events and daily-log activities.
-  //   kind   ∈ 'volunteer' | 'activity'
+  // Unified activities table — single source of truth for every concrete
+  // occurrence at the club. One row per activity instance; an activity may
+  // be templated from an `activity_types` (a.k.a. activity-template) row or
+  // authored ad-hoc.
+  //   signupRequired ∈ true | false  — true means signup-tracked (volunteer
+  //                                    portal surfaces it with roles/leader);
+  //                                    false means a plain activity (daily-log
+  //                                    renderer + midnight materializer).
+  //   kind ∈ 'volunteer' | 'activity' — legacy discriminator. Kept alongside
+  //                                    signupRequired during the transition;
+  //                                    new readers should consult signupRequired.
   //   status ∈ 'upcoming' | 'completed' | 'cancelled' | 'orphaned'
   //   source ∈ 'bulk' | 'calendar' | 'manual' | 'daily-log'
   scheduled_events: [
-    'id','kind','status','source',
+    'id','kind','signupRequired','status','source',
     'date','endDate','startTime','endTime',
     'activityTypeId','subtypeId','subtypeName',
     'title','titleIS','notes','notesIS',
@@ -244,6 +252,40 @@ function setupSpreadsheet() {
       Logger.log('Seeded config key: ' + k);
     }
   });
+
+  // ── Migrations ─────────────────────────────────────────────────────────────
+  // Backfill signupRequired on scheduled_events from the legacy `kind` column.
+  // Idempotent: only writes when signupRequired is empty/missing on a row.
+  // Safe to run repeatedly; no-op once every row carries the boolean.
+  try {
+    var seSheet = ss.getSheetByName('scheduled_events');
+    if (seSheet && seSheet.getLastRow() >= 2) {
+      var headers = seSheet.getRange(1, 1, 1, seSheet.getLastColumn()).getValues()[0]
+        .map(function (h) { return String(h).trim(); });
+      var kindCol = headers.indexOf('kind');
+      var sigCol  = headers.indexOf('signupRequired');
+      if (kindCol >= 0 && sigCol >= 0) {
+        var nRows = seSheet.getLastRow() - 1;
+        var range = seSheet.getRange(2, 1, nRows, headers.length);
+        var values = range.getValues();
+        var changed = 0;
+        for (var i = 0; i < values.length; i++) {
+          var existing = values[i][sigCol];
+          if (existing === true || existing === false) continue;
+          if (existing === 'TRUE' || existing === 'FALSE') continue;
+          var kindVal = String(values[i][kindCol] || '').trim().toLowerCase();
+          values[i][sigCol] = (kindVal === 'volunteer');
+          changed++;
+        }
+        if (changed > 0) {
+          range.setValues(values);
+          Logger.log('Migrated signupRequired on ' + changed + ' scheduled_events row(s).');
+        }
+      }
+    }
+  } catch (e) {
+    Logger.log('signupRequired backfill skipped: ' + e.message);
+  }
 
   Logger.log('setupSpreadsheet complete. Tabs processed: ' + results.join(', '));
   return 'Done — tabs processed: ' + results.join(', ');

--- a/admin/scheduling.js
+++ b/admin/scheduling.js
@@ -118,30 +118,31 @@ function _upcomingRowHtml(ev, L) {
     // the row's daily-log link and reschedule/cancel buttons aren't shadowed
     // by a whole-row click.
     var volId = ev.linkedVolunteerEvent ? ev.linkedVolunteerEvent.id
-              : (ev.kind === 'volunteer' ? ev.id : '');
+              : (ev.signupRequired ? ev.id : '');
     var chipClick = volId
       ? ' data-admin-click="openVolEventModal" data-admin-arg="' + esc(volId) + '" style="cursor:pointer"'
       : '';
     signups = ' <span class="sched-signup"' + chipClick + '>' + ev.signupCount + '/' + ev.capacity + '</span>';
   }
-  // Standalone volunteer rows stay whole-row-clickable. Activity rows (paired
-  // or not) leave the whole-row click off — they have multiple child actions.
-  var editAction = (ev.kind === 'volunteer') ? 'openVolEventModal' : '';
+  // Standalone signup rows stay whole-row-clickable. Plain activity rows
+  // (paired or not) leave the whole-row click off — they have multiple child
+  // actions.
+  var editAction = ev.signupRequired ? 'openVolEventModal' : '';
   var openAttr = editAction
     ? (' data-admin-click="' + editAction + '" data-admin-arg="' + esc(ev.id) + '" style="cursor:pointer"')
     : '';
-  var linkOut = ev.kind === 'activity'
+  var linkOut = !ev.signupRequired
     ? ' <a href="../dailylog/?date=' + esc(ev.date) + '" class="sched-link">' + s('admin.schedOpenDailyLog') + '</a>'
     : '';
-  // Inline cancel/delete for any kind. Volunteer events delete the row
-  // outright (deleteVolEvent → deleteVolunteerEvent). Activity occurrences
-  // cancel just the one date (cancelClassOccurrence writes a tombstone +
-  // PATCHes the master GCal event's instance) — the parent class survives.
+  // Inline cancel/delete. Signup-tracked activities delete the row outright
+  // (deleteVolEvent → deleteVolunteerEvent). Plain activity occurrences cancel
+  // just the one date (cancelClassOccurrence writes a tombstone + PATCHes the
+  // master GCal event's instance) — the parent activity template survives.
   var deleteBtn = '';
-  if (ev.kind === 'volunteer') {
+  if (ev.signupRequired) {
     deleteBtn = ' <button type="button" class="sched-del" data-admin-click="deleteVolEvent" data-admin-arg="'
       + esc(ev.id) + '" data-s-aria="btn.delete" data-s-title="btn.delete" aria-label="Delete">×</button>';
-  } else if (ev.kind === 'activity' && ev.activityTypeId && ev.date) {
+  } else if (ev.activityTypeId && ev.date) {
     // Two inline actions on activity rows: ✎ to edit, × to cancel that
     // single occurrence (cancelClassOccurrence writes a status='cancelled'
     // tombstone + PATCHes the master GCal instance).

--- a/checkouts.gs
+++ b/checkouts.gs
@@ -664,7 +664,7 @@ function cancelClassOccurrence_(b) {
   //    plus history.
   sched_upsert_({
     id:                   'sched-' + classId + '-' + dateISO,
-    kind:                 'activity',
+    signupRequired:       false,
     status:               'cancelled',
     sourceActivityTypeId: classId,
     activityTypeId:       classId,
@@ -736,7 +736,7 @@ function overrideClassOccurrence_(b) {
   var cls = _activityClassById_(classId);
   sched_upsert_({
     id:                   'sched-' + classId + '-' + dateISO,
-    kind:                 'activity',
+    signupRequired:       false,
     status:               'upcoming',
     sourceActivityTypeId: classId,
     activityTypeId:       classId,
@@ -1035,7 +1035,7 @@ function syncVolunteerEventToCalendar_(eventId) {
   try {
     if (!eventId) return;
     var ev = sched_getById_(eventId);
-    if (!ev || ev.kind !== 'volunteer') return;
+    if (!ev || !ev.signupRequired) return;
     var cfgMap = getConfigMap_();
     var types = [];
     try { types = JSON.parse(getConfigValue_('activity_types', cfgMap) || '[]'); } catch (e) {}

--- a/config.gs
+++ b/config.gs
@@ -150,10 +150,12 @@ function _scheduledEventsForConfig_() {
   try {
     (readAll_('scheduledEvents') || []).forEach(function (r) {
       if (!r) return;
-      if (r.kind === 'volunteer' && r.status !== 'cancelled') {
-        volunteerRows.push(sched_parseRow_(r));
-      } else if (r.kind === 'activity' && r.status === 'cancelled' && r.id) {
-        cancelledActivityIds.push(String(r.id));
+      var ev = sched_parseRow_(r);
+      if (!ev) return;
+      if (ev.signupRequired && ev.status !== 'cancelled') {
+        volunteerRows.push(ev);
+      } else if (!ev.signupRequired && ev.status === 'cancelled' && ev.id) {
+        cancelledActivityIds.push(String(ev.id));
       }
     });
   } catch (e) {}

--- a/members.gs
+++ b/members.gs
@@ -772,9 +772,10 @@ function getDailyLog_(date) {
     // their matching projection virtual. Union the cancelled ids in.
     try {
       (readAll_('scheduledEvents') || []).forEach(function (r) {
-        if (r && r.kind === 'activity' && r.date === d
-            && r.status === 'cancelled' && r.id) {
-          materialized[r.id] = true;
+        if (!r || !r.id) return;
+        var ev = sched_parseRow_(r);
+        if (ev && !ev.signupRequired && ev.date === d && ev.status === 'cancelled') {
+          materialized[ev.id] = true;
         }
       });
     } catch (e) {}
@@ -884,7 +885,7 @@ function persistDailyLogActivities_(dateISO, oldRows, newActs, updatedBy) {
     nextIds[a.id] = true;
     sched_upsert_({
       id:                     a.id,
-      kind:                   'activity',
+      signupRequired:         false,
       status:                 status,
       source:                 _inferActivitySource_(a),
       date:                   dateISO,

--- a/public.gs
+++ b/public.gs
@@ -1181,7 +1181,7 @@ function saveVolunteerEvent_(b) {
     var todayIso = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
     var saved = sched_upsert_({
       id:                    b.id || '',
-      kind:                  'volunteer',
+      signupRequired:        true,
       status:                (_startIso && _startIso < todayIso) ? 'completed' : 'upcoming',
       source:                prev ? (prev.source || 'manual') : 'manual',
       activityTypeId:        b.activityTypeId || '',
@@ -1255,7 +1255,7 @@ function volunteerSignup_(b) {
       const ve = b.virtualEvent;
       evt = sched_upsert_({
         id:                    ve.id,
-        kind:                  'volunteer',
+        signupRequired:        true,
         status:                'upcoming',
         source:                'bulk',
         activityTypeId:        ve.activityTypeId || ve.sourceActivityTypeId || '',
@@ -1551,6 +1551,7 @@ function _volExpandedToDomain_(e) {
   return {
     id:                    e.id,
     kind:                  'volunteer',
+    signupRequired:        true,
     status:                'upcoming',
     source:                'bulk',
     date:                  e.date,

--- a/scheduling.gs
+++ b/scheduling.gs
@@ -1,12 +1,21 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// SCHEDULING  —  single source of truth for scheduled events (volunteer + activity)
+// SCHEDULING  —  single source of truth for activities (every concrete
+// occurrence at the club: signup-tracked or plain).
 // ═══════════════════════════════════════════════════════════════════════════════
-// Every row in scheduled_events carries a `kind` discriminator:
+// Every row in scheduled_events represents one concrete activity instance.
+// The `signupRequired` boolean flags whether it's signup-tracked:
 //
-//   kind='volunteer' — signup-tracked events with roles/leader. The volunteer
-//                      portal + admin volunteer view read these.
-//   kind='activity'  — concrete daily-log activities (past + today). Daily-log
-//                      renderer + midnight materializer read these.
+//   signupRequired=true  — has roles/leader, surfaced in the volunteer portal
+//                          and admin volunteer view.
+//   signupRequired=false — plain activity, surfaced by the daily-log renderer
+//                          and the midnight materializer.
+//
+// (The legacy `kind` column — 'volunteer' | 'activity' — is still written
+// alongside signupRequired during the transition. New code should consult
+// signupRequired; both fields are kept in lock-step by sched_rowShape_.)
+//
+// An activity may be templated from an `activity_types` (a.k.a. activity
+// template) row via `activityTypeId`, or authored ad-hoc with no template.
 //
 // Projections (bulk schedule, Google Calendar) still produce virtual rows at
 // read time — see `projectActivitiesForDate_` in config.gs — but any row that's
@@ -18,6 +27,11 @@
 // sched_parseRow_ takes a sanitized row from readAll_('scheduledEvents') and
 // returns a shape where `roles` is parsed back into an array and booleans are
 // unwrapped. Use this everywhere readers need the domain object.
+//
+// `signupRequired` is the canonical boolean. If a row predates the migration
+// (no signupRequired cell yet), we derive it from the legacy `kind` column.
+// Both are emitted on the parsed object during the transition so frontend
+// callers that still read `.kind === 'volunteer'` continue to work.
 function sched_parseRow_(row) {
   if (!row) return null;
   var roles = [];
@@ -26,9 +40,24 @@ function sched_parseRow_(row) {
   try { reservedBoatIds = row.reservedBoatIds ? JSON.parse(row.reservedBoatIds) : []; } catch (e) { reservedBoatIds = []; }
   var linkedGroupCheckoutIds = [];
   try { linkedGroupCheckoutIds = row.linkedGroupCheckoutIds ? JSON.parse(row.linkedGroupCheckoutIds) : []; } catch (e) { linkedGroupCheckoutIds = []; }
+  // Coerce signupRequired to a real boolean. Sheets returns true/false for
+  // new rows but the migration backfill writes the same; legacy rows have
+  // it empty and we fall back to deriving from `kind`.
+  var sigRaw = row.signupRequired;
+  var signupRequired;
+  if (sigRaw === true || sigRaw === false) {
+    signupRequired = sigRaw;
+  } else if (sigRaw === 'TRUE' || sigRaw === 'true') {
+    signupRequired = true;
+  } else if (sigRaw === 'FALSE' || sigRaw === 'false') {
+    signupRequired = false;
+  } else {
+    signupRequired = (String(row.kind || '').toLowerCase() === 'volunteer');
+  }
   return {
     id:                    row.id || '',
-    kind:                  row.kind || '',
+    kind:                  row.kind || (signupRequired ? 'volunteer' : 'activity'),
+    signupRequired:        signupRequired,
     status:                row.status || '',
     source:                row.source || '',
     date:                  row.date || '',
@@ -67,10 +96,23 @@ function sched_parseRow_(row) {
 // Inverse of sched_parseRow_ — takes a partial domain object and returns the
 // row shape suitable for insertRow_/updateRow_. Undefined fields pass through
 // so callers can do partial updates (updateRow_ ignores absent keys).
+//
+// signupRequired ↔ kind are written in lockstep: if the caller specified
+// either one, both are populated on the row so legacy and modern readers see
+// consistent values until `kind` is removed in a follow-up.
 function sched_rowShape_(ev) {
   var out = {};
   if (ev.id !== undefined)                    out.id = ev.id;
-  if (ev.kind !== undefined)                  out.kind = ev.kind;
+  // signupRequired is canonical; kind mirrors it for legacy compat.
+  // If only one was supplied, derive the other.
+  if (ev.signupRequired !== undefined) {
+    out.signupRequired = !!ev.signupRequired;
+    if (ev.kind === undefined) out.kind = ev.signupRequired ? 'volunteer' : 'activity';
+    else                       out.kind = ev.kind;
+  } else if (ev.kind !== undefined) {
+    out.kind = ev.kind;
+    out.signupRequired = (String(ev.kind).toLowerCase() === 'volunteer');
+  }
   if (ev.status !== undefined)                out.status = ev.status;
   if (ev.source !== undefined)                out.source = ev.source;
   if (ev.date !== undefined)                  out.date = ev.date;
@@ -112,7 +154,7 @@ function sched_rowShape_(ev) {
 // re-run yet still serves the pages that read scheduled events (they just
 // return empty lists until the migration populates rows).
 var SCHEDULED_EVENTS_COLS_ = [
-  'id','kind','status','source',
+  'id','kind','signupRequired','status','source',
   'date','endDate','startTime','endTime',
   'activityTypeId','subtypeId','subtypeName',
   'title','titleIS','notes','notesIS','runNotes',
@@ -144,38 +186,44 @@ function sched_listAll_() {
   return (readAll_('scheduledEvents') || []).map(sched_parseRow_);
 }
 
+// Activities surfaced by the volunteer portal — i.e. signup-tracked.
 function sched_listVolunteerEvents_() {
   return sched_listAll_().filter(function (e) {
-    if (!e || e.kind !== 'volunteer') return false;
+    if (!e || !e.signupRequired) return false;
     return e.status !== 'cancelled';
   });
 }
 
-// Concrete activity rows for a specific date (kind='activity'). Used by the
-// daily log read path; projections for not-yet-materialized days stay in
+// Plain (non-signup) activity rows for a specific date. Used by the daily-log
+// read path; projections for not-yet-materialized days stay in
 // projectActivitiesForDate_ (config.gs).
 function sched_listActivitiesForDate_(dateISO) {
   if (!dateISO) return [];
   return sched_listAll_().filter(function (e) {
-    return e && e.kind === 'activity' && e.date === dateISO && e.status !== 'cancelled';
+    return e && !e.signupRequired && e.date === dateISO && e.status !== 'cancelled';
   });
 }
 
+// Filter activities to a date range. Optional `kind` filter accepts the legacy
+// values 'volunteer' / 'activity' for backward compat, mapped to signupRequired.
 function sched_listInRange_(fromIso, toIso, kind) {
+  var wantSignup = null;
+  if (kind === 'volunteer') wantSignup = true;
+  else if (kind === 'activity') wantSignup = false;
   return sched_listAll_().filter(function (e) {
     if (!e || e.status === 'cancelled') return false;
-    if (kind && e.kind !== kind) return false;
+    if (wantSignup !== null && e.signupRequired !== wantSignup) return false;
     if (fromIso && (e.date || '') < fromIso) return false;
     if (toIso   && (e.date || '') > toIso)   return false;
     return true;
   });
 }
 
-// Activity-log read for staff Logbook Review. Returns concrete activity rows
-// (kind='activity') in a date range, enriched with classTag from the parent
-// activity-type definition so the frontend can group/filter by tag without a
-// second config lookup. Optional activityTypeId / classTag filters apply
-// server-side; an empty filter passes through.
+// Activity-log read for staff Logbook Review. Returns concrete plain
+// (non-signup) activity rows in a date range, enriched with classTag from the
+// parent activity-template definition so the frontend can group/filter by tag
+// without a second config lookup. Optional activityTypeId / classTag filters
+// apply server-side; an empty filter passes through.
 function sched_listActivityLog_(fromIso, toIso, opts) {
   opts = opts || {};
   var rows = sched_listInRange_(fromIso, toIso, 'activity');

--- a/shared/scheduled-event.js
+++ b/shared/scheduled-event.js
@@ -1,11 +1,14 @@
-// ══ SCHEDULED EVENT — CLIENT NORMALIZER ══════════════════════════════════════
-// Backend storage lives in the `scheduled_events` sheet with a `kind`
-// discriminator ('volunteer' | 'activity') and a `status` field — see
-// scheduling.gs. On the client, we keep the two existing API surfaces
+// ══ ACTIVITY — CLIENT NORMALIZER ═════════════════════════════════════════════
+// Backend storage lives in the `scheduled_events` sheet (one row per concrete
+// activity occurrence). The canonical flag is `signupRequired` (boolean);
+// the legacy `kind` discriminator ('volunteer' | 'activity') is still emitted
+// in lockstep during the transition — see scheduling.gs.
+//
+// On the client we keep the two existing API surfaces
 // (getConfig().volunteerEvents and getDailyLog().log.activities) and project
 // them through a single shape for views that want a unified timeline:
 //
-//   { id, kind, source, status,
+//   { id, kind, signupRequired, source, status,
 //     date, endDate, startTime, endTime,
 //     activityTypeId, subtypeId, subtypeName,
 //     title, titleIS, notes, notesIS,
@@ -15,8 +18,9 @@
 //     gcalEventId,
 //     raw }
 //
-//   kind   ∈ { 'volunteer', 'activity' }
-//   source ∈ { 'bulk' | 'calendar' | 'manual' | 'daily-log' }
+//   signupRequired ∈ { true, false }   — canonical
+//   kind           ∈ { 'volunteer', 'activity' }   — legacy mirror
+//   source         ∈ { 'bulk' | 'calendar' | 'manual' | 'daily-log' }
 
 (function (global) {
   'use strict';
@@ -28,12 +32,28 @@
   }
 
   // Normalize a single raw row (volunteer event DTO from getConfig, or a
-  // daily-log activity from getDailyLog) into the ScheduledEvent shape.
-  // `opts.kind` is required; `opts.source` defaults to a sensible guess.
+  // daily-log activity from getDailyLog) into the unified Activity shape.
+  // `opts.signupRequired` (or legacy `opts.kind`) determines the flavor;
+  // `opts.source` defaults to a sensible guess.
   function toScheduledEvent(raw, opts) {
     if (!raw) return null;
     opts = opts || {};
-    var kind = opts.kind || (raw.roles || raw.leaderName ? 'volunteer' : 'activity');
+    // Resolve signupRequired from explicit opt, legacy opts.kind, or by
+    // sniffing the raw row (presence of roles/leaderName implies a
+    // signup-tracked activity).
+    var signupRequired;
+    if (opts.signupRequired === true || opts.signupRequired === false) {
+      signupRequired = opts.signupRequired;
+    } else if (opts.kind) {
+      signupRequired = (opts.kind === 'volunteer');
+    } else if (raw.signupRequired === true || raw.signupRequired === false) {
+      signupRequired = raw.signupRequired;
+    } else if (raw.kind) {
+      signupRequired = (raw.kind === 'volunteer');
+    } else {
+      signupRequired = !!(raw.roles || raw.leaderName);
+    }
+    var kind = signupRequired ? 'volunteer' : 'activity';
     var source = opts.source || _guessSource(raw, kind);
     var roles = _parse(raw.roles, []);
     var capacity = roles.reduce(function (acc, r) { return acc + (Number(r && r.slots) || 0); }, 0);
@@ -43,6 +63,7 @@
     return {
       id:                raw.id || '',
       kind:              kind,
+      signupRequired:    signupRequired,
       source:            source,
       status:            status,
       date:              raw.date || '',
@@ -113,7 +134,7 @@
     var signupCounts    = _countSignups(opts.volunteerSignups);
     var fromIso         = opts.fromIso || new Date().toISOString().slice(0, 10);
     var toIso           = opts.toIso   || _addDaysIso(fromIso, 30);
-    // Cancelled tombstones (sched_events rows with kind=activity status=cancelled).
+    // Cancelled tombstones (plain-activity rows with status=cancelled).
     // Passed through getConfig as a list of ids; build a Set for O(1) lookup
     // so the projection skips matching dates.
     var cancelled = new Set(Array.isArray(opts.cancelledActivityOccurrences) ? opts.cancelledActivityOccurrences : []);
@@ -144,7 +165,7 @@
           title:          cls.name || '',
           titleIS:        cls.nameIS || '',
         };
-        out.push(toScheduledEvent(raw, { kind: 'activity', source: 'bulk' }));
+        out.push(toScheduledEvent(raw, { signupRequired: false, source: 'bulk' }));
       });
     });
 
@@ -161,7 +182,7 @@
       if (ev.date < fromIso || ev.date > toIso) return;
       if (ev.active === false || ev.active === 'false') return;
       out.push(toScheduledEvent(ev, {
-        kind: 'volunteer',
+        signupRequired: true,
         signupCount: signupCounts[ev.id] || 0,
       }));
     });
@@ -180,13 +201,13 @@
     // or activity-class cancelled but signups remain) still render alone.
     var volByKey = {};
     out.forEach(function (ev) {
-      if (ev.kind !== 'volunteer' || !ev.activityTypeId) return;
+      if (!ev.signupRequired || !ev.activityTypeId) return;
       var key = ev.activityTypeId + '|' + ev.date;
       if (!volByKey[key]) volByKey[key] = ev;
     });
     var consumed = {};
     out.forEach(function (ev) {
-      if (ev.kind !== 'activity' || !ev.activityTypeId) return;
+      if (ev.signupRequired || !ev.activityTypeId) return;
       var key = ev.activityTypeId + '|' + ev.date;
       var vol = volByKey[key];
       if (!vol || consumed[vol.id]) return;
@@ -196,7 +217,7 @@
       consumed[vol.id] = true;
     });
     return out.filter(function (ev) {
-      return !(ev.kind === 'volunteer' && consumed[ev.id]);
+      return !(ev.signupRequired && consumed[ev.id]);
     });
   }
 


### PR DESCRIPTION
The scheduled_events row's `kind` column ('volunteer' | 'activity') was a yes/no question — "is this signup-tracked?" — masquerading as a two-value enum. First step of the activities vocabulary cleanup: introduce the `signupRequired` boolean as the canonical field, leaving `kind` in lockstep on the row for one transition cycle.

Schema (_setup.gs): adds signupRequired column to scheduled_events and runs an idempotent backfill on setupSpreadsheet — empty cells derive from the existing kind value.

Backend: sched_parseRow_ emits both fields; sched_rowShape_ accepts either and writes both. Predicates in scheduling.gs/config.gs/members.gs switch to signupRequired. Write callers in checkouts.gs/public.gs/ members.gs pass signupRequired as the canonical field.

Frontend: shared/scheduled-event.js accepts opts.signupRequired, emits both fields on the normalized object. admin/scheduling.js row predicates switch to ev.signupRequired. No UI/UX change.

https://claude.ai/code/session_01YFeWvTsBHYH3U2ZV63YaCh