### PR TITLE
fix: stack second stats row on mobile in logbook review

### DIFF
--- a/staff/staff_logbook-review.css
+++ b/staff/staff_logbook-review.css
@@ -7,6 +7,12 @@
     .stat-cell { background:var(--card); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 10px; text-align:center; box-shadow:var(--shadow-sm); }
     .stat-n { font-size:22px; color:var(--accent-fg); font-weight:500; }
     .stat-l { font-size:9px; color:var(--muted); margin-top:3px; letter-spacing:.5px; }
+    .slr-stat-cats { text-align:left; padding:8px 10px; }
+    .slr-boat-cats { line-height:1.8; }
+    @media (max-width: 600px) {
+      .slr-stats-detail { grid-template-columns:1fr 1fr; }
+      .slr-stats-detail > .slr-stat-cats { grid-column:1 / -1; }
+    }
     .cert-row { display:flex; align-items:flex-start; justify-content:space-between; padding:10px 0; border-bottom:1px solid var(--border); gap:10px; }
     .cert-row:last-child { border-bottom:none; }
     .cert-name { font-size:13px; font-weight:500; color:var(--text); }

--- a/staff/staff_logbook-review.html
+++ b/staff/staff_logbook-review.html
@@ -36,12 +36,12 @@
     <div class="stat-cell"><div class="stat-n" id="sVerified">—</div><div class="stat-l" data-s="slr.stat.verified"></div></div>
   </div>
   <!-- Stats row 2 -->
-  <div class="stat-strip mb-16">
+  <div class="stat-strip slr-stats-detail mb-16">
     <div class="stat-cell"><div class="stat-n" id="sTotalPersons">—</div><div class="stat-l" data-s="slr.stat.peopleOut"></div></div>
     <div class="stat-cell"><div class="stat-n" id="sUniquePersons">—</div><div class="stat-l" data-s="slr.stat.uniqueMem"></div></div>
-    <div class="stat-cell" style="text-align:left;padding:8px 10px">
+    <div class="stat-cell slr-stat-cats">
       <div class="section-label mb-4" data-s="slr.stat.byBoatType"></div>
-      <div id="sBoatCats" class="text-sm" style="line-height:1.8"></div>
+      <div id="sBoatCats" class="text-sm slr-boat-cats"></div>
     </div>
   </div>
   


### PR DESCRIPTION
The second stat strip had a tall "By Boat Type" list squeezed alongside two number cards, stretching the number cards awkwardly on small screens. On widths ≤600px the strip now collapses to 2 columns with the boat-type card spanning full width below the two number cards.

Also moved inline styles into named classes (slr-stat-cats, slr-boat-cats).