### PR TITLE
admin: keep activity-template Category dropdown on the saved preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — admin: activity-template Category dropdown reflects saved tag
+
+Reopening an activity template that was saved with a preset class tag
+(e.g. "Lesson") showed the Category dropdown stuck on "Pick category…"
+even though the underlying `classTag`/`classTagIS` were persisted. The
+Custom (EN/IS) inputs displayed correctly, but admins read the empty
+dropdown as "the class tag isn't saved."
+
+`admin/act-types.js` (`openActTypeModal`): the function called
+`populateClassTagPresets()` twice — once before setting
+`presetSel.value` from `_matchClassTagPreset`, and once again further
+down (a leftover from when the field was a `<datalist>`). The second
+call rebuilt `<select>.innerHTML`, which discarded the just-set value
+and reverted the dropdown to its placeholder. Drops the duplicate
+call so the dropdown keeps the matched preset on reopen.
+
 ## Unreleased — daily-log: action button reflects sign-off state on today
 
 The bottom action button on `/dailylog/` previously read "Save & Sign

--- a/admin/act-types.js
+++ b/admin/act-types.js
@@ -79,8 +79,6 @@ function openActTypeModal(id) {
   // occurrence. Empty = no resource reservation (classroom, land work, etc.).
   window._atReservedBoatIds = a && Array.isArray(a.reservedBoatIds)
     ? a.reservedBoatIds.slice().map(String) : [];
-  // Refresh datalist of existing class tags so the input autocompletes
-  populateClassTagPresets();
   renderAtDayBtns();
   renderAtBoatPicker();
   // Schedule source: default 'bulk' for legacy rows and new types.


### PR DESCRIPTION
`openActTypeModal` called `populateClassTagPresets()` twice — once before setting `presetSel.value` to the matched preset, and once again further down (stale comment refers to "datalist autocompletion"). The second call rebuilt `<select>.innerHTML`, which discarded the just-set value and reverted the dropdown to its placeholder. Reopening a template saved with a preset like "Lesson" then showed the Category dropdown empty, which read to admins as "the class tag isn't saved" even though the Custom (EN/IS) inputs and persisted `classTag` / `classTagIS` were correct. Drops the redundant call.