### PR TITLE
Fix admin time-entry edits losing the clock-in time on refresh

### DIFF
--- a/payroll.gs
+++ b/payroll.gs
@@ -129,7 +129,7 @@ function adminEditTime_(b) {
   const row = readAll_(TABS_.timeClock).find(function(r){ return r.id === b.id; });
   if (!row) return failJ('Entry not found');
   updateRow_('timeClock','id',b.id,{
-    timestamp:b.timestamp, originalTimestamp:row.originalTimestamp||row.timestamp,
+    timestamp:b.timestamp, originalTimestamp:b.clockIn||row.originalTimestamp||row.timestamp,
     note:b.note||row.note||'admin edit', source:'admin',
     durationMinutes:b.durationMinutes!==undefined?b.durationMinutes:row.durationMinutes,
   });


### PR DESCRIPTION
adminEditTime_ ignored the clockIn field sent by the admin Payroll UI and always fell back to the entry's previous originalTimestamp/timestamp, so an edited start time appeared saved but reverted after a page refresh.