### PR TITLE
Group Checkout: space-separate joined boat names in trip rows

### DIFF
--- a/checkouts.gs
+++ b/checkouts.gs
@@ -257,7 +257,7 @@ function saveGroupCheckout_(b, caller) {
   insertRow_('checkouts', {
     id,
     boatId:          boatIds.join(','),
-    boatName:        boatNames.join(','),
+    boatName:        boatNames.join(', '),
     boatCategory:    b.boatCategory || '',
     memberKennitala: '',
     memberName:      staffNames.length ? staffNames.join(', ') : 'Group',

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -107,8 +107,16 @@ function renderTrips() {
     const tin   = sstr(co.checkedInAt ||co.timeIn).slice(0,5);
     const retBy = sstr(co.expectedReturn).slice(0,5);
     const overdue = retBy && !tin && retBy < fmtTimeNow();
+    let boatLabel;
+    try {
+      const arr = co.boatNames ? (typeof co.boatNames === 'string' ? JSON.parse(co.boatNames) : co.boatNames) : null;
+      boatLabel = (Array.isArray(arr) && arr.length) ? arr.join(', ') : (co.boatName || co.boatId || '');
+    } catch (e) {
+      boatLabel = co.boatName || co.boatId || '';
+    }
+    boatLabel = String(boatLabel).replace(/,(?!\s)/g, ', ');
     row.innerHTML = `<div class="flex-1">
-      <div class="trip-boat">${esc(co.boatName||co.boatId)}
+      <div class="trip-boat">${esc(boatLabel)}
         ${co.memberIsMinor ? `<span class="badge badge-yellow" style="margin-left:6px">${s('lbl.minor')}</span>` : ''}
       </div>
       <div class="trip-meta">${esc(co.memberName||'')}${co.locationName ? ' · '+esc(co.locationName) : ''}${co.crew && co.crew > 1 ? ' · '+co.crew+' '+s('lbl.crew').toLowerCase() : ''}</div>


### PR DESCRIPTION
The "Trips Today" row in dailylog rendered group-checkout boat names as "A,B,C" because checkouts.gs persisted boatName as boatNames.join(','). Storage now joins with ', '; dailylog also prefers the parallel boatNames JSON array and normalizes legacy ',' values for already-stored rows.