### PR TITLE
_setup: actively drop the legacy payroll tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Material changes to the Ýmir Sailing Club codebase. Entries are newest-first.
 Commit hashes reference the `main` branch.
 
+## Unreleased — _setup: actively drop the legacy `payroll` tab
+
+Followup to the payroll cleanup: an existing spreadsheet may still carry the
+`payroll` sheet from before the schema entry was removed, and an outdated
+deployment or trigger could have recreated it. `setupSpreadsheet()` now runs a
+`dropLegacyTabs_` step before ensuring schema tabs — it deletes the `payroll`
+sheet if it's empty/header-only, and logs a loud warning if it still has data
+so an operator can archive and remove it manually. `LEGACY_TABS_` is the
+single list to extend the next time another schema tab gets retired.
+
 ## Unreleased — backend: drop unused `payroll` sheet + dead pay-calc code
 
 The `payroll` sheet in the spreadsheet was never written to at runtime. Its

--- a/_setup.gs
+++ b/_setup.gs
@@ -215,9 +215,32 @@ function ensureTab_(ss, tabName, cols) {
 
 // ── Main entry point ─────────────────────────────────────────────────────────
 
+// Tabs that used to be in SCHEMA_ but were removed and should be deleted
+// from any spreadsheet still carrying them. Each entry is the literal sheet
+// name. setupSpreadsheet() drops empty/header-only sheets silently and
+// preserves anything with data while warning loudly so the operator can
+// archive and remove it manually.
+var LEGACY_TABS_ = ['payroll'];
+
+function dropLegacyTabs_(ss) {
+  LEGACY_TABS_.forEach(function(name) {
+    var sh = ss.getSheetByName(name);
+    if (!sh) return;
+    if (sh.getLastRow() <= 1) {
+      ss.deleteSheet(sh);
+      Logger.log('Dropped legacy tab: ' + name);
+    } else {
+      Logger.log('⚠ Legacy tab "' + name + '" has '
+        + (sh.getLastRow() - 1) + ' data row(s); leaving in place — archive and delete manually.');
+    }
+  });
+}
+
 function setupSpreadsheet() {
   var ss = SpreadsheetApp.openById(SHEET_ID_);
   var results = [];
+
+  dropLegacyTabs_(ss);
 
   Object.keys(SCHEMA_).forEach(function(tabName) {
     ensureTab_(ss, tabName, SCHEMA_[tabName]);


### PR DESCRIPTION
Followup to be07841 (payroll cleanup). The schema entry is gone but an existing spreadsheet may still have the payroll sheet from before, and an outdated deployment or trigger could have recreated it. setupSpreadsheet() now calls dropLegacyTabs_ before ensuring schema tabs — empty/header-only payroll sheets are deleted, sheets with data are left alone with a loud warning so an operator can archive and remove manually.

LEGACY_TABS_ is the single list to extend next time a schema tab is retired.

https://claude.ai/code/session_01SgydNMaMKDVxukDMcznNLN