### PR TITLE
dailylog: cache getDailyLog + consume the prefetch on first paint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — daily-log caching: promote getDailyLog, consume prefetch
+
+Two issues in the daily-log frontend caused needless round-trips when
+navigating across days:
+
+- `dailylog/dailylog.js` prefetched `getDailyLog` at the top of the file,
+  but the action wasn't in `_CACHEABLE` in `shared/api.js`, so `apiGet`
+  skipped the cache + inflight-dedup path. The prefetched promise sat on
+  `window._earlyDailyLog` unread while `loadTodayLog` fired its own
+  duplicate fetch. Result: today's daily log went over the wire twice
+  on every page load.
+- Day-to-day navigation (prev/next/today/picker) called `apiGet(
+  'getDailyLog', { date })` with no caching, so every click was a fresh
+  round-trip even on rapid back-and-forth.
+
+Fixes:
+
+- `shared/api.js`: add `getDailyLog: 60000` to `_CACHEABLE`. Cache key is
+  already params-suffixed, so per-date entries don't clobber each other.
+- `shared/api.js`: `_INVALIDATES.saveDailyLog` now drops `getDailyLog`
+  alongside `getActivityLog` + `getTrips`, so the just-saved day reads
+  back fresh. Comment on the `cancelClassOccurrence` / `overrideClassOccurrence`
+  / `restoreClassOccurrence` rows updated — `getDailyLog` listed there
+  is no longer a no-op.
+- `dailylog/dailylog.js`: `loadTodayLog` consumes `window._earlyDailyLog`
+  / `window._earlyConfig` and clears the references, so return-to-today
+  navigations after a save read fresh data through the apiGet cache
+  instead of re-resolving the original (now stale) prefetch.
+
 ## Unreleased — sched_* shims + buildGroupLabelMap_ post-rename fix
 
 Daily-log saves were failing on deployments where one or more `.gs` files

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -865,10 +865,15 @@ async function loadTodayLog() {
   // Don't pre-render checklists/activity-type buttons before config arrives —
   // the spinner from loadDay() stays until real data replaces it.
   renderActivities(); renderWxLog(); renderIncidentSection([]);
+  // Consume the prefetched promises once, then drop the references so
+  // return-to-today navigations after a save read fresh data through the
+  // apiGet cache instead of re-resolving the original (now stale) prefetch.
+  const earlyLog = window._earlyDailyLog; window._earlyDailyLog = null;
+  const earlyCfg = window._earlyConfig;   window._earlyConfig   = null;
   try {
     const [logRes, cfgRes, incidents] = await Promise.all([
-      apiGet('getDailyLog', { date: TODAY }),
-      apiGet('getConfig'),
+      earlyLog || apiGet('getDailyLog', { date: TODAY }),
+      earlyCfg || apiGet('getConfig'),
       loadIncidentsForDate(TODAY),
     ]);
     applyLogData(logRes, cfgRes);

--- a/shared/api.js
+++ b/shared/api.js
@@ -34,7 +34,7 @@ async function apiGet(action, params) {
   // different params (e.g. getSlots for adjacent weeks) doesn't clobber the
   // single-entry cache. apiPost invalidates by prefix scan so all entries
   // for an action drop together.
-  var _CACHEABLE = { getConfig: 120000, getWeather: 300000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewBoard: 30000, getCrewInvites: 30000, getNotifications: 30000, getConfirmations: 30000, getHandbook: 600000, getSlots: 60000 };
+  var _CACHEABLE = { getConfig: 120000, getWeather: 300000, getMembers: 30000, getTrips: 30000, getMaintenance: 30000, getCrews: 30000, getCrewBoard: 30000, getCrewInvites: 30000, getNotifications: 30000, getConfirmations: 30000, getHandbook: 600000, getSlots: 60000, getDailyLog: 60000 };
   if (_CACHEABLE[action] && !params._fresh) {
     try {
       var _ck = 'ymir_' + action + '_' + JSON.stringify(params);
@@ -220,8 +220,8 @@ var _INVALIDATES = {
   importRowingPassportCsv: ['getConfig'],
   // Class-occurrence writes touch the activities sheet (which feeds getConfig's
   // volunteerEvents + cancelledActivityOccurrences) and the activity-class
-  // virtual-slot projection. getDailyLog isn't cached — listed only for
-  // semantic intent (no-op today).
+  // virtual-slot projection. getDailyLog is also cached per-date, so any write
+  // that may surface in a daily-log view drops it.
   cancelClassOccurrence:   ['getConfig', 'getSlots', 'getDailyLog', 'getActivityLog'],
   overrideClassOccurrence: ['getConfig', 'getSlots', 'getDailyLog', 'getActivityLog'],
   restoreClassOccurrence:  ['getConfig', 'getSlots', 'getDailyLog', 'getActivityLog'],
@@ -261,7 +261,8 @@ var _INVALIDATES = {
   // Logbook Review activity-log section reads via getActivityLog. Activities
   // can also carry linkedGroupCheckoutIds → trip group labels resolve through
   // those, so dropping getTrips keeps the trip-detail Activity row fresh.
-  saveDailyLog:            ['getActivityLog', 'getTrips'],
+  // getDailyLog is cached per-date so the just-saved day reads back fresh.
+  saveDailyLog:            ['getDailyLog', 'getActivityLog', 'getTrips'],
   // Trips.
   saveTrip:                ['getTrips'],
   deleteTrip:              ['getTrips'],


### PR DESCRIPTION
getDailyLog wasn't in `_CACHEABLE`, so the page-top prefetch in `dailylog.js` produced an unread `window._earlyDailyLog` promise while `loadTodayLog` fired its own duplicate fetch. Day-to-day navigation also re-hit the backend on every prev/next click even on rapid back-and-forth.

Promote `getDailyLog` to `_CACHEABLE` (60s, params-suffixed by date), have `loadTodayLog` consume + clear the prefetched promises, and add `getDailyLog` to `_INVALIDATES.saveDailyLog` so the just-saved day reads back fresh.