### PR TITLE
dailylog: action button reflects sign-off state on today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — daily-log: action button reflects sign-off state on today
+
+The bottom action button on `/dailylog/` previously read "Save & Sign
+off" on today's view regardless of whether the day was already signed
+off, and clicking it called `signOffDay` → `doSave(true)`, which
+re-stamped `signedOffBy` / `signedOffAt` over the original entry
+instead of recording an amendment.
+
+- `dailylog/dailylog.js`: button text is now driven by `logSignedOff`
+  alongside `isToday()`. "Save & Sign off" only shows on today before
+  sign-off; past/future days and today-after-sign-off both read "Save
+  amendments". The click handler routes the same way — only an
+  unsigned today triggers `signOffDay`; everything else confirms and
+  saves as an amendment via `doSave(false)`.
+- `dailylog/dailylog.js`: `doSave` promotes local state
+  (`logSignedOff` / `logSignedOffBy` / `logSignedOffAt`) on successful
+  sign-off and re-runs `updateDateNav` so the button immediately
+  switches to "Save amendments". Error path falls back to
+  `updateDateNav` too, keeping the today/past/future branching in
+  one place.
+
 ## Unreleased — daily-log caching: promote getDailyLog, consume prefetch
 
 Two issues in the daily-log frontend caused needless round-trips when

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -520,10 +520,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('actSaveAddBtn').addEventListener('click', function() { saveActivity(true); });
 
   dom.signOffBtn.addEventListener('click', async () => {
-    // Today: full sign-off (marks signedOffBy/signedOffAt). Past/future: save
-    // as an amendment — the row already has a signOffBy stamp (either staff
-    // or the midnight trigger), and updatedBy/updatedAt distinguishes the edit.
-    if (isToday()) { signOffDay(); return; }
+    // Full sign-off only when today AND not yet signed off (marks
+    // signedOffBy/signedOffAt). Otherwise save as an amendment — the row
+    // already has a signOffBy stamp (staff, or the midnight trigger),
+    // and updatedBy/updatedAt distinguishes the edit.
+    if (isToday() && !logSignedOff) { signOffDay(); return; }
     const msg = s('daily.confirmAmendmentSave', { date: viewDate });
     if (!await ymConfirm(msg)) return;
     doSave(false);
@@ -587,7 +588,10 @@ function updateDateNav() {
   dom.mainWrap.classList.remove('readonly');
   dom.readonlyBadge.classList.add('hidden');
   dom.signOffBtn.style.display = '';
-  dom.signOffBtn.textContent   = isToday() ? s('btn.signOff') : s('daily.saveAmendments');
+  // "Sign off" only when today AND not yet signed off; everything else is
+  // an amendment (past/future days, or today after sign-off).
+  const isAmendment = !isToday() || logSignedOff;
+  dom.signOffBtn.textContent = isAmendment ? s('daily.saveAmendments') : s('btn.signOff');
   dom.logWxBtn.parentElement.style.display = 'block';
   dom.logWxBtn.style.display   = isToday() ? '' : 'none';
   dom.logWxDesc.style.display  = isToday() ? '' : 'none';
@@ -1064,6 +1068,13 @@ async function doSave(signOff) {
     dom.saveMsg.textContent = signOff ? s('toast.signedOff') : s('toast.saved');
     if (!signOff) setTimeout(function(){ dom.saveMsg.textContent = ''; }, 3000);
     if (signOff) {
+      // Promote local state so updateDateNav flips the action button to
+      // "Save amendments" — without this, a second click of the (still
+      // labelled "Sign off") button would re-stamp signedOff over the
+      // original entry instead of saving as an amendment.
+      logSignedOff   = true;
+      logSignedOffBy = user.name || '';
+      logSignedOffAt = nowIso;
       dom.signoffBadge.classList.remove('hidden');
       dom.signoffBadge.textContent = s('daily.signedOffBy') + user.name;
     }
@@ -1075,7 +1086,10 @@ async function doSave(signOff) {
   } finally {
     if (signOff) {
       dom.signOffBtn.disabled = false;
-      dom.signOffBtn.textContent = s('btn.signOff');
+      // Restore button text from current state (now signed off → "Save
+      // amendments"; on error → still "Sign off"). Defers to updateDateNav
+      // so the today/past/future branching stays in one place.
+      updateDateNav();
     }
   }
 }


### PR DESCRIPTION
The bottom action button on the daily-log page read "Save & Sign off" regardless of sign-off state on today's view, and clicking it called signOffDay → doSave(true), re-stamping signedOffBy/At over the original entry instead of recording an amendment.

Drive the button text and click handler from logSignedOff alongside isToday(): "Save & Sign off" only shows on an unsigned today; everything else (past/future, or today after sign-off) reads "Save amendments" and routes through the amendment confirm + doSave(false). On successful sign-off, promote local state so updateDateNav flips the button immediately.