### PR TITLE
Group sails: resolve activity label at read time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — group sails: render-time activity label
+
+The trip/checkout detail modals used to show `Notes: Group: — None —`
+when a group sail's gmActivity dropdown was left at the placeholder —
+the dropdown's display text was being captured as `activityTypeName`
+and stamped into the trip's `notes` field at check-in. Worse, links
+made later (either via the staff portal's "link to today's daily-log
+activity" picker or via the daily-log activity modal's "link group
+checkout") never propagated to the trip card — `notes` was frozen at
+group-check-in time.
+
+Fix: stop writing `Group: …` / `Activity: …` into the `notes` column.
+A new helper `buildGroupLabelMap_` (in `checkouts.gs`) resolves group
+sails to an activity name at read time, preferring the linked
+scheduled-event title (Path A: `checkouts.linkedActivityId`; Path B:
+`scheduledEvents.linkedGroupCheckoutIds`), falling back to
+`activityTypeName` only when an actual `activityTypeId` is set, and
+otherwise leaving the value empty (frontend renders `Group sail`).
+Both `getActiveCheckouts_` and `getTrips_` attach `groupLabel` (and
+`getTrips_` also flags `isGroupTrip` for supervisor trips). The
+daily-log and staff checkout detail modals show a dedicated
+`Activity` row instead of conflating with `Notes`. Cache invalidation
+extended for `linkGroupCheckoutToActivity` and `saveDailyLog`.
+
+Also patches the original `— None —` leak: `staff.js` now only
+captures `gmActivity.selectedOptions[0].text` when an actual id is
+selected, so the placeholder label can't propagate even on older
+clients hitting newer backends.
+
 ## Unreleased — staff Logbook Review: activity-log filter section
 
 Adds a third section to the staff Logbook Review page (below trips

--- a/checkouts.gs
+++ b/checkouts.gs
@@ -21,17 +21,71 @@ function getActiveCheckouts_(b) {
   }
   let memberMap = {};
   try { memberMap = getMemberMap_(); } catch (e) { }
+  let labelMap = {};
+  try { labelMap = buildGroupLabelMap_(); } catch (e) { labelMap = {}; }
   const enriched = result.map(c => {
     const m = memberMap[String(c.memberKennitala || '')] || {};
+    const key = String(c.id);
     return {
       ...c,
       memberPhone: c.memberPhone || m.phone || '',
       memberIsMinor: c.memberIsMinor !== undefined && c.memberIsMinor !== '' ? bool_(c.memberIsMinor) : bool_(m.isMinor),
       guardianName: c.guardianName || m.guardianName || '',
       guardianPhone: c.guardianPhone || m.guardianPhone || '',
+      groupLabel: key in labelMap ? labelMap[key] : '',
     };
   });
   return okJ({ checkouts: enriched });
+}
+
+// Build { checkoutId → activity-name } for every group-sail checkout. Every
+// group checkout is present as a key — value is '' when no name resolves so
+// callers can use map-key presence to mean "this is a group sail" and fall
+// back to a generic "Group sail" label when the value is empty.
+//
+// Resolution order, per checkout:
+//   1. checkout.linkedActivityId → scheduledEvents.title  (Path A: link picker
+//      shown right after launching the group sail)
+//   2. scheduledEvents.linkedGroupCheckoutIds[] contains checkout.id → that
+//      activity's title  (Path B: link from the daily-log activity modal)
+//   3. checkout.activityTypeName, when an actual activityTypeId is set
+//      (gmActivity dropdown selection at launch time).
+function buildGroupLabelMap_() {
+  var labels = {};
+  var sched = [];
+  try { sched = (readAll_('scheduledEvents') || []).filter(function (r) { return r && r.kind === 'activity'; }); } catch (e) { sched = []; }
+  var schedById = {};
+  sched.forEach(function (r) { if (r.id) schedById[String(r.id)] = r; });
+  var checkouts = [];
+  try { checkouts = (readAll_('checkouts') || []).filter(function (c) { return c && (c.isGroup === true || c.isGroup === 'true'); }); } catch (e) { checkouts = []; }
+  // Seed every group checkout with '' so map presence carries the group flag
+  // even when no link/type resolves.
+  checkouts.forEach(function (c) { labels[String(c.id)] = ''; });
+  // Path A
+  checkouts.forEach(function (c) {
+    if (!c.linkedActivityId) return;
+    var ev = schedById[String(c.linkedActivityId)];
+    if (ev && ev.title) labels[String(c.id)] = ev.title;
+  });
+  // Path B (Path A wins when both are set — explicit checkout-side link.)
+  sched.forEach(function (r) {
+    if (!r.linkedGroupCheckoutIds || !r.title) return;
+    var arr;
+    try { arr = JSON.parse(r.linkedGroupCheckoutIds); } catch (e) { arr = []; }
+    if (!Array.isArray(arr)) return;
+    arr.forEach(function (coId) {
+      var key = String(coId);
+      if (key in labels && !labels[key]) labels[key] = r.title;
+    });
+  });
+  // Fallback to activityTypeName when an actual type was picked at launch.
+  // Skips rows where only the placeholder text leaked through (no id).
+  checkouts.forEach(function (c) {
+    var key = String(c.id);
+    if (labels[key]) return;
+    if (c.activityTypeId && c.activityTypeName) labels[key] = c.activityTypeName;
+  });
+  return labels;
 }
 
 function saveCheckout_(b, caller) {
@@ -186,7 +240,7 @@ function saveGroupCheckout_(b, caller) {
     expectedReturn:  b.expectedReturn || '',
     checkedInAt:     '',
     wxSnapshot:      wxSnap,
-    notes:           b.activityTypeName ? 'Activity: ' + b.activityTypeName : '',
+    notes:           '',
     status:          'out',
     createdAt:       ts,
     isGroup:         true,
@@ -263,7 +317,7 @@ function createSupervisorTripsForGroup_(checkoutId, checkedInAt, caller) {
       locationId: co.locationId || '', locationName: co.locationName || '',
       crew: parseInt(co.crew) || 0, role: 'supervisor',
       wxSnapshot: co.wxSnapshot || '',
-      notes: co.activityTypeName ? 'Group: ' + co.activityTypeName : 'Group sail',
+      notes: '',
       isLinked: true, linkedCheckoutId: String(checkoutId),
       departurePort: co.departurePort || '',
       actorKennitala: actorKt_(caller), actorName: actorName_(caller),

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -759,6 +759,14 @@ function openTripDetail(id) {
   document.getElementById('tdReturn').textContent   = co.expectedReturn||'—';
   document.getElementById('tdIn').textContent       = (co.checkedInAt||co.timeIn||'')||'—';
   document.getElementById('tdCrew').textContent     = co.crew||1;
+  // Group sails get a resolved activity name from the backend (via either
+  // checkout→activity link path); fall back to a generic label when no link
+  // or activity type was set. Today's view feeds in checkout rows (isGroup
+  // flag); past days feed in trip rows (isGroupTrip flag from getTrips).
+  const isGrp = (co.isGroup === true || co.isGroup === 'true') || co.isGroupTrip === true;
+  const actRow = document.getElementById('tdActivityRow');
+  actRow.style.display = isGrp ? '' : 'none';
+  document.getElementById('tdActivity').textContent = isGrp ? (co.groupLabel || s('lbl.groupSail')) : '';
   const notesRow = document.getElementById('tdNotesRow');
   notesRow.style.display = co.notes ? '' : 'none';
   document.getElementById('tdNotes').textContent    = co.notes||'';

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -218,6 +218,7 @@
       <div class="dl-drow"><span class="dl-dlbl" id="tdReturnLabel"></span><span class="dl-dval" id="tdReturn"></span></div>
       <div class="dl-drow"><span class="dl-dlbl" id="tdInLabel"></span><span class="dl-dval" id="tdIn"></span></div>
       <div class="dl-drow"><span class="dl-dlbl" data-s="lbl.crew"></span><span class="dl-dval" id="tdCrew"></span></div>
+      <div class="dl-drow" id="tdActivityRow"><span class="dl-dlbl" data-s="lbl.activity"></span><span class="dl-dval" id="tdActivity"></span></div>
       <div class="dl-drow" id="tdNotesRow"><span class="dl-dlbl" data-s="lbl.notes"></span><span class="dl-dval" id="tdNotes"></span></div>
     </div>
     <div class="info-panel" id="tdMemberSection">

--- a/shared/api.js
+++ b/shared/api.js
@@ -258,12 +258,17 @@ var _INVALIDATES = {
   unlinkGoogleAccount:     ['getMembers'],
 
   // Daily log: writes activity rows into scheduled_events, which the staff
-  // Logbook Review activity-log section reads via getActivityLog.
-  saveDailyLog:            ['getActivityLog'],
+  // Logbook Review activity-log section reads via getActivityLog. Activities
+  // can also carry linkedGroupCheckoutIds → trip group labels resolve through
+  // those, so dropping getTrips keeps the trip-detail Activity row fresh.
+  saveDailyLog:            ['getActivityLog', 'getTrips'],
   // Trips.
   saveTrip:                ['getTrips'],
   deleteTrip:              ['getTrips'],
   setHelm:                 ['getTrips'],
+  // Group sail ↔ activity link: trip cards' resolved Activity row reads
+  // through this on the backend, so cached getTrips needs to drop.
+  linkGroupCheckoutToActivity: ['getTrips'],
   // respondConfirmation can mint a new crew-trip row AND clear a notification.
   respondConfirmation:     ['getTrips', 'getNotifications', 'getConfirmations'],
   createConfirmation:      ['getConfirmations', 'getNotifications'],

--- a/shared/strings-en.js
+++ b/shared/strings-en.js
@@ -26,6 +26,8 @@ var _STRINGS_FLAT = {
   "lbl.date": "Date",
   "lbl.time": "Time",
   "lbl.notes": "Notes",
+  "lbl.activity": "Activity",
+  "lbl.groupSail": "Group sail",
   "lbl.phone": "Phone",
   "lbl.email": "Email",
   "lbl.location": "Location",

--- a/shared/strings-is.js
+++ b/shared/strings-is.js
@@ -26,6 +26,8 @@ var _STRINGS_FLAT = {
   "lbl.date": "Dagsetning",
   "lbl.time": "Tími",
   "lbl.notes": "Athugasemdir",
+  "lbl.activity": "Viðburður",
+  "lbl.groupSail": "Hópsigling",
   "lbl.phone": "Sími",
   "lbl.email": "Netfang",
   "lbl.location": "Staðsetning",

--- a/staff/index.html
+++ b/staff/index.html
@@ -244,6 +244,7 @@
       <div class="dl-drow"><span class="dl-dlbl" data-s="staff.coDetail.out"></span><span class="dl-dval" id="cdOut"></span></div>
       <div class="dl-drow"><span class="dl-dlbl" data-s="staff.coDetail.return"></span><span class="dl-dval" id="cdReturn"></span></div>
       <div class="dl-drow"><span class="dl-dlbl" data-s="lbl.crew"></span><span class="dl-dval" id="cdCrew"></span></div>
+      <div class="dl-drow" id="cdActivityRow"><span class="dl-dlbl" data-s="lbl.activity"></span><span class="dl-dval" id="cdActivity"></span></div>
       <div class="dl-drow" id="cdNotesRow"><span class="dl-dlbl" data-s="lbl.notes"></span><span class="dl-dval" id="cdNotes"></span></div>
     </div>
     <div class="info-panel mb-10">

--- a/staff/staff.js
+++ b/staff/staff.js
@@ -526,6 +526,13 @@ function openCoDetail(id, event) {
   document.getElementById('cdOut').textContent      = sstr(co.checkedOutAt||co.timeOut).slice(0,5) || '—';
   document.getElementById('cdReturn').textContent   = co.expectedReturn || '—';
   document.getElementById('cdCrew').textContent     = co.crew || 1;
+  // Group sails get a resolved activity name from the backend; show a generic
+  // fallback when nothing's linked yet so staff can still tell it apart from
+  // an individual checkout.
+  const isGrp = co.isGroup === true || co.isGroup === 'true';
+  const actRow = document.getElementById('cdActivityRow');
+  actRow.style.display = isGrp ? '' : 'none';
+  document.getElementById('cdActivity').textContent = isGrp ? (co.groupLabel || s('lbl.groupSail')) : '';
   const notesRow = document.getElementById('cdNotesRow');
   notesRow.style.display = co.notes ? '' : 'none';
   document.getElementById('cdNotes').textContent    = co.notes || '';
@@ -872,7 +879,10 @@ async function submitGroupCheckout() {
   const tout  = document.getElementById('gmTimeOut').value || fmtTimeNow();
   const retBy = document.getElementById('gmReturnBy').value;
   const actId = document.getElementById('gmActivity').value;
-  const actName = document.getElementById('gmActivity').selectedOptions[0]?.text || '';
+  // Only capture the visible label when a real type is selected; the
+  // placeholder option's text ("— None —") would otherwise leak into the
+  // checkout's activityTypeName and render badly downstream.
+  const actName = actId ? (document.getElementById('gmActivity').selectedOptions[0]?.text || '') : '';
   const loc = locations.find(l => l.id === lid) || {};
   const snap = (typeof wxSnapshot === 'function') ? wxSnapshot(wxData) : null;
   const staffEntries = Array.from(document.querySelectorAll('#gmStaffSection input'))

--- a/trips.gs
+++ b/trips.gs
@@ -10,6 +10,21 @@ function getTrips_(kennitala, limit, p) {
   const offset = parseInt(p.offset) || 0;
   const lim    = limit || 100;
   const page   = sorted.slice(offset, offset + lim);
+  // Resolve the group-sail activity name for supervisor trips at read time so
+  // edits via either link path (checkouts.linkedActivityId or
+  // scheduledEvents.linkedGroupCheckoutIds) flow through without backfill.
+  // Map-key presence carries the "is group" flag; the value (possibly '') is
+  // the resolved activity name.
+  let labelMap = {};
+  try { labelMap = buildGroupLabelMap_(); } catch (e) { labelMap = {}; }
+  page.forEach(t => {
+    if (!t.linkedCheckoutId) return;
+    const key = String(t.linkedCheckoutId);
+    if (key in labelMap) {
+      t.isGroupTrip = true;
+      t.groupLabel = labelMap[key];
+    }
+  });
   return okJ({ trips: page, total: sorted.length, offset: offset, limit: lim });
 }
 


### PR DESCRIPTION
Stops conflating the trip's private notes column with an auto-stamped "Group: <activity>" string. The label is now computed in buildGroupLabelMap_ and attached to checkouts (getActiveCheckouts_) and trips (getTrips_) on the way out, preferring the linked scheduled-event title (either link path), falling back to activityTypeName when a real type was picked at launch, and otherwise empty so the frontend renders "Group sail". The daily-log and staff checkout detail modals get a dedicated Activity row, leaving Notes for real notes. Also patches the original "— None —" leak: gmActivity now only captures its visible text when an actual id is selected.