### PR TITLE
code.gs: restore LEGACY_TAB_ALIASES_['activities'] safety net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — restore LEGACY_TAB_ALIASES_['activities'] safety net
+
+`8072be6` cleared `LEGACY_TAB_ALIASES_` alongside the kind-column drop,
+but the tab rename (`scheduled_events` → `activities`, introduced in
+`63a10db`) is independent of the kind backfill. Any deployment that
+hadn't run `setupSpreadsheet` between those commits ended up with an
+empty `activities` tab created next to the legacy `scheduled_events`
+tab — orphaning every existing activity row and silently dropping new
+writes. Re-added the `'activities': ['scheduled_events']` entry so
+`_reconcileLegacyTab_` self-heals via `setName` on first access. Safe
+to drop again once every deployment is verified to live on the
+canonical name.
+
 ## Unreleased — sched_* shims + buildGroupLabelMap_ post-rename fix
 
 Daily-log saves were failing on deployments where one or more `.gs` files

--- a/code.gs
+++ b/code.gs
@@ -954,9 +954,18 @@ function sweepExpiredSessions() {
 // legacy names to fall back to. If the canonical tab is missing but a legacy
 // name is present, _reconcileLegacyTab_ renames it via setName so existing
 // data is preserved and subsequent calls find it normally. Idempotent — a
-// no-op once the rename has happened. Empty for now; populate when the
-// next rename lands.
-const LEGACY_TAB_ALIASES_ = {};
+// no-op once the rename has happened.
+//
+// 'activities' ← 'scheduled_events': introduced in 63a10db, prematurely
+// cleared in 8072be6 alongside the kind-column drop. Restored because the
+// tab rename is independent of the kind backfill and any deployment that
+// hadn't run setupSpreadsheet between those commits ended up with an empty
+// 'activities' tab created next to the legacy 'scheduled_events' tab,
+// orphaning every existing activity row. Safe to drop again once every
+// deployment is verified to live on the canonical name.
+const LEGACY_TAB_ALIASES_ = {
+  'activities': ['scheduled_events'],
+};
 
 function _reconcileLegacyTab_(ss, canonicalName) {
   var aliases = LEGACY_TAB_ALIASES_[canonicalName];


### PR DESCRIPTION
8072be6 cleared LEGACY_TAB_ALIASES_ alongside the kind-column drop, but the tab rename ('scheduled_events' → 'activities', introduced in 63a10db) is independent of the kind backfill. A deployment that hadn't run setupSpreadsheet between those commits ended up with an empty 'activities' tab created next to the legacy 'scheduled_events' tab — orphaning every existing activity row and silently dropping new writes.

Re-add the 'activities': ['scheduled_events'] entry so _reconcileLegacyTab_ self-heals via setName on first access. Idempotent no-op once the tab carries the canonical name. Safe to drop again once every deployment is verified to live on the canonical name.

https://claude.ai/code/session_01Cve5z8j8grh48eJZXLUERy