### PR TITLE
Fix admin-added time entries disappearing from the payroll view

### DIFF
--- a/admin/payroll/payroll.js
+++ b/admin/payroll/payroll.js
@@ -216,13 +216,19 @@ function _pairTimeEntries(rows) {
   // Pair out rows with their matching in rows
   var usedInIds=new Set();
   outs.slice().sort(function(a,b){return a.timestamp>b.timestamp?1:-1;}).forEach(function(out){
-    var matchIn=null;
-    ins.slice().reverse().forEach(function(inn){
-      if(!matchIn&&!usedInIds.has(inn.id)&&inn.employeeId===out.employeeId&&inn.timestamp<out.timestamp)
-        matchIn=inn;
-    });
     var e=Object.assign({},out);
-    if(matchIn){e.clockIn=matchIn.timestamp;usedInIds.add(matchIn.id);}
+    if(out.originalTimestamp){
+      // Admin-added/edited entries store their own start time on the row
+      // itself — no separate type='in' row was ever created to pair against.
+      e.clockIn=out.originalTimestamp;
+    }else{
+      var matchIn=null;
+      ins.slice().reverse().forEach(function(inn){
+        if(!matchIn&&!usedInIds.has(inn.id)&&inn.employeeId===out.employeeId&&inn.timestamp<out.timestamp)
+          matchIn=inn;
+      });
+      if(matchIn){e.clockIn=matchIn.timestamp;usedInIds.add(matchIn.id);}
+    }
     paired.push(e);
   });
   return paired;

--- a/payroll.gs
+++ b/payroll.gs
@@ -40,7 +40,7 @@ function initPayrollSheets_() {
 
 function periodKey_(date) {
   const d = date || new Date();
-  return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0');
+  return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-01';
 }
 
 function clockIn_(b) {
@@ -143,7 +143,7 @@ function adminAddTime_(b) {
     var id = 'entry_' + Date.now() + '_' + Math.random().toString(36).slice(2,6);
     // Column order matches sheet: id, employeeId, type, timestamp(clockOut), source, originalTimestamp(clockIn), note, periodKey, durationMinutes
     var periodKey = b.clockIn ? b.clockIn.slice(0,7) + '-01' : new Date().toISOString().slice(0,7) + '-01';
-    sh.appendRow([id, b.employeeId, '', b.timestamp, 'admin', b.clockIn, literalWrite_(b.note || 'admin entry'), periodKey, b.durationMinutes]);
+    sh.appendRow([id, b.employeeId, 'out', b.timestamp, 'admin', b.clockIn, literalWrite_(b.note || 'admin entry'), periodKey, b.durationMinutes]);
     return okJ({ success: true, id: id });
   } catch(e) {
     return failJ(e.message);


### PR DESCRIPTION
adminAddTime_ wrote new entries with type:'' (instead of 'out'), and the admin Payroll page's pairing logic only surfaces rows with type==='out', so admin-added sessions saved correctly but never rendered after reload. Also fixed periodKey_'s format ('YYYY-MM') not matching the 'YYYY-MM-01' format used by adminAddTime_ and the admin UI's period filter, which made real staff clock-in/out entries invisible in the same view.