### PR TITLE
ui: collapse staff notes to flowing text when not being edited

### DIFF
--- a/dailylog/dailylog.css
+++ b/dailylog/dailylog.css
@@ -63,6 +63,21 @@
 .activity-note { color:var(--text); font-size:12px; margin-top:4px; }
 .activity-note-brief { opacity:.55; font-style:italic; }
 .activity-note-record { white-space:pre-wrap; border-left:2px solid color-mix(in srgb, var(--brass) 50%, transparent); padding-left:8px; }
+
+/* Staff-notes finalized view — collapses the textarea to inline flowing text
+   when it has saved content and isn't being edited. Click to switch back to
+   the textarea for editing. */
+.dl-narrative-view {
+  white-space:pre-wrap; word-wrap:break-word;
+  color:var(--text); font-size:13px; line-height:1.55;
+  border-left:2px solid color-mix(in srgb, var(--brass) 50%, transparent);
+  padding:2px 0 2px 10px; cursor:text; min-height:20px;
+  border-radius:2px; transition:background-color .12s;
+}
+.dl-narrative-view:hover, .dl-narrative-view:focus {
+  background:color-mix(in srgb, var(--accent) 6%, transparent);
+  outline:none;
+}
 .del-btn { background:none; border:none; color:var(--border); cursor:pointer; font-size:18px; padding:0 4px; transition:color .15s; line-height:1; }
 .del-btn:hover { color:var(--red); }
 

--- a/dailylog/dailylog.js
+++ b/dailylog/dailylog.js
@@ -74,6 +74,7 @@ const dom = domRefs({
   activitiesEmpty:   'activitiesEmpty',
   activitiesList:    'activitiesList',
   narrativeInput:    'narrativeInput',
+  narrativeView:     'narrativeView',
   incidentContainer: 'incidentContainer',
   incidentHeading:   'incidentHeading',
   saveMsg:           'saveMsg',
@@ -530,6 +531,10 @@ document.addEventListener('DOMContentLoaded', () => {
     doSave(false);
   });
   dom.narrativeInput.addEventListener('input', markDirty);
+  dom.narrativeInput.addEventListener('blur', _renderNarrativeView);
+  dom.narrativeView.addEventListener('keydown', function(e){
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); editNarrative(); }
+  });
   dom.logWxBtn.addEventListener('click',     logCurrentWeather);
 
   // Tide fields are now auto-filled from harmonic prediction (no manual inputs)
@@ -844,6 +849,7 @@ async function loadDay() {
   dom.signoffBadge.classList.add('hidden');
   dom.signoffBadge.textContent = s('daily.signedOff');
   dom.narrativeInput.value = '';
+  _renderNarrativeView();
   updateDateNav();
 
   const spinner = '<div class="empty-state"><span class="spinner"></span></div>';
@@ -969,6 +975,7 @@ function applyLogData(logRes, cfgRes) {
     }
     wxLog    = sjson(log.weatherLog, []);
     dom.narrativeInput.value = log.narrative || '';
+    _renderNarrativeView();
     _renderSignoffBadge(log.signedOffBy, log.signedOffAt, log.updatedBy, log.updatedAt);
   } else {
     // No sheet row yet — pre-populate from the bulk schedule so today's user
@@ -1000,6 +1007,28 @@ function _renderSignoffBadge(signedOffBy, signedOffAt, updatedBy, updatedAt) {
     });
   }
   dom.signoffBadge.textContent = txt;
+}
+
+// Staff-notes view/edit swap. Empty content keeps the textarea visible so the
+// user can start typing; once there's saved text we collapse the textarea into
+// a flowing-text view that visually matches activity run-notes. Click (or
+// Enter/Space) on the view re-opens the textarea via editNarrative().
+function _renderNarrativeView() {
+  const v = (dom.narrativeInput.value || '').trim();
+  if (!v) {
+    dom.narrativeView.classList.add('d-none');
+    dom.narrativeInput.classList.remove('d-none');
+    return;
+  }
+  dom.narrativeView.textContent = v;
+  dom.narrativeView.classList.remove('d-none');
+  dom.narrativeInput.classList.add('d-none');
+}
+
+function editNarrative() {
+  dom.narrativeView.classList.add('d-none');
+  dom.narrativeInput.classList.remove('d-none');
+  dom.narrativeInput.focus();
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/dailylog/index.html
+++ b/dailylog/index.html
@@ -96,6 +96,7 @@
   <!-- ══ 6. STAFF NOTES ══ -->
   <div class="section-heading" data-s="daily.staffNotes"></div>
   <div class="content-card">
+    <div id="narrativeView" class="dl-narrative-view d-none" data-dl-click="editNarrative" role="button" tabindex="0"></div>
     <textarea id="narrativeInput" rows="4" class="w-full" style="resize:vertical"></textarea>
   </div>
 


### PR DESCRIPTION
Staff-notes textarea now switches to a read-mode view div whenever it has content and isn't focused. The view div uses the same brass-bordered flowing-text styling as activity run-notes, so a saved/signed-off log looks finalized rather than showing a tall scrollable input box mid-page. Click (or Enter/Space) on the view re-opens the textarea for editing, and on blur it collapses back to flowing text.

Empty narratives keep the textarea visible so a fresh day still has an obvious place to type.