### PR TITLE
Match input/textarea text formatting to body text

### DIFF
--- a/shared/style.css
+++ b/shared/style.css
@@ -334,6 +334,7 @@ textarea {
   color: var(--text);
   padding: 10px 14px;
   font-size: 14px;
+  line-height: 1.5;
   font-family: inherit;
   outline: none;
   transition: border-color .2s, box-shadow .2s;
@@ -1461,7 +1462,7 @@ textarea { min-height: 70px; }
   input[type=text], input[type=number], input[type=email],
   input[type=tel], input[type=date], input[type=time],
   input[type=password], input[type=file], select, textarea {
-    padding: 10px 12px; font-size: 16px;
+    padding: 10px 12px;
   }
 
   /* ── Modals ── */


### PR DESCRIPTION
- Add line-height: 1.5 to input/select/textarea so multi-line textareas read at the same density as the body text around them (previously inputs fell back to the browser default ~1.2 while body uses 1.6).
- Drop the mobile font-size: 16px override on form fields. The 16px was the standard iOS-zoom-prevention trick, but it left input text visibly larger than surrounding body copy on phones (most visible in the dailylog Staff Notes textarea). Inputs now match body at 14px; iOS will zoom slightly on focus, which is the accepted tradeoff.

https://claude.ai/code/session_01FHUU5xTSy7uaat9Sw2teAR