### PR TITLE
Fix month navigation: coerce data-pr-arg string to number in prCalMove

### DIFF
--- a/admin/payroll/payroll.js
+++ b/admin/payroll/payroll.js
@@ -199,7 +199,7 @@ function prSetView(v){
   if(v==='list') prRenderList();else prRenderCalDays();
 }
 function prCalMove(dir){
-  _calMonth+=dir;
+  _calMonth+=+dir;
   if(_calMonth>11){_calMonth=0;_calYear++;}
   if(_calMonth<0){_calMonth=11;_calYear--;}
   prRenderCalLabel();prLoadTsEntries();


### PR DESCRIPTION
_calMonth += dir was string-concatenating ("+"-1" → "5-1") instead of subtracting, causing NaN in the date calculations and empty results.