### PR TITLE
Purge legacy/migration shims (testing-stage cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,43 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — purge legacy/migration shims (testing-stage cleanup)
+
+Cleared aliases, transitional shims, completed migrations, and stale
+comments that accumulated during the activity-vocabulary cleanup and
+earlier renames. Net −288 lines. Existing test sheets must have run
+`setupSpreadsheet()` at least once on the previous version (or already
+live on canonical names) — there is no longer a self-healing path for
+deployments that haven't.
+
+- `scheduling.gs`: dropped 13 `sched_*` → `activity_*` re-export shims;
+  `activity_listInRange_(fromIso, toIso, kind)` now takes a boolean
+  `signupRequired` directly instead of mapping the legacy
+  `'volunteer'` / `'activity'` strings.
+- `code.gs`: dropped duplicate `saveDailyLog` case in `route_` (was
+  shadowed by the canonical handler); dropped `requestValidation`
+  action alias (canonical is `requestVerification`); dropped
+  `LEGACY_TAB_ALIASES_` + `_reconcileLegacyTab_` self-healing rename
+  for `scheduled_events` → `activities`.
+- `trips.gs`: removed dead `requestValidation_` function (no callers
+  after the route alias dropped).
+- `config.gs`: dropped `LEGACY_CONFIG_KEY_ALIASES_` map and the
+  fallback paths in `getConfigValue_` / `getConfigSheetValue_`. The
+  `activity_types` → `activity_templates` rename is fully cut over.
+- `_setup.gs`: dropped four migration blocks (config-key copy,
+  `signupRequired` backfill from `kind`, legacy `kind` column drop,
+  generic alias copier) and the `_reconcileLegacyTab_` call in
+  `ensureTab_`.
+- `shared/api.js`: dropped one-shot service-worker cleanup block (SW
+  was removed long ago); dropped redundant `requestValidation` entry
+  in `_INVALIDATES`.
+- `shared/scheduled-event.js`: `toScheduledEvent` no longer consults
+  `opts.kind` / `raw.kind` as a fallback for `signupRequired`.
+- `passport.gs`, `coxswain/coxswain.js`: dropped `'theoretical'` →
+  `'theory'` spelling normalizer.
+- `admin/admin.js`: dropped `actTypes` / `volunteers` / `clubCal` /
+  `slotCal` URL-tab redirects to the unified `scheduling` tab.
+
 ## Unreleased — daily-log: sign-off badge stays accurate after save
 
 The post-click sign-off badge on `/dailylog/` showed only the signer's

--- a/_setup.gs
+++ b/_setup.gs
@@ -160,10 +160,6 @@ var SCHEMA_ = {
   //                                    renderer + midnight materializer).
   //   status ∈ 'upcoming' | 'completed' | 'cancelled' | 'orphaned'
   //   source ∈ 'bulk' | 'calendar' | 'manual' | 'daily-log'
-  // (Legacy `kind` column may still be present on rows from before the
-  // vocabulary cleanup. New writes don't populate it; activity_parseRow_
-  // falls back to it only if signupRequired is missing. Drop it manually
-  // from the sheet once you're confident every row has signupRequired set.)
   activities: [
     'id','signupRequired','status','source',
     'date','endDate','startTime','endTime',
@@ -195,9 +191,6 @@ var SCHEMA_ = {
 
 function ensureTab_(ss, tabName, cols) {
   var sheet = ss.getSheetByName(tabName);
-  // Self-healing rename: if the canonical tab is missing but a legacy alias
-  // is present, rename so existing data is preserved.
-  if (!sheet) sheet = _reconcileLegacyTab_(ss, tabName);
   if (!sheet) {
     sheet = ss.insertSheet(tabName);
     sheet.getRange(1, 1, 1, cols.length).setValues([cols]);
@@ -259,143 +252,6 @@ function setupSpreadsheet() {
       Logger.log('Seeded config key: ' + k);
     }
   });
-
-  // ── Migrations ─────────────────────────────────────────────────────────────
-  // Copy legacy 'activity_types' → canonical 'activity_templates' (config key
-  // rename, see LEGACY_CONFIG_KEY_ALIASES_ in config.gs). Idempotent: only
-  // copies when the canonical key is empty AND the legacy key has data, so
-  // re-running setup never clobbers a populated canonical key. Reads already
-  // fall through via the alias, but the canonical key needs to land in the
-  // sheet so future writes (saveActivityType etc.) hit it directly without
-  // depending on the alias.
-  try {
-    var legacyVal = getConfigSheetValue_('activity_types');
-    var canonicalVal = null;
-    try {
-      var cSheet = ss.getSheetByName('config');
-      if (cSheet && cSheet.getLastRow() >= 2) {
-        var cRows = cSheet.getRange(2, 1, cSheet.getLastRow() - 1, 2).getValues();
-        var cRow = cRows.find(function (r) { return String(r[0]).trim() === 'activity_templates'; });
-        canonicalVal = cRow ? String(cRow[1]).trim() : '';
-      }
-    } catch (e) { canonicalVal = ''; }
-    if (legacyVal && legacyVal !== '' && (!canonicalVal || canonicalVal === '')) {
-      setConfigSheetValue_('activity_templates', legacyVal);
-      Logger.log('Migrated config key activity_types → activity_templates');
-    }
-  } catch (e) {
-    Logger.log('activity_templates migration skipped: ' + e.message);
-  }
-
-  // Backfill signupRequired on activities from the legacy `kind` column.
-  // Idempotent: only writes when signupRequired is empty/missing on a row.
-  // Safe to run repeatedly; no-op once every row carries the boolean.
-  // Tab may still be named 'scheduled_events' on older deployments —
-  // the SCHEMA_ loop above runs ensureTab_ which auto-renames via
-  // _reconcileLegacyTab_, so by this point it's named 'activities'.
-  try {
-    var seSheet = ss.getSheetByName('activities');
-    if (seSheet && seSheet.getLastRow() >= 2) {
-      var headers = seSheet.getRange(1, 1, 1, seSheet.getLastColumn()).getValues()[0]
-        .map(function (h) { return String(h).trim(); });
-      var kindCol = headers.indexOf('kind');
-      var sigCol  = headers.indexOf('signupRequired');
-      if (kindCol >= 0 && sigCol >= 0) {
-        var nRows = seSheet.getLastRow() - 1;
-        var range = seSheet.getRange(2, 1, nRows, headers.length);
-        var values = range.getValues();
-        var changed = 0;
-        for (var i = 0; i < values.length; i++) {
-          var existing = values[i][sigCol];
-          if (existing === true || existing === false) continue;
-          if (existing === 'TRUE' || existing === 'FALSE') continue;
-          var kindVal = String(values[i][kindCol] || '').trim().toLowerCase();
-          values[i][sigCol] = (kindVal === 'volunteer');
-          changed++;
-        }
-        if (changed > 0) {
-          range.setValues(values);
-          Logger.log('Migrated signupRequired on ' + changed + ' activities row(s).');
-        }
-      }
-    }
-  } catch (e) {
-    Logger.log('signupRequired backfill skipped: ' + e.message);
-  }
-
-  // Drop the legacy `kind` column from the activities sheet once every row
-  // carries the canonical `signupRequired` boolean. Safety-gated: if any
-  // row still has signupRequired empty/missing, the migration logs a
-  // warning and skips so no information is lost. Idempotent — once the
-  // column is gone, getLastColumn no longer turns it up and this is a
-  // no-op. Re-run safely.
-  try {
-    var actSheet = ss.getSheetByName('activities');
-    if (actSheet && actSheet.getLastColumn() > 0) {
-      var actHeaders = actSheet.getRange(1, 1, 1, actSheet.getLastColumn()).getValues()[0]
-        .map(function (h) { return String(h).trim(); });
-      var kindIdx = actHeaders.indexOf('kind');
-      var sigIdx2 = actHeaders.indexOf('signupRequired');
-      if (kindIdx >= 0) {
-        var safe = true;
-        if (actSheet.getLastRow() >= 2 && sigIdx2 >= 0) {
-          var sigVals = actSheet.getRange(2, sigIdx2 + 1, actSheet.getLastRow() - 1, 1).getValues();
-          for (var r = 0; r < sigVals.length; r++) {
-            var v = sigVals[r][0];
-            if (v === true || v === false) continue;
-            if (v === 'TRUE' || v === 'true' || v === 'FALSE' || v === 'false') continue;
-            safe = false; break;
-          }
-        } else if (sigIdx2 < 0) {
-          safe = false;
-        }
-        if (safe) {
-          actSheet.deleteColumn(kindIdx + 1);
-          Logger.log('Dropped legacy `kind` column from activities sheet.');
-        } else {
-          Logger.log('⚠ Legacy `kind` column NOT dropped: some rows are missing signupRequired. ' +
-            'Re-run setupSpreadsheet after the backfill completes, or fix those rows by hand.');
-        }
-      }
-    }
-  } catch (e) {
-    Logger.log('Legacy kind-column drop skipped: ' + e.message);
-  }
-
-  // Copy legacy config keys into their canonical names. Idempotent — only
-  // copies when the canonical row is missing/empty AND the legacy row has a
-  // value. Leaves the legacy row in place for one cycle so a partial-deploy
-  // rollback still has a working source. See LEGACY_CONFIG_KEY_ALIASES_ in
-  // config.gs for the source of truth.
-  try {
-    var cfgSheet2 = ss.getSheetByName('config');
-    if (cfgSheet2 && cfgSheet2.getLastRow() >= 2) {
-      var cfgRows = cfgSheet2.getRange(2, 1, cfgSheet2.getLastRow() - 1, 2).getValues();
-      var cfgKeyToRow = {};
-      cfgRows.forEach(function (r, i) {
-        cfgKeyToRow[String(r[0]).trim()] = { rowIndex: i + 2, value: String(r[1]).trim() };
-      });
-      Object.keys(LEGACY_CONFIG_KEY_ALIASES_).forEach(function (canonical) {
-        var canonRow = cfgKeyToRow[canonical];
-        if (canonRow && canonRow.value !== '') return; // canonical already populated
-        var legacies = LEGACY_CONFIG_KEY_ALIASES_[canonical] || [];
-        for (var j = 0; j < legacies.length; j++) {
-          var legacyRow = cfgKeyToRow[legacies[j]];
-          if (legacyRow && legacyRow.value !== '') {
-            if (canonRow) {
-              cfgSheet2.getRange(canonRow.rowIndex, 2).setValue(literalWrite_(legacyRow.value));
-            } else {
-              cfgSheet2.appendRow([canonical, literalWrite_(legacyRow.value)]);
-            }
-            Logger.log('Migrated config key: "' + legacies[j] + '" → "' + canonical + '"');
-            break;
-          }
-        }
-      });
-    }
-  } catch (e) {
-    Logger.log('Config-key migration skipped: ' + e.message);
-  }
 
   Logger.log('setupSpreadsheet complete. Tabs processed: ' + results.join(', '));
   return 'Done — tabs processed: ' + results.join(', ');

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -182,12 +182,6 @@ function showTopTab(top) {
 
 // ── Settings sub-tab switching ─────────────────────────────────────────────────
 function showTab(tab) {
-  // Legacy tab aliases — old standalone tabs now live as col-sections inside
-  // Scheduling. Keep old bookmarks (?tab=slotCal etc.) working.
-  // Legacy URL hash redirect — pre-consolidation tab ids should send the
-  // user to the unified Scheduling tab. Keep the literal strings stable
-  // so old bookmarks keep working.
-  if (tab === 'actTypes' || tab === 'volunteers' || tab === 'clubCal' || tab === 'slotCal') tab = 'scheduling';
   document.querySelectorAll('#top-settings > [id^="tab-"]').forEach(el => el.classList.add('hidden'));
   document.querySelectorAll('#settingsTabBar .tab-btn').forEach(b => {
     b.classList.toggle('active', b.dataset.tab === tab);

--- a/code.gs
+++ b/code.gs
@@ -12,9 +12,6 @@ const TABS_ = {
   dailyLog: 'daily_log',
   maintenance: 'maintenance',
   checkouts: 'checkouts',
-  // actTypes removed — activity templates live in the config sheet under
-  // key 'activity_templates' (legacy alias 'activity_types'), not a tab.
-  // dailyCL removed — daily checklists now stored as JSON in config key 'dailyChecklist'
   incidents: 'incidents',
   trips: 'trips',
   config: 'config',
@@ -671,7 +668,6 @@ function ensureSheet_(tabKey, columns) {
   const name = TABS_[tabKey] || tabKey;
   const ss = ss_();
   let sh = ss.getSheetByName(name);
-  if (!sh) sh = _reconcileLegacyTab_(ss, name);
   if (!sh) {
     sh = ss.insertSheet(name);
     sh.getRange(1, 1, 1, columns.length).setValues([columns]);
@@ -950,44 +946,9 @@ function sweepExpiredSessions() {
 // SHEET HELPERS
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Self-healing tab renames. Key = canonical sheet tab name; value = list of
-// legacy names to fall back to. If the canonical tab is missing but a legacy
-// name is present, _reconcileLegacyTab_ renames it via setName so existing
-// data is preserved and subsequent calls find it normally. Idempotent — a
-// no-op once the rename has happened.
-//
-// 'activities' ← 'scheduled_events': introduced in 63a10db, prematurely
-// cleared in 8072be6 alongside the kind-column drop. Restored because the
-// tab rename is independent of the kind backfill and any deployment that
-// hadn't run setupSpreadsheet between those commits ended up with an empty
-// 'activities' tab created next to the legacy 'scheduled_events' tab,
-// orphaning every existing activity row. Safe to drop again once every
-// deployment is verified to live on the canonical name.
-const LEGACY_TAB_ALIASES_ = {
-  'activities': ['scheduled_events'],
-};
-
-function _reconcileLegacyTab_(ss, canonicalName) {
-  var aliases = LEGACY_TAB_ALIASES_[canonicalName];
-  if (!aliases || !aliases.length) return null;
-  for (var i = 0; i < aliases.length; i++) {
-    var legacyName = aliases[i];
-    if (legacyName === canonicalName) continue;
-    var legacy = ss.getSheetByName(legacyName);
-    if (legacy) {
-      legacy.setName(canonicalName);
-      Logger.log('Renamed legacy sheet tab: "' + legacyName + '" → "' + canonicalName + '"');
-      return legacy;
-    }
-  }
-  return null;
-}
-
 function getSheet_(tabKey) {
   const name = TABS_[tabKey] || tabKey;
-  const ss = ss_();
-  let s = ss.getSheetByName(name);
-  if (!s) s = _reconcileLegacyTab_(ss, name);
+  const s = ss_().getSheetByName(name);
   if (!s) throw new Error('Tab not found: ' + name);
   return s;
 }
@@ -1330,7 +1291,6 @@ function route_(action, b, caller) {
     case 'deactivateMembers': return deactivateMembers_(b.ids);
     case 'savePreferences': return savePreferences_(b);
     case 'getDailyLog': return getDailyLog_(b.date);
-    case 'saveDailyLog': return saveDailyLog_(b);
     case 'getActivityLog': return getActivityLog_(b);
     case 'saveDailyLog': return saveDailyLog_(b, caller);
     case 'getMaintenance': return getMaintenance_();
@@ -1392,7 +1352,6 @@ function route_(action, b, caller) {
     case 'deleteCheckout': return deleteCheckout_(b.id);
     case 'saveGroupCheckout': return saveGroupCheckout_(b, caller);
     case 'groupCheckIn': return groupCheckIn_(b, caller);
-    // charter endpoints removed — use saveReservation / removeReservation
     case 'saveBoatAccess': return saveBoatAccess_(b);
     case 'saveBoatOos': return saveBoatOos_(b);
     case 'saveReservation': return saveReservation_(b);
@@ -1449,7 +1408,6 @@ function route_(action, b, caller) {
     case 'saveTrip': return saveTrip_(b);
     case 'setHelm': return setHelm_(b);
     case 'deleteTrip': return deleteTrip_(b.id);
-    case 'requestValidation': return requestVerification_(b);
     case 'requestVerification': return requestVerification_(b);
     case 'getVerificationRequests': return getVerificationRequests_();
     case 'getConfirmations': return getConfirmations_(b);

--- a/config.gs
+++ b/config.gs
@@ -7,14 +7,6 @@
 // the (typically JSON) value. Most domain config (boats, locations, certDefs,
 // activity templates, flagConfig, …) lives in here under one row per key.
 
-// Self-healing config-key renames. Key = canonical config key; value = list
-// of legacy keys to fall back to when the canonical key is missing/empty.
-// Reads transparently fall through to the legacy key during the transition;
-// setupSpreadsheet copies legacy → canonical once explicitly.
-const LEGACY_CONFIG_KEY_ALIASES_ = {
-  'activity_templates': ['activity_types'],
-};
-
 // Read the entire config sheet once and return a key→value map.
 function getConfigMap_() {
   let sheet;
@@ -28,14 +20,6 @@ function getConfigMap_() {
 
 function getConfigValue_(key, map) {
   const v = map[key];
-  if (v !== undefined && v !== '') return v;
-  const aliases = LEGACY_CONFIG_KEY_ALIASES_[key];
-  if (aliases) {
-    for (let i = 0; i < aliases.length; i++) {
-      const alt = map[aliases[i]];
-      if (alt !== undefined && alt !== '') return alt;
-    }
-  }
   return v !== undefined ? v : null;
 }
 
@@ -46,20 +30,8 @@ function getConfigSheetValue_(key) {
   try { sheet = getSheet_('config'); } catch (e) { return null; }
   if (sheet.getLastRow() < 2) return null;
   const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 2).getValues();
-  const findRow = function (k) {
-    const r = data.find(row => String(row[0]).trim() === k);
-    return r ? String(r[1]).trim() : null;
-  };
-  const v = findRow(key);
-  if (v !== null && v !== '') return v;
-  const aliases = LEGACY_CONFIG_KEY_ALIASES_[key];
-  if (aliases) {
-    for (let i = 0; i < aliases.length; i++) {
-      const alt = findRow(aliases[i]);
-      if (alt !== null && alt !== '') return alt;
-    }
-  }
-  return v;
+  const r = data.find(row => String(row[0]).trim() === key);
+  return r ? String(r[1]).trim() : null;
 }
 
 function setConfigSheetValue_(key, value) {

--- a/coxswain/coxswain.js
+++ b/coxswain/coxswain.js
@@ -763,7 +763,6 @@ function _ppRenderItemCard(passport, it, prog, signingSomeoneElse, canRevoke, op
   }).join(' · ');
   var onclick = signingSomeoneElse ? ' data-cx-click="signPassportItemClick" data-cx-arg="'+it.id+'"' : '';
   var assessment = it.assessment || 'practical';
-  if (assessment === 'theoretical') assessment = 'theory'; // back-compat for older stored data
   var badgeCls = 'pp-asmt pp-asmt-' + assessment;
   var badgeLbl = s('passport.' + assessment);
   var moduleNum = Number(it.module || 0);

--- a/passport.gs
+++ b/passport.gs
@@ -292,8 +292,6 @@ function importRowingPassportCsv_(b) {
     }
 
     let assessment = (r.assessment || '').toLowerCase();
-    // Back-compat: accept historical 'theoretical' spelling and normalise to 'theory'.
-    if (assessment === 'theoretical') assessment = 'theory';
     if (assessment !== 'theory' && assessment !== 'practical') assessment = 'practical';
     // Module: optional non-negative integer (0 / blank = unassigned).
     let moduleNum = parseInt((r.module || '').toString().trim(), 10);

--- a/scheduling.gs
+++ b/scheduling.gs
@@ -10,12 +10,6 @@
 //   signupRequired=false — plain activity, surfaced by the daily-log renderer
 //                          and the midnight materializer.
 //
-// (A legacy `kind` column — 'volunteer' | 'activity' — may still be present
-// on rows written before the cleanup; new writes no longer populate it, and
-// activity_parseRow_ falls back to it only if signupRequired is missing. It
-// can be dropped manually from the sheet once you're confident the
-// signupRequired backfill has run for every row.)
-//
 // An activity may be templated from an `activity_templates` row via
 // `activityTypeId`, or authored ad-hoc with no template.
 //
@@ -29,10 +23,6 @@
 // activity_parseRow_ takes a sanitized row from readAll_('activities') and
 // returns a shape where `roles` is parsed back into an array and booleans are
 // unwrapped. Use this everywhere readers need the domain object.
-//
-// `signupRequired` is the canonical boolean. The migration backfilled it on
-// every existing row before this commit, so a missing value just falls back
-// to false (a plain activity).
 function activity_parseRow_(row) {
   if (!row) return null;
   var roles = [];
@@ -193,12 +183,10 @@ function activity_listForDate_(dateISO) {
   });
 }
 
-// Filter activities to a date range. Optional `kind` filter accepts the legacy
-// values 'volunteer' / 'activity' for backward compat, mapped to signupRequired.
-function activity_listInRange_(fromIso, toIso, kind) {
-  var wantSignup = null;
-  if (kind === 'volunteer') wantSignup = true;
-  else if (kind === 'activity') wantSignup = false;
+// Filter activities to a date range. Optional `signupRequired` filter
+// (true | false | null) restricts to one flavor; null returns both.
+function activity_listInRange_(fromIso, toIso, signupRequired) {
+  var wantSignup = (signupRequired === true || signupRequired === false) ? signupRequired : null;
   return activity_listAll_().filter(function (e) {
     if (!e || e.status === 'cancelled') return false;
     if (wantSignup !== null && e.signupRequired !== wantSignup) return false;
@@ -215,7 +203,7 @@ function activity_listInRange_(fromIso, toIso, kind) {
 // apply server-side; an empty filter passes through.
 function activity_listLog_(fromIso, toIso, opts) {
   opts = opts || {};
-  var rows = activity_listInRange_(fromIso, toIso, 'activity');
+  var rows = activity_listInRange_(fromIso, toIso, false);
   // Build id -> { classTag, classTagIS } map from saved activity types so the
   // response carries the tag without forcing the client to read getConfig.
   var typeMap = {};
@@ -371,22 +359,3 @@ function activity_signupCountsById_() {
   return out;
 }
 
-// ── Transitional shims for the sched_* → activity_* rename (b108509) ─────────
-// Apps Script projects can hold partially-stale .gs files between pushes — if
-// scheduling.gs lands but a caller (e.g. members.gs) is still pre-rename, the
-// caller throws "sched_X is not defined" until the next push lands. These
-// aliases keep the old names callable so a partial sync degrades gracefully.
-// Drop once you're confident every deployment has caught up.
-function sched_parseRow_(row)                   { return activity_parseRow_(row); }
-function sched_rowShape_(ev)                    { return activity_rowShape_(ev); }
-function sched_getById_(id)                     { return activity_getById_(id); }
-function sched_listAll_()                       { return activity_listAll_(); }
-function sched_listVolunteerEvents_()           { return activity_listVolunteerEvents_(); }
-function sched_listActivitiesForDate_(dateISO)  { return activity_listForDate_(dateISO); }
-function sched_listInRange_(fromIso, toIso, kind) { return activity_listInRange_(fromIso, toIso, kind); }
-function sched_listActivityLog_(fromIso, toIso, opts) { return activity_listLog_(fromIso, toIso, opts); }
-function sched_upsert_(ev)                      { return activity_upsert_(ev); }
-function sched_cancel_(id, updatedBy)           { return activity_cancel_(id, updatedBy); }
-function sched_hardDelete_(id)                  { return activity_hardDelete_(id); }
-function sched_signupCountsByEvent_()           { return activity_signupCountsById_(); }
-function ensureScheduledEventsSheet_()          { return ensureActivitiesSheet_(); }

--- a/shared/api.js
+++ b/shared/api.js
@@ -7,27 +7,6 @@ const BASE_URL   = "https://skarfur.github.io/ymir";
 // verify tokens unless the GOOGLE_CLIENT_ID script property is set.
 const GOOGLE_CLIENT_ID = "231967339479-m1fqbqk134sjtt2o4nloljfle7l7hk7b.apps.googleusercontent.com";
 
-// ── Service Worker Cleanup (one-shot per browser) ──────────────────────────
-// The app used to register a SW; it was removed long ago. This block
-// guarantees any stranded old SW + its caches get purged so users don't
-// see stale static assets. Once it's run successfully in a browser we
-// flip a localStorage flag and skip on every subsequent page load —
-// there's no point re-querying navigator.serviceWorker on every view.
-try {
-  if (!localStorage.getItem('ymirSwCleanupDone') && 'serviceWorker' in navigator) {
-    var _swCleanupDone = function () { try { localStorage.setItem('ymirSwCleanupDone', '1'); } catch (e) {} };
-    navigator.serviceWorker.getRegistrations()
-      .then(function (regs) { regs.forEach(function (r) { r.unregister(); }); })
-      .catch(function () {})
-      .finally(_swCleanupDone);
-    if (typeof caches !== 'undefined') {
-      caches.keys().then(function (names) {
-        names.forEach(function (n) { caches.delete(n); });
-      }).catch(function () {});
-    }
-  }
-} catch (e) {}
-
 async function apiGet(action, params) {
   params = params || {};
   // Cache key now includes a serialized params suffix so the same action with
@@ -277,7 +256,6 @@ var _INVALIDATES = {
   respondConfirmation:     ['getTrips', 'getNotifications', 'getConfirmations'],
   createConfirmation:      ['getConfirmations', 'getNotifications'],
   requestVerification:     ['getConfirmations', 'getNotifications', 'getTrips'],
-  requestValidation:       ['getConfirmations', 'getNotifications', 'getTrips'],
   // Maintenance — most also change notification counts (follower pings, etc.).
   saveMaintenance:         ['getMaintenance', 'getNotifications'],
   resolveMaintenance:      ['getMaintenance', 'getNotifications'],

--- a/shared/scheduled-event.js
+++ b/shared/scheduled-event.js
@@ -31,23 +31,18 @@
 
   // Normalize a single raw row (volunteer event DTO from getConfig, or a
   // daily-log activity from getDailyLog) into the unified Activity shape.
-  // `opts.signupRequired` determines the flavor (legacy `opts.kind` is still
-  // accepted for back-compat); `opts.source` defaults to a sensible guess.
+  // `opts.signupRequired` determines the flavor; `opts.source` defaults to a
+  // sensible guess.
   function toScheduledEvent(raw, opts) {
     if (!raw) return null;
     opts = opts || {};
     // Resolve signupRequired from explicit opt, raw row, or by sniffing
     // (presence of roles/leaderName implies a signup-tracked activity).
-    // Legacy `kind` is consulted as a final fallback for stragglers.
     var signupRequired;
     if (opts.signupRequired === true || opts.signupRequired === false) {
       signupRequired = opts.signupRequired;
     } else if (raw.signupRequired === true || raw.signupRequired === false) {
       signupRequired = raw.signupRequired;
-    } else if (opts.kind) {
-      signupRequired = (opts.kind === 'volunteer');
-    } else if (raw.kind) {
-      signupRequired = (raw.kind === 'volunteer');
     } else {
       signupRequired = !!(raw.roles || raw.leaderName);
     }

--- a/trips.gs
+++ b/trips.gs
@@ -93,13 +93,6 @@ function deleteTrip_(id) {
   return okJ({ deleted: deleteRow_('trips', 'id', id) });
 }
 
-function requestValidation_(b) {
-  if (!b.tripId) return failJ('tripId required');
-  updateRow_('trips', 'id', b.tripId, { validationRequested: true });
-  return okJ({ requested: true });
-}
-
-
 // ═══════════════════════════════════════════════════════════════════════════════
 // TRIP CONFIRMATIONS (handshake protocol)
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Net -288 lines. Existing test sheets must already live on canonical names; the self-healing rename / fallback paths are gone.

- scheduling.gs: drop 13 sched_* re-export shims; activity_listInRange_ now takes a boolean signupRequired instead of legacy 'volunteer' / 'activity' strings.
- code.gs: drop duplicate saveDailyLog route case (shadowed), requestValidation action alias, LEGACY_TAB_ALIASES_ + _reconcileLegacyTab_.
- trips.gs: remove dead requestValidation_ function.
- config.gs: drop LEGACY_CONFIG_KEY_ALIASES_ + fallback paths.
- _setup.gs: drop four migration blocks (config-key copy, signupRequired backfill from kind, kind-column drop, generic alias copier) and the _reconcileLegacyTab_ call in ensureTab_.
- shared/api.js: drop service-worker cleanup block; drop redundant requestValidation entry in _INVALIDATES.
- shared/scheduled-event.js: drop opts.kind / raw.kind fallback.
- passport.gs, coxswain/coxswain.js: drop 'theoretical' -> 'theory' normalizer.
- admin/admin.js: drop actTypes/volunteers/clubCal/slotCal URL-tab redirects.

https://claude.ai/code/session_012khMWAruXD8NMZ2BEQeatH