### PR TITLE
scheduling.gs: sched_* shims + buildGroupLabelMap_ post-rename fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — sched_* shims + buildGroupLabelMap_ post-rename fix
+
+Daily-log saves were failing on deployments where one or more `.gs` files
+hadn't been re-pushed after the `sched_* → activity_*` rename in `b108509`
+("Server error: sched_listActivitiesForDate_ is not defined"). The
+codebase itself is consistent — the error only surfaces when an Apps
+Script project holds a partially-stale set of files between pushes.
+
+- `scheduling.gs`: transitional shim aliases for the renamed
+  `sched_*` functions (and `ensureScheduledEventsSheet_`) so a
+  pre-rename caller in another `.gs` file degrades to the new
+  implementation instead of throwing. Drop the shims once every
+  deployment is on post-rename code.
+- `checkouts.gs`: `buildGroupLabelMap_` was still calling
+  `readAll_('scheduledEvents')` (the TABS_ key was renamed to
+  `'activities'` in `b108509`) and filtering on `r.kind === 'activity'`
+  (the `kind` column was dropped in `8072be6`). Both paths silently
+  returned empty, so group-sail activity labels never resolved via
+  Path A or Path B. Fixed to read `'activities'` and filter on
+  `signupRequired` falsy.
+
 ## Unreleased — frontend: rename actTypes / activityTypes vars to activityTemplates
 
 Cosmetic rename across the portals to align in-code variable names

--- a/checkouts.gs
+++ b/checkouts.gs
@@ -44,16 +44,16 @@ function getActiveCheckouts_(b) {
 // back to a generic "Group sail" label when the value is empty.
 //
 // Resolution order, per checkout:
-//   1. checkout.linkedActivityId → scheduledEvents.title  (Path A: link picker
+//   1. checkout.linkedActivityId → activities.title  (Path A: link picker
 //      shown right after launching the group sail)
-//   2. scheduledEvents.linkedGroupCheckoutIds[] contains checkout.id → that
+//   2. activities.linkedGroupCheckoutIds[] contains checkout.id → that
 //      activity's title  (Path B: link from the daily-log activity modal)
 //   3. checkout.activityTypeName, when an actual activityTypeId is set
 //      (gmActivity dropdown selection at launch time).
 function buildGroupLabelMap_() {
   var labels = {};
   var sched = [];
-  try { sched = (readAll_('scheduledEvents') || []).filter(function (r) { return r && r.kind === 'activity'; }); } catch (e) { sched = []; }
+  try { sched = (readAll_('activities') || []).filter(function (r) { return r && !(r.signupRequired === true || r.signupRequired === 'TRUE' || r.signupRequired === 'true'); }); } catch (e) { sched = []; }
   var schedById = {};
   sched.forEach(function (r) { if (r.id) schedById[String(r.id)] = r; });
   var checkouts = [];

--- a/scheduling.gs
+++ b/scheduling.gs
@@ -370,3 +370,23 @@ function activity_signupCountsById_() {
   });
   return out;
 }
+
+// ── Transitional shims for the sched_* → activity_* rename (b108509) ─────────
+// Apps Script projects can hold partially-stale .gs files between pushes — if
+// scheduling.gs lands but a caller (e.g. members.gs) is still pre-rename, the
+// caller throws "sched_X is not defined" until the next push lands. These
+// aliases keep the old names callable so a partial sync degrades gracefully.
+// Drop once you're confident every deployment has caught up.
+function sched_parseRow_(row)                   { return activity_parseRow_(row); }
+function sched_rowShape_(ev)                    { return activity_rowShape_(ev); }
+function sched_getById_(id)                     { return activity_getById_(id); }
+function sched_listAll_()                       { return activity_listAll_(); }
+function sched_listVolunteerEvents_()           { return activity_listVolunteerEvents_(); }
+function sched_listActivitiesForDate_(dateISO)  { return activity_listForDate_(dateISO); }
+function sched_listInRange_(fromIso, toIso, kind) { return activity_listInRange_(fromIso, toIso, kind); }
+function sched_listActivityLog_(fromIso, toIso, opts) { return activity_listLog_(fromIso, toIso, opts); }
+function sched_upsert_(ev)                      { return activity_upsert_(ev); }
+function sched_cancel_(id, updatedBy)           { return activity_cancel_(id, updatedBy); }
+function sched_hardDelete_(id)                  { return activity_hardDelete_(id); }
+function sched_signupCountsByEvent_()           { return activity_signupCountsById_(); }
+function ensureScheduledEventsSheet_()          { return ensureActivitiesSheet_(); }


### PR DESCRIPTION
Daily-log saves throw "Server error: sched_listActivitiesForDate_ is not defined" on deployments where one or more .gs files haven't caught up to the sched_* → activity_* rename in b108509. The codebase is consistent; the error only surfaces when an Apps Script project holds a partially stale set of files between pushes.

scheduling.gs: add transitional shim aliases for the renamed sched_* functions (sched_listActivitiesForDate_, sched_upsert_, sched_cancel_, sched_hardDelete_, etc.) plus ensureScheduledEventsSheet_, so a pre-rename caller in another .gs file degrades to the new implementation instead of throwing. Drop the shims once every deployment is post-rename.

checkouts.gs: buildGroupLabelMap_ was still calling readAll_('scheduledEvents') (TABS_ key was renamed to 'activities' in b108509) and filtering on r.kind === 'activity' (the kind column was dropped in 8072be6). Both made the filter silently return empty, so group-sail activity labels never resolved via Path A or Path B. Read 'activities' and filter on signupRequired falsy.

https://claude.ai/code/session_01Cve5z8j8grh48eJZXLUERy